### PR TITLE
if we do not send sni, vhost will be selected by the host header

### DIFF
--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -98,10 +98,6 @@
             "reason" : "Bug #1324."
         },
         {
-            "name" : "tls.test_tls_handshake.TlsVhostHandshakeTest.test_empty_sni_default",
-            "reason" : "Bug #1347: Tempesta doesn't send TLS alerts on empty sni default."
-        },
-        {
             "name" : "tls.test_tls_handshake.TlsHandshakeTest.test_fuzzing",
             "reason" : "Bug #1318: crash on ttls_recv()."
         }


### PR DESCRIPTION
fix tempesta-tech/tempesta#1347

We do not send sni, the tls connection will be open using a global certificate (vhost1), and vhost will be selected by the host header