### PR TITLE
Do not change sysctl net.core.message_cost by default in DmesgFinder.

### DIFF
--- a/msg_sequence/test_pairing.py
+++ b/msg_sequence/test_pairing.py
@@ -41,13 +41,12 @@ class PairingTest(functional.FunctionalTest):
         disconnects before Tempesta received responses from backend. Responses
         must be evicted, no 'Paired request missing' messages are allowed.
         """
-        klog = dmesg.DmesgFinder()
         self.prepare()
         self.tester.loop(0.5) # Let handle connects
         self.tester.send_reqs(self.send_to_close)
         self.tester.disconnect_clnt()
         self.tester.send_resps()
-        self.assertEqual(klog.warn_count(dmesg.WARN_SPLIT_ATTACK), 0,
+        self.assertEqual(self.oops.warn_count(dmesg.WARN_SPLIT_ATTACK), 0,
                          msg=("Got '%s'" % dmesg.WARN_SPLIT_ATTACK))
 
 

--- a/tls/handshake.py
+++ b/tls/handshake.py
@@ -357,7 +357,7 @@ class TlsHandshakeStandard:
         self.verbose = verbose
 
     def try_tls_vers(self, version):
-        klog = dmesg.DmesgFinder()
+        klog = dmesg.DmesgFinder(ratelimited=False)
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.settimeout(self.io_to)
         sock.connect((self.addr, self.port))

--- a/tls/test_tls_cert.py
+++ b/tls/test_tls_cert.py
@@ -92,13 +92,12 @@ class X509(tester.TempestaTest):
                         "Cannot start Tempesta")
 
         # Collect warnings before start w/ a bad certificate.
-        klog = dmesg.DmesgFinder()
         self.start_all_clients()
         client = self.get_client('deproxy')
         client.make_request('GET / HTTP/1.1\r\nHost: localhost\r\n\r\n')
         res = client.wait_for_response(timeout=X509.TIMEOUT)
         self.assertFalse(res, "Erroneously established connection")
-        self.assertEqual(klog.warn_count(msg), 1,
+        self.assertEqual(self.oops.warn_count(msg), 1,
                          "Tempesta doesn't throw a warning on bad certificate")
 
     def check_cannot_start(self, msg):
@@ -110,9 +109,8 @@ class X509(tester.TempestaTest):
         cert_path, key_path = self.cgen.get_file_paths()
         remote.tempesta.copy_file(cert_path, self.cgen.serialize_cert())
         remote.tempesta.copy_file(key_path, self.cgen.serialize_priv_key())
-        klog = dmesg.DmesgFinder()
         self.start_tempesta()
-        self.assertGreater(klog.warn_count(msg), 0,
+        self.assertGreater(self.oops.warn_count(msg), 0,
                            "Tempesta doesn't report error")
 
 

--- a/tls/test_tls_handshake.py
+++ b/tls/test_tls_handshake.py
@@ -84,12 +84,11 @@ class TlsHandshakeTest(tester.TempestaTest):
         hs12.ciphers = range(2000) # TTLS_HS_CS_MAX_SZ = 984
         # Test compressions as well - they're just ignored anyway.
         hs12.compressions = range(15)
-        klog = dmesg.DmesgFinder()
         # Tempesta must send a TLS alert raising TLSProtocolError exception.
         # Nginx/OpenSSL sends DECODE_ERROR FATAL alert for the ClientHello.
         with self.assertRaises(tls.TLSProtocolError):
             hs12.do_12()
-        self.assertEqual(klog.warn_count(WARN), 1,
+        self.assertEqual(self.oops.warn_count(WARN), 1,
                          "No warning about bad ClientHello")
 
     def test_long_sni(self):
@@ -97,11 +96,10 @@ class TlsHandshakeTest(tester.TempestaTest):
         self.start_all()
         hs12 = TlsHandshake(addr='127.0.0.1', port=443)
         hs12.sni = ["a" * 100 for i in xrange(10)]
-        klog = dmesg.DmesgFinder()
         # Tempesta must send a TLS alerts raising TLSProtocolError exception.
         with self.assertRaises(tls.TLSProtocolError):
             hs12.do_12()
-        self.assertEqual(klog.warn_count(WARN), 1,
+        self.assertEqual(self.oops.warn_count(WARN), 1,
                          "No warning about bad ClientHello")
 
     def test_empty_sni_default(self):
@@ -115,11 +113,11 @@ class TlsHandshakeTest(tester.TempestaTest):
         hs12 = TlsHandshake(addr='127.0.0.1', port=443)
         hs12.sni = ["bad.server.name"]
         hs12.host = "tempesta-tech.com"
-        klog = dmesg.DmesgFinder()
         # Tempesta must send a TLS alerts raising TLSProtocolError exception.
         with self.assertRaises(tls.TLSProtocolError):
             hs12.do_12()
-        self.assertEqual(klog.warn_count(WARN), 1, "Bad SNI isn't rejected")
+        self.assertEqual(self.oops.warn_count(WARN), 1,
+                         "Bad SNI isn't rejected")
 
     def test_bad_sign_algs(self):
         self.start_all()
@@ -129,11 +127,10 @@ class TlsHandshakeTest(tester.TempestaTest):
                           tls.TLSExtSignatureAlgorithms(
                               algs=[0x0201, 0x0401, 0x0501, 0x0601, 0x0403],
                               length=11)]
-        klog = dmesg.DmesgFinder()
         # Tempesta must send a TLS alerts raising TLSProtocolError exception.
         with self.assertRaises(tls.TLSProtocolError):
             hs12.do_12()
-        self.assertEqual(klog.warn_count(WARN), 1,
+        self.assertEqual(self.oops.warn_count(WARN), 1,
                          "No warning about bad ClientHello")
 
     def test_bad_elliptic_curves(self):
@@ -144,11 +141,10 @@ class TlsHandshakeTest(tester.TempestaTest):
                                 tls.TLSExtEllipticCurves(
                                     named_group_list=range(13),
                                     length=26)]
-        klog = dmesg.DmesgFinder()
         # Tempesta must send a TLS alerts raising TLSProtocolError exception.
         with self.assertRaises(tls.TLSProtocolError):
             hs12.do_12()
-        self.assertEqual(klog.warn_count(WARN), 1,
+        self.assertEqual(self.oops.warn_count(WARN), 1,
                          "No warning about bad ClientHello")
 
     def test_bad_renegotiation_info(self):
@@ -156,11 +152,10 @@ class TlsHandshakeTest(tester.TempestaTest):
         hs12 = TlsHandshake(addr='127.0.0.1', port=443)
         hs12.renegotiation_info = [tls.TLSExtension() /
                                    tls.TLSExtRenegotiationInfo(data="foo")]
-        klog = dmesg.DmesgFinder()
         # Tempesta must send a TLS alerts raising TLSProtocolError exception.
         with self.assertRaises(tls.TLSProtocolError):
             hs12.do_12()
-        self.assertEqual(klog.warn_count(WARN), 1,
+        self.assertEqual(self.oops.warn_count(WARN), 1,
                          "No warning about non-empty RenegotiationInfo")
 
     def test_alert(self):
@@ -309,11 +304,11 @@ class TlsVhostHandshakeTest(tester.TempestaTest):
         self.init()
         hs12 = TlsHandshake(addr='127.0.0.1', port=443)
         hs12.sni = []
-        klog = dmesg.DmesgFinder()
         # Tempesta must send a TLS alerts raising TLSProtocolError exception.
         with self.assertRaises(tls.TLSProtocolError):
             hs12.do_12()
-        self.assertEqual(klog.warn_count(WARN), 1, "No warning about bad SNI")
+        self.assertEqual(self.oops.warn_count(WARN), 1,
+                         "No warning about bad SNI")
 
     def test_bad_host(self):
         self.init()


### PR DESCRIPTION
Do not change sysctl net.core.message_cost by default in DmesgFinder.
Switch of net ratelimiting only for local context instances of the class
when we sure that Python GC frees the instance on return, failed assertion,
or unhandled exception.

Use TempestaTest.oops when we don't need our own instance of DmesgFinder().