### PR TITLE
helpers: try to get exact lines from dmesg that appeared during a test

### DIFF
--- a/helpers/dmesg.py
+++ b/helpers/dmesg.py
@@ -37,15 +37,12 @@ class DmesgOopsFinder(object):
 
     def __init__(self):
         self.node = remote.tempesta
+        res, _ = self.node.run_cmd("date +%s.%N")
+        self.start_time = float(res)
 
     def update(self):
-        dml, _ = self.node.run_cmd("dmesg | wc -l")
-        l = int(dml)
-        cmd = 'dmesg | tac | grep -m 1 "Start test" -B %i | tac' % l
+        cmd = "journalctl -k --since=@{:.6f}".format(self.start_time)
         self.log, _ = self.node.run_cmd(cmd)
-        if len(self.log) == 0:
-            cmd = 'dmesg'
-            self.log, _ = self.node.run_cmd(cmd)
 
     def warn_count(self, msg):
         match = re.findall(msg, self.log)


### PR DESCRIPTION
It turned out the current version of `DmesgOopsFinder` is not precise enough. It tries to cut everything before line with substring "Start test" in it. But none of the tests I tried, push such line to the kernel buffer. In that case the whole output of `dmesg` was used. That makes a single line with "ERROR" substring to mark all subsequent tests as failed.

We can remove that fallback, but then there is no way to determine which parts of the log to take based only on the log contents anyway. However, we know that we need only the part that appeared after the moment `DmesgOopsFinder` is constructed.

The code in the patch polls output of `dmesg -w` to extract only lines we are interested in.
