### PR TITLE
fix #92. Ensure all data was sent before close server connection

### DIFF
--- a/framework/deproxy_server.py
+++ b/framework/deproxy_server.py
@@ -25,6 +25,11 @@ class ServerConnection(asyncore.dispatcher_with_send):
         self.request_buffer = ''
         tf_cfg.dbg(6, '\tDeproxy: SrvConnection: New server connection.')
 
+    def send_pending_and_close(self):
+        while len(self.out_buffer):
+            self.initiate_send()
+        self.handle_close()
+
     def send_response(self, response):
         if response:
             tf_cfg.dbg(4, '\tDeproxy: SrvConnection: Send response.')
@@ -35,7 +40,7 @@ class ServerConnection(asyncore.dispatcher_with_send):
         if self.keep_alive:
             self.responses_done += 1
             if self.responses_done == self.keep_alive:
-                self.handle_close()
+                self.send_pending_and_close()
 
     def handle_error(self):
         _, v, _ = sys.exc_info()


### PR DESCRIPTION
Fix #92 

**UPD**

Initial fix was wrong. Actually there was two attempts to fix the problem: one - in 281de6c1c9dc823cc5163f8a1cfabae171ea72aa by changing base class of `ServerConnection` from `asyncore.dispatcher_with_send` to `asyncore.dispatcher` and in previous version of this patch by forcing `ServerConnection.socket` to be synchronous. Fist attempt was mistakenly incomplete, but second was absolutely unneeded. 

The issue was in the `ServerConnection.send_response()` function. After N requests are responded the server connection may be closed. The function is very simple:  send response and close the connection.  But actual things is little bit different: only part of response may be sent: up to 512 bytes if `ServerConnection` is derived from  `asyncore.dispatcher_with_send`  or some unpredictable number of bytes if `ServerConnection` is derived from  `asyncore.dispatcher` since return value from `socket.send()` was ignored. To solve the issue, need to reassure that all pending data was sent.

`ServerConnection` is returned back to `asyncore.dispatcher_with_send` implementation, but now server connections are forced to send the whole pending buffer before closing the connection.