### PR TITLE
enable tests disabled because of #1283

### DIFF
--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -128,15 +128,6 @@
         {
             "name" : "tls.test_tls_handshake.TlsHandshakeTest.test_fuzzing",
             "reason" : "Bug #1318: crash on ttls_recv()."
-        },
-        {
-            "name" : "tls.test_tls_integrity.Proxy.test_various_req_resp_sizes",
-            "reason" : "Bug #1283: all messages longer than 4096 aren't processed."
-        },
-        {
-            "name" : "tls.test_tls_integrity.Cache.test_various_req_resp_sizes",
-            "reason" : "Bug #1283: all messages longer than 4096 aren't processed."
         }
-
     ]
 }


### PR DESCRIPTION
https://github.com/tempesta-tech/tempesta/issues/1283 is now closed, so it's time to enable those tests again.