### PR TITLE
Fix failed tests from #59: use correct ip address to connect Tempesta to backend server

### DIFF
--- a/cache/test_cache_deception_attack.py
+++ b/cache/test_cache_deception_attack.py
@@ -25,7 +25,7 @@ class TempestaCacheSharding(tester.TempestaTest):
 
     tempesta = {
         'config' : """
-server ${tempesta_ip}:8000;
+server ${general_ip}:8000;
 
 cache 1;
 cache_fulfill suffix ".jpg";
@@ -36,7 +36,7 @@ class TestCacheReplicated(tester.TempestaTest):
 
     tempesta = {
         'config' : """
-server ${tempesta_ip}:8000;
+server ${general_ip}:8000;
 
 cache 2;
 cache_fulfill suffix ".jpg";

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -64,22 +64,6 @@
         {
             "name" : "cache.test_purge.TestPurge.test_purge",
             "reason" : ""
-        },
-        {
-            "name" : "cache.test_cache_deception_attack.CacheDeceptionAttackTest11",
-            "reason" : "Issue #1116. Process the `Pragma` header field"
-        },
-        {
-            "name" : "cache.test_cache_deception_attack.CacheDeceptionAttackTest12",
-            "reason" : "Issue #1116. Process the `Pragma` header field"
-        },
-        {
-            "name" : "cache.test_cache_deception_attack.CacheDeceptionAttackTest13",
-            "reason" : "Issue #1116. Process the `Pragma` header field"
-        },
-        {
-            "name" : "cache.test_cache_deception_attack.CacheDeceptionAttackTest14",
-            "reason" : "Issue #1116. Process the `Pragma` header field"
         }
     ]
 }


### PR DESCRIPTION
`tempesta_ip` stands for ip address of the Tempesta node,
`general_ip` - is for tests framework node.
Deproxy server is started on framework node, not on the same node Tempesta is started.