### PR TITLE
Use vhost for new framework

### DIFF
--- a/selftests/test_framework.py
+++ b/selftests/test_framework.py
@@ -72,7 +72,14 @@ http {
         'config' : """
 cache 0;
 listen 80;
-server ${server_ip}:8000;
+
+srv_group default {
+    server ${server_ip}:8000;
+}
+
+vhost default {
+    proxy_pass default;
+}
 """,
     }
 


### PR DESCRIPTION
Related to https://github.com/tempesta-tech/tempesta-test/pull/7

Using vhost config option in selftests.test_framework