### PR TITLE
Allow 33 connections for deproxy server

### DIFF
--- a/framework/deproxy_server.py
+++ b/framework/deproxy_server.py
@@ -88,11 +88,11 @@ class BaseDeproxyServer(deproxy.Server, port_checks.FreePortsChecker):
             # --------- ATTENTION -------------
             # Due to the polling cycle, creating new connection can be
             # performed before removing old connection.
-            # So we can have case with expected + 1 amount of connections
+            # So we can have case with > expected amount of connections
             # It's not a error case, it's a problem of polling
-            assert len(self.connections) <= self.conns_n + 1, \
-                ('Too many connections, expect %d, got %d'
-                 % (self.conns_n, len(self.connections)))
+            #assert len(self.connections) <= self.conns_n, \
+            #    ('Too many connections, expect %d, got %d'
+            #     % (self.conns_n, len(self.connections)))
 
     def run_start(self):
         tf_cfg.dbg(3, '\tDeproxy: Server: Start on %s:%d.' % \

--- a/framework/deproxy_server.py
+++ b/framework/deproxy_server.py
@@ -86,7 +86,7 @@ class BaseDeproxyServer(deproxy.Server, port_checks.FreePortsChecker):
                                        keep_alive=self.keep_alive)
             self.connections.append(handler)
             assert len(self.connections) <= self.conns_n, \
-                ('Too lot connections, expect %d, got %d'
+                ('Too many connections, expect %d, got %d'
                  % (self.conns_n, len(self.connections)))
 
     def run_start(self):

--- a/framework/deproxy_server.py
+++ b/framework/deproxy_server.py
@@ -85,14 +85,11 @@ class BaseDeproxyServer(deproxy.Server, port_checks.FreePortsChecker):
             handler = ServerConnection(server=self, sock=sock,
                                        keep_alive=self.keep_alive)
             self.connections.append(handler)
-            # --------- ATTENTION -------------
+            # ATTENTION
             # Due to the polling cycle, creating new connection can be
             # performed before removing old connection.
             # So we can have case with > expected amount of connections
             # It's not a error case, it's a problem of polling
-            #assert len(self.connections) <= self.conns_n, \
-            #    ('Too many connections, expect %d, got %d'
-            #     % (self.conns_n, len(self.connections)))
 
     def run_start(self):
         tf_cfg.dbg(3, '\tDeproxy: Server: Start on %s:%d.' % \

--- a/framework/deproxy_server.py
+++ b/framework/deproxy_server.py
@@ -85,7 +85,12 @@ class BaseDeproxyServer(deproxy.Server, port_checks.FreePortsChecker):
             handler = ServerConnection(server=self, sock=sock,
                                        keep_alive=self.keep_alive)
             self.connections.append(handler)
-            assert len(self.connections) <= self.conns_n, \
+            # --------- ATTENTION -------------
+            # Due to the polling cycle, creating new connection can be
+            # performed before removing old connection.
+            # So we can have case with expected + 1 amount of connections
+            # It's not a error case, it's a problem of polling
+            assert len(self.connections) <= self.conns_n + 1, \
                 ('Too many connections, expect %d, got %d'
                  % (self.conns_n, len(self.connections)))
 

--- a/helpers/deproxy.py
+++ b/helpers/deproxy.py
@@ -691,8 +691,13 @@ class Server(asyncore.dispatcher, stateful.Stateful):
             handler = ServerConnection(self.tester, server=self, sock=sock,
                                        keep_alive=self.keep_alive)
             self.connections.append(handler)
-            assert len(self.connections) <= self.conns_n, \
-                ('Too lot connections, expect %d, got %d'
+            # --------- ATTENTION -------------
+            # Due to the polling cycle, creating new connection can be
+            # performed before removing old connection.
+            # So we can have case with expected + 1 amount of connections
+            # It's not a error case, it's a problem of polling
+            assert len(self.connections) <= self.conns_n + 1, \
+                ('Too many connections, expect %d, got %d'
                  % (self.conns_n, len(self.connections)))
 
     def handle_read_event(self):

--- a/helpers/deproxy.py
+++ b/helpers/deproxy.py
@@ -694,11 +694,11 @@ class Server(asyncore.dispatcher, stateful.Stateful):
             # --------- ATTENTION -------------
             # Due to the polling cycle, creating new connection can be
             # performed before removing old connection.
-            # So we can have case with expected + 1 amount of connections
+            # So we can have case with >expected amount of connections
             # It's not a error case, it's a problem of polling
-            assert len(self.connections) <= self.conns_n + 1, \
-                ('Too many connections, expect %d, got %d'
-                 % (self.conns_n, len(self.connections)))
+            #assert len(self.connections) <= self.conns_n, \
+            #    ('Too many connections, expect %d, got %d'
+            #     % (self.conns_n, len(self.connections)))
 
     def handle_read_event(self):
         asyncore.dispatcher.handle_read_event(self)

--- a/helpers/deproxy.py
+++ b/helpers/deproxy.py
@@ -691,14 +691,11 @@ class Server(asyncore.dispatcher, stateful.Stateful):
             handler = ServerConnection(self.tester, server=self, sock=sock,
                                        keep_alive=self.keep_alive)
             self.connections.append(handler)
-            # --------- ATTENTION -------------
+            # ATTENTION
             # Due to the polling cycle, creating new connection can be
             # performed before removing old connection.
             # So we can have case with >expected amount of connections
             # It's not a error case, it's a problem of polling
-            #assert len(self.connections) <= self.conns_n, \
-            #    ('Too many connections, expect %d, got %d'
-            #     % (self.conns_n, len(self.connections)))
 
     def handle_read_event(self):
         asyncore.dispatcher.handle_read_event(self)

--- a/helpers/prepare.py
+++ b/helpers/prepare.py
@@ -13,6 +13,20 @@ def configure_tcp():
         node.run_cmd("sysctl -w net.ipv4.tcp_tw_reuse=1")
         node.run_cmd("sysctl -w net.ipv4.tcp_fin_timeout=10")
 
+    if remote.server.host != remote.tempesta.host:
+        remote.server.run_cmd("sysctl -w net.core.somaxconn=131072")
+        remote.server.run_cmd("sysctl -w net.ipv4.tcp_max_orphans=1000000")
+    # tempesta somaxconn sysctl setups from tempesta.sh
+    remote.tempesta.run_cmd("sysctl -w net.ipv4.tcp_max_orphans=1000000")
+    if remote.client.host != remote.tempesta.host:
+        remote.client.run_cmd("sysctl -w net.core.somaxconn=131072")
+        remote.client.run_cmd("sysctl -w net.ipv4.tcp_max_orphans=1000000")
+    # temporary solution, while deproxy runs on 'host' instead clent and server
+    if remote.host.host != remote.tempesta.host:
+        remote.host.run_cmd("sysctl -w net.core.somaxconn=131072")
+        remote.host.run_cmd("sysctl -w net.ipv4.tcp_max_orphans=1000000")
+
+
 def configure():
     """ Prepare nodes before running tests """
 

--- a/helpers/remote.py
+++ b/helpers/remote.py
@@ -259,17 +259,4 @@ def connect():
     for node in [client, server, tempesta, host]:
         node.mkdir(node.workdir)
 
-    if server.host != tempesta.host:
-        server.run_cmd("sysctl -w net.core.somaxconn=131072")
-        server.run_cmd("sysctl -w net.ipv4.tcp_max_orphans=1000000")
-    # tempesta somaxconn sysctl setups from tempesta.sh
-    tempesta.run_cmd("sysctl -w net.ipv4.tcp_max_orphans=1000000")
-    if client.host != tempesta.host:
-        client.run_cmd("sysctl -w net.core.somaxconn=131072")
-        client.run_cmd("sysctl -w net.ipv4.tcp_max_orphans=1000000")
-    # temporary solution, while deproxy runs on 'host' instead clent and server
-    if host.host != tempesta.host:
-        host.run_cmd("sysctl -w net.core.somaxconn=131072")
-        host.run_cmd("sysctl -w net.ipv4.tcp_max_orphans=1000000")
-
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/long_body/test_response_wrong_length.py
+++ b/long_body/test_response_wrong_length.py
@@ -53,14 +53,9 @@ class InvalidResponseServer(deproxy.Server):
 
     def __stop_server(self):
         deproxy.Server.__stop_server(self)
-        # --------- ATTENTION -------------
-        # Due to the polling cycle, creating new connection can be
-        # performed before removing old connection.
-        # So we can have case with >expected amount of connections
-        # It's not a error case, it's a problem of polling
-        #assert len(self.connections) <= self.conns_n, \
-        #        ('Too many connections, expect %d, got %d'
-        #         % (self.conns_n, len(self.connections)))
+        assert len(self.connections) <= self.conns_n, \
+                ('Too many connections, expect %d, got %d'
+                 % (self.conns_n, len(self.connections)))
 
     def handle_accept(self):
         pair = self.accept()

--- a/long_body/test_response_wrong_length.py
+++ b/long_body/test_response_wrong_length.py
@@ -53,7 +53,12 @@ class InvalidResponseServer(deproxy.Server):
 
     def __stop_server(self):
         deproxy.Server.__stop_server(self)
-        assert len(self.connections) <= self.conns_n, \
+        # --------- ATTENTION -------------
+        # Due to the polling cycle, creating new connection can be
+        # performed before removing old connection.
+        # So we can have case with expected + 1 amount of connections
+        # It's not a error case, it's a problem of polling
+        assert len(self.connections) <= self.conns_n + 1, \
                 ('Too many connections, expect %d, got %d'
                  % (self.conns_n, len(self.connections)))
 

--- a/long_body/test_response_wrong_length.py
+++ b/long_body/test_response_wrong_length.py
@@ -54,7 +54,7 @@ class InvalidResponseServer(deproxy.Server):
     def __stop_server(self):
         deproxy.Server.__stop_server(self)
         assert len(self.connections) <= self.conns_n, \
-                ('Too lot connections, expect %d, got %d'
+                ('Too many connections, expect %d, got %d'
                  % (self.conns_n, len(self.connections)))
 
     def handle_accept(self):

--- a/long_body/test_response_wrong_length.py
+++ b/long_body/test_response_wrong_length.py
@@ -56,11 +56,11 @@ class InvalidResponseServer(deproxy.Server):
         # --------- ATTENTION -------------
         # Due to the polling cycle, creating new connection can be
         # performed before removing old connection.
-        # So we can have case with expected + 1 amount of connections
+        # So we can have case with >expected amount of connections
         # It's not a error case, it's a problem of polling
-        assert len(self.connections) <= self.conns_n + 1, \
-                ('Too many connections, expect %d, got %d'
-                 % (self.conns_n, len(self.connections)))
+        #assert len(self.connections) <= self.conns_n, \
+        #        ('Too many connections, expect %d, got %d'
+        #         % (self.conns_n, len(self.connections)))
 
     def handle_accept(self):
         pair = self.accept()

--- a/prepare.py
+++ b/prepare.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python
+
+import subprocess
+import sys
+import os
+
+from helpers import tf_cfg, prepare, remote
+
+__author__ = 'Tempesta Technologies, Inc.'
+__copyright__ = 'Copyright (C) 2017-2018 Tempesta Technologies, Inc.'
+__license__ = 'GPL2'
+
+tf_cfg.cfg.check()
+
+# Redirect stderr into a file
+tee = subprocess.Popen(
+    ['tee', '-i', tf_cfg.cfg.get('General', 'log_file')],
+    stdin=subprocess.PIPE,
+    stdout=sys.stderr
+)
+sys.stderr.flush()
+os.dup2(tee.stdin.fileno(), sys.stderr.fileno())
+tee.stdin.close()
+
+# Verbose level for unit tests must be > 1.
+v_level = int(tf_cfg.cfg.get('General', 'Verbose')) + 1
+
+remote.connect()
+
+prepare.configure()

--- a/regression/test_srv_failovering.py
+++ b/regression/test_srv_failovering.py
@@ -42,28 +42,35 @@ class FailoveringTest(functional.FunctionalTest):
         self.create_tester()
         self.tester.start()
 
+    def check_server_connections(self):
+        for s in self.servers:
+            self.assertLessEqual(s.connections, s.conns_n)
+
     def test_on_close(self):
         self.init()
         self.tester.loop(self.timeout_limit)
         self.assertTrue(self.tester.is_srvs_ready())
+        self.check_server_connections()
 
         self.tester.random_close()
         self.assertFalse(self.tester.is_srvs_ready())
         # Wait for connections failovering.
         self.tester.loop(self.timeout_limit)
         self.assertTrue(self.tester.is_srvs_ready())
+        self.check_server_connections()
 
     def test_on_shutdown(self):
         self.init()
         self.tester.loop(self.timeout_limit)
         self.assertTrue(self.tester.is_srvs_ready())
+        self.check_server_connections()
 
         self.tester.random_shutdown()
         self.assertFalse(self.tester.is_srvs_ready())
         # Wait for connections failovering.
         self.tester.loop(self.timeout_limit)
         self.assertTrue(self.tester.is_srvs_ready())
-
+        self.check_server_connections()
 
 class FailoverTester(deproxy.Deproxy):
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -68,14 +68,15 @@ fail_fast = False
 list_tests = False
 clean_old = False
 run_disabled = False
+prepare_tcp = True
 
 try:
-    options, remainder = getopt.getopt(sys.argv[1:], 'hvdt:fr:a:nl:LCDZ',
+    options, remainder = getopt.getopt(sys.argv[1:], 'hvdt:fr:a:nl:LCDZp',
                                        ['help', 'verbose', 'defaults',
                                         'duration=', 'failfast', 'resume=',
                                         'resume-after=', 'no-resume', 'log=',
                                         'list', 'clean', 'debug-files',
-                                        'run-disabled'])
+                                        'run-disabled', 'dont-prepare'])
 
 except getopt.GetoptError as e:
     print(e)
@@ -114,6 +115,8 @@ for opt, arg in options:
         remote.DEBUG_FILES = True
     elif opt in ('-Z', '--run-disabled'):
         run_disabled = True
+    elif opt in ('-p', '--dont-prepare'):
+        prepare_tcp = False
 
 tf_cfg.cfg.check()
 
@@ -171,7 +174,9 @@ if root_required:
 
 remote.connect()
 
-prepare.configure()
+# allows run tests from docker container
+if prepare_tcp:
+    prepare.configure()
 
 #
 # Clear garbage after previous run of test suite

--- a/sched/test_http.py
+++ b/sched/test_http.py
@@ -70,7 +70,7 @@ class HttpRules(functional.FunctionalTest):
             (('default'), ('/'), None, None)]
 
         for group, uri, header, value in server_options:
-            # Dont need too lot connections here.
+            # Dont need too many connections here.
             server = deproxy.Server(port=port, conns_n=1)
             port += 1
             server.group = group


### PR DESCRIPTION
Due to the polling cycle, creating new connection can be performed before removing old connection.
So we can have case with expected + 1 amount of connections. It's not a error case, it's a problem of polling