### PR TITLE
Fix eternal waiting for lock in case of exception

### DIFF
--- a/framework/deproxy_manager.py
+++ b/framework/deproxy_manager.py
@@ -37,7 +37,7 @@ class DeproxyManager(stateful.Stateful):
     Tests don't need to manually use this class."""
 
     def __init__(self):
-        self.exception = Queue.Queue()
+        self.thread_expts = Queue.Queue()
         self.servers = []
         self.clients = []
         self.exit_event = threading.Event()
@@ -60,13 +60,14 @@ class DeproxyManager(stateful.Stateful):
         self.exit_event.clear()
         self.proc = threading.Thread(target = run_deproxy_server,
                                     args=(self, self.exit_event,
-                                          self.polling_lock, self.exception))
+                                          self.polling_lock, self.thread_expts))
         self.proc.start()
 
     def thread_exception(self):
-        if self.exception.empty():
+        try:
+            return self.thread_expts.get()
+        except Queue.Empty:
             return None
-        return self.exception.get()
 
     def __stop(self):
         tf_cfg.dbg(3, "Stopping deproxy")

--- a/framework/deproxy_manager.py
+++ b/framework/deproxy_manager.py
@@ -16,16 +16,20 @@ def finish_all_deproxy():
 def run_deproxy_server(deproxy, exit_event, polling_lock):
     tf_cfg.dbg(3, "Running deproxy server manager")
 
-    if hasattr(select, 'poll'):
-        poll_fun = asyncore.poll2
-    else:
-        poll_fun = asyncore.poll
-    while not exit_event.is_set():
-        polling_lock.acquire()
-        poll_fun()
+    try:
+        if hasattr(select, 'poll'):
+            poll_fun = asyncore.poll2
+        else:
+            poll_fun = asyncore.poll
+        while not exit_event.is_set():
+            polling_lock.acquire()
+            poll_fun()
+            polling_lock.release()
+    except Exception as e:
+        tf_cfg.dbg(2, "Error while polling: %s" % str(e))
         polling_lock.release()
-
-    tf_cfg.dbg(3, "Stopped deproxy manager")
+        raise e
+    tf_cfg.dbg(3, "Finished deproxy manager")
 
 class DeproxyManager(stateful.Stateful):
     """ Class for running and managing

--- a/framework/deproxy_server.py
+++ b/framework/deproxy_server.py
@@ -97,10 +97,15 @@ class BaseDeproxyServer(deproxy.Server, port_checks.FreePortsChecker):
         self.check_ports_status()
         self.polling_lock.acquire()
 
-        self.create_socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.set_reuse_addr()
-        self.bind((self.ip, self.port))
-        self.listen(socket.SOMAXCONN)
+        try:
+            self.create_socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.set_reuse_addr()
+            self.bind((self.ip, self.port))
+            self.listen(socket.SOMAXCONN)
+        except Exception as e:
+            tf_cfg.dbg(2, "Error while creating socket: %s" % str(e))
+            self.polling_lock.release()
+            raise e
 
         self.polling_lock.release()
 

--- a/framework/tester.py
+++ b/framework/tester.py
@@ -166,15 +166,12 @@ class TempestaTest(unittest.TestCase):
         time.sleep(0.2)
 
     def tearDown(self):
-        tf_cfg.dbg(2, "\tTeardown")
+        tf_cfg.dbg(3, "\tTeardown")
         for id in self.__clients:
-            tf_cfg.dbg(2, "\tStop client: %s" % id)
             client = self.__clients[id]
             client.stop()
-        tf_cfg.dbg(2, "\tStop tempesta")
         self.__tempesta.stop()
         for id in self.__servers:
-            tf_cfg.dbg(2, "\tStop server: %s" % id)
             server = self.__servers[id]
             server.stop()
         self.__deproxy_manager.stop()

--- a/framework/tester.py
+++ b/framework/tester.py
@@ -166,11 +166,15 @@ class TempestaTest(unittest.TestCase):
         time.sleep(0.2)
 
     def tearDown(self):
+        tf_cfg.dbg(2, "\tTeardown")
         for id in self.__clients:
+            tf_cfg.dbg(2, "\tStop client: %s" % id)
             client = self.__clients[id]
             client.stop()
+        tf_cfg.dbg(2, "\tStop tempesta")
         self.__tempesta.stop()
         for id in self.__servers:
+            tf_cfg.dbg(2, "\tStop server: %s" % id)
             server = self.__servers[id]
             server.stop()
         self.__deproxy_manager.stop()


### PR DESCRIPTION
If we have exception during polling function, lock.release() doen't called. This PR fixes it and handles exceptions