### PR TITLE
Remove explicit directives if they can be implicitly created

### DIFF
--- a/leaks/test_leak.py
+++ b/leaks/test_leak.py
@@ -136,15 +136,8 @@ http {
     tempesta = {
         'config' : """
 cache 0;
-listen 80;
+server ${server_ip}:8000;
 
-srv_group default {
-    server ${server_ip}:8000;
-}
-
-vhost default {
-    proxy_pass default;
-}
 """,
     }
 

--- a/malformed/test_malformed_headers.py
+++ b/malformed/test_malformed_headers.py
@@ -26,13 +26,8 @@ Connection: keep-alive
 cache 0;
 listen 80;
 
-srv_group default {
-    server ${general_ip}:8000;
-}
+server ${general_ip}:8000;
 
-vhost default {
-    proxy_pass default;
-}
 """,
     }
 
@@ -115,9 +110,9 @@ vhost default {
 
     # Authorization
     # https://tools.ietf.org/html/rfc7235#section-4.2
-    # 
+    #
     # Authorization = credentials
-    # 
+    #
     # No format for credentials is defined
 
     def test_content_encoding(self):
@@ -149,7 +144,7 @@ vhost default {
         self.common_check(request)
 
     def test_content_length(self):
-        # https://tools.ietf.org/html/rfc7230#section-3.3.2   
+        # https://tools.ietf.org/html/rfc7230#section-3.3.2
         #
         # Content-Length = 1*DIGIT
         request = 'POST / HTTP/1.1\r\n' \
@@ -314,7 +309,7 @@ vhost default {
                   'Content-Length: 0\r\n' \
                   '\r\n'
         self.common_check(request)
-    
+
     def test_if_range(self):
         # https://tools.ietf.org/html/rfc7232#section-2.3
         # https://tools.ietf.org/html/rfc7232#section-3.5
@@ -537,15 +532,8 @@ Content-Length: 0
     tempesta = {
         'config' : """
 cache 0;
-listen 80;
+server ${general_ip}:8000;
 
-srv_group default {
-    server ${general_ip}:8000;
-}
-
-vhost default {
-    proxy_pass default;
-}
 """,
     }
 
@@ -665,7 +653,7 @@ vhost default {
                    'Content-Length: 0\r\n' \
                    '\r\n'
         self.common_check(response, self.request)
-    
+
     def test_connection(self):
         # https://tools.ietf.org/html/rfc7230#section-6.1
         # https://tools.ietf.org/html/rfc7230#section-3.2.6

--- a/malformed/test_malformed_structure.py
+++ b/malformed/test_malformed_structure.py
@@ -24,15 +24,8 @@ Connection: keep-alive
     tempesta = {
         'config' : """
 cache 0;
-listen 80;
+server ${general_ip}:8000;
 
-srv_group default {
-    server ${general_ip}:8000;
-}
-
-vhost default {
-    proxy_pass default;
-}
 """,
     }
 

--- a/mixed_requests/test_mixed.py
+++ b/mixed_requests/test_mixed.py
@@ -277,15 +277,8 @@ http {
     tempesta = {
         'config' : """
 cache 0;
-listen 80;
+server ${server_ip}:8600;
 
-srv_group default {
-    server ${server_ip}:8600;
-}
-
-vhost default {
-    proxy_pass default;
-}
 """,
     }
 

--- a/pipelining/test_pipelining.py
+++ b/pipelining/test_pipelining.py
@@ -121,15 +121,8 @@ Connection: keep-alive
     tempesta = {
         'config' : """
 cache 0;
-listen 80;
+server ${general_ip}:8000;
 
-srv_group default {
-    server ${general_ip}:8000;
-}
-
-vhost default {
-    proxy_pass default;
-}
 """,
     }
 
@@ -290,16 +283,10 @@ Connection: keep-alive
         'type' : "tempesta_fi",
         'config' : """
 cache 0;
-listen 80;
 nonidempotent GET prefix "/";
 
-srv_group default {
-    server ${general_ip}:8000;
-}
+server ${general_ip}:8000;
 
-vhost default {
-    proxy_pass default;
-}
 """,
     }
 

--- a/selftests/test_framework.py
+++ b/selftests/test_framework.py
@@ -73,13 +73,7 @@ http {
 cache 0;
 listen 80;
 
-srv_group default {
-    server ${server_ip}:8000;
-}
-
-vhost default {
-    proxy_pass default;
-}
+server ${server_ip}:8000;
 """,
     }
 


### PR DESCRIPTION
Don't use directives like 
```
vhost default {
    proxy_pass default;
}
```
or `listen 80;`. There no need to repeat defaults in tests or explicitly add directives which should be implicitly created. Even worse, explicit definitions may shadow bugs with implicit generation.