### PR TITLE
don`t took pagecache memory into account used memory

### DIFF
--- a/leaks/test_leak.py
+++ b/leaks/test_leak.py
@@ -49,7 +49,7 @@ def read_kmemleaks():
 def get_memory_lines(*names):
     """ Get values from /proc/meminfo """
     if not has_meminfo():
-        return -1
+        raise Exception("/proc/meminfo does not exist")
     [stdout, stderr] = remote.tempesta.run_cmd("cat /proc/meminfo")
     lines = []
     for name in names:
@@ -57,7 +57,7 @@ def get_memory_lines(*names):
         if line:
             lines.append(int(line.group(1)))
         else:
-            lines.append(-1)
+            raise Exception("Can not get %s from /proc/meminfo" % name)
     return lines
 
 def slab_memory():
@@ -70,8 +70,6 @@ def free_memory():
     """ Measure free memory usage """
     drop_caches()
     freemem, = get_memory_lines("MemFree")
-    if freemem == -1:
-        return -1
     return freemem
 
 class LeakTest(tester.TempestaTest):

--- a/leaks/test_leak.py
+++ b/leaks/test_leak.py
@@ -66,15 +66,13 @@ def slab_memory():
     slabmem, = get_memory_lines("Slab")
     return slabmem
 
-def used_memory():
-    """ Measure total memory usage """
+def free_memory():
+    """ Measure free memory usage """
     drop_caches()
-    totalmem, freemem = get_memory_lines("MemTotal", "MemFree")
-    if totalmem == -1:
-        return -1
+    freemem, = get_memory_lines("MemFree")
     if freemem == -1:
         return -1
-    return totalmem - freemem
+    return freemem
 
 class LeakTest(tester.TempestaTest):
     """ Leaks testing """
@@ -192,10 +190,10 @@ server ${server_ip}:8000;
         nginx = self.get_server('nginx')
         wrk = self.get_client('wrk')
 
-        used1 = used_memory()
+        free1 = free_memory()
         self.run_routine(nginx, wrk)
-        used2 = used_memory()
+        free2 = free_memory()
 
         tf_cfg.dbg(2, "used %i kib of memory = %s kib - %s kib" % \
-                    (used2 - used1, used2, used1))
-        self.assertLess(used2 - used1, self.memory_leak_thresold)
+                    (free1 - free2, free1, free2))
+        self.assertLess(free1 - free2, self.memory_leak_thresold)


### PR DESCRIPTION
- replace 2 get_memory_line() calls with 1 get_memory_lines() call
- to calculate the used memory you do not need to know the total memory
- using exceptions instead of error codes
- don`t took pagecache memory into account used memory 