### PR TITLE
Small improvements in stress testing.

### DIFF
--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -1,4 +1,4 @@
 __all__ = ['tf_cfg', 'deproxy', 'nginx', 'tempesta', 'error', 'flacky',
-           'analyzer', 'stateful', 'dmesg', 'wrk', 'prepare']
+           'analyzer', 'stateful', 'dmesg', 'wrk', 'prepare', 'util']
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/helpers/control.py
+++ b/helpers/control.py
@@ -7,6 +7,7 @@ import os
 import asyncore
 import multiprocessing.dummy as multiprocessing
 from . import tf_cfg, remote, error, nginx, tempesta, deproxy, stateful, dmesg
+from . import util
 
 __author__ = 'Tempesta Technologies, Inc.'
 __copyright__ = 'Copyright (C) 2017 Tempesta Technologies, Inc.'
@@ -114,6 +115,7 @@ class Client(object):
         self.options.append('-H \'User-Agent: %s\'' % ua)
 
 
+@util.deprecated("framework.Wrk")
 class Wrk(Client):
     """ wrk - HTTP benchmark utility.
 
@@ -123,11 +125,6 @@ class Wrk(Client):
     test, otherwise print warning and count the errors as usual errors.
     """
     FAIL_ON_SOCK_ERR=False
-
-    def __new__(cls, *args, **kwargs):
-        tf_cfg.dbg(5, "%s must be used instead of deprecated %s"
-                   % ("framework.Wrk", cls.__name__))
-        return super(Wrk, cls).__new__(cls, *args, **kwargs)
 
     def __init__(self, threads=-1, uri='/', ssl=False, timeout=60):
         Client.__init__(self, binary='wrk', uri=uri, ssl=ssl)

--- a/helpers/control.py
+++ b/helpers/control.py
@@ -124,6 +124,11 @@ class Wrk(Client):
     """
     FAIL_ON_SOCK_ERR=False
 
+    def __new__(cls, *args, **kwargs):
+        tf_cfg.dbg(5, "%s must be used instead of deprecated %s"
+                   % ("framework.Wrk", cls.__name__))
+        return super(Wrk, cls).__new__(cls, *args, **kwargs)
+
     def __init__(self, threads=-1, uri='/', ssl=False, timeout=60):
         Client.__init__(self, binary='wrk', uri=uri, ssl=ssl)
         self.threads = threads

--- a/helpers/util.py
+++ b/helpers/util.py
@@ -10,7 +10,7 @@ __license__ = 'GPL2'
 
 def deprecated(alt_impl_name):
     """
-    Decorator to declare a class and its inheritants as deprecated.
+    Decorator to declare a class and its descendants as deprecated.
     Example ('Foo' is a new alternative implementation which should be used
     instead):
 

--- a/helpers/util.py
+++ b/helpers/util.py
@@ -1,0 +1,33 @@
+"""
+Utils for the testing framework.
+"""
+from . import tf_cfg
+
+__author__ = 'Tempesta Technologies, Inc.'
+__copyright__ = 'Copyright (C) 2019 Tempesta Technologies, Inc.'
+__license__ = 'GPL2'
+
+
+def deprecated(alt_impl_name):
+    """
+    Decorator to declare a class and its inheritants as deprecated.
+    Example ('Foo' is a new alternative implementation which should be used
+    instead):
+
+        @deprecated("Foo")
+        class A(...):
+            ...
+    """
+    def decorator(cls):
+
+        def deprecated_new(new_func):
+            def wrap(cls_arg, *args, **kwargs):
+                tf_cfg.dbg(5, "%s must be used instead of deprecated %s"
+                        % (alt_impl_name, cls_arg.__name__))
+                return new_func(cls_arg, *args, **kwargs)
+            return wrap
+
+        setattr(cls, '__new__', staticmethod(deprecated_new(cls.__new__)))
+        return cls
+
+    return decorator

--- a/testers/functional.py
+++ b/testers/functional.py
@@ -3,20 +3,17 @@ import unittest
 import copy
 import asyncore
 from helpers import dmesg, tf_cfg, control, tempesta, deproxy, stateful, remote
+from helpers import util
 from helpers.deproxy import ParseError
 
 __author__ = 'Tempesta Technologies, Inc.'
 __copyright__ = 'Copyright (C) 2017 Tempesta Technologies, Inc.'
 __license__ = 'GPL2'
 
+@util.deprecated("tester.TempestaTest")
 class FunctionalTest(unittest.TestCase):
 
     tfw_clnt_msg_otherr = False
-
-    def __new__(cls, *args, **kwargs):
-        tf_cfg.dbg(5, "%s must be used instead of deprecated %s"
-                   % ("tester.TempestaTest", cls.__name__))
-        return super(FunctionalTest, cls).__new__(cls, *args, **kwargs)
 
     def create_client(self):
         """ Override to set desired list of benchmarks and their options. """

--- a/testers/functional.py
+++ b/testers/functional.py
@@ -13,6 +13,11 @@ class FunctionalTest(unittest.TestCase):
 
     tfw_clnt_msg_otherr = False
 
+    def __new__(cls, *args, **kwargs):
+        tf_cfg.dbg(5, "%s must be used instead of deprecated %s"
+                   % ("tester.TempestaTest", cls.__name__))
+        return super(FunctionalTest, cls).__new__(cls, *args, **kwargs)
+
     def create_client(self):
         """ Override to set desired list of benchmarks and their options. """
         self.client = deproxy.Client()

--- a/testers/stress.py
+++ b/testers/stress.py
@@ -21,6 +21,11 @@ class StressTest(unittest.TestCase):
     errors_write = 0
     errors_timeout = 0
 
+    def __new__(cls, *args, **kwargs):
+        tf_cfg.dbg(5, "%s must be used instead of deprecated %s"
+                   % ("tester.TempestaTest", cls.__name__))
+        return super(StressTest, cls).__new__(cls, *args, **kwargs)
+
     def create_clients(self):
         """ Override to set desired list of benchmarks and their options. """
         self.wrk = control.Wrk()
@@ -162,6 +167,7 @@ class StressTest(unittest.TestCase):
         tf_cfg.dbg(2, "errors read: %i" % e_read)
         tf_cfg.dbg(2, "errors write: %i" % e_write)
         tf_cfg.dbg(2, "errors timeout: %i" % e_timeout)
+        self.assertGreater(req, 0, msg="No work was done by the client")
         self.assertEqual(err, e_500 + e_502 + e_504 + e_connect, msg=msg)
 
     def assert_clients(self):
@@ -189,7 +195,9 @@ class StressTest(unittest.TestCase):
         exp_max = cl_req_cnt + cl_conn_cnt
         self.assertTrue(
             self.tempesta.stats.cl_msg_received >= exp_min and
-            self.tempesta.stats.cl_msg_received <= exp_max
+            self.tempesta.stats.cl_msg_received <= exp_max,
+            msg="Tempesta received bad number %d of messages, expected [%d:%d]"
+                % (self.tempesta.stats.cl_msg_received, exp_min, exp_max)
         )
 
     def assert_tempesta(self):

--- a/testers/stress.py
+++ b/testers/stress.py
@@ -1,11 +1,13 @@
 from __future__ import print_function
 import unittest
 from helpers import tf_cfg, control, tempesta, stateful, dmesg, remote
+from helpers import util
 
 __author__ = 'Tempesta Technologies, Inc.'
 __copyright__ = 'Copyright (C) 2017-2018 Tempesta Technologies, Inc.'
 __license__ = 'GPL2'
 
+@util.deprecated("tester.TempestaTest")
 class StressTest(unittest.TestCase):
     """ Test Suite to use HTTP benchmarks as a clients. Can be used for
     functional testing of schedulers and stress testing for other components.
@@ -20,11 +22,6 @@ class StressTest(unittest.TestCase):
     errors_read = 0
     errors_write = 0
     errors_timeout = 0
-
-    def __new__(cls, *args, **kwargs):
-        tf_cfg.dbg(5, "%s must be used instead of deprecated %s"
-                   % ("tester.TempestaTest", cls.__name__))
-        return super(StressTest, cls).__new__(cls, *args, **kwargs)
 
     def create_clients(self):
         """ Override to set desired list of benchmarks and their options. """


### PR DESCRIPTION
Assert that a client in stress test actually did some work.
Fix ugly assertion 'False is not true'.
Print warnings on higest verbose level about deprecated classes (#56).