### PR TITLE
keep client.responses array length intact

### DIFF
--- a/tls/test_tls_integrity.py
+++ b/tls/test_tls_integrity.py
@@ -70,7 +70,7 @@ class TlsIntegrityTester(tester.TempestaTest):
             res = client.wait_for_response(timeout=5)
             self.assertTrue(res, "Cannot process request (len=%d) or response" \
                                  " (len=%d)" % (req_len, resp_len))
-            resp = client.responses.pop().body
+            resp = client.responses[-1].body
             tf_cfg.dbg(4, '\tDeproxy response (len=%d): %s...'
                        % (len(resp), resp[:100]))
             hash2 = hashlib.md5(resp).digest()


### PR DESCRIPTION
Deproxy client is confused when its `.responses` array length changes. Which can cause false positives if the same client instance is used for more than one request-response pair.

`DeproxyClient.wait_for_response` [expects](https://github.com/tempesta-tech/tempesta-test/blob/5ee7af2a091ccf2c5e2bbe5a1333b418dc72eeff/framework/deproxy_client.py#L176) `self.responses` length to be in sync with `self.valid_req_num`.