### PR TITLE
secp192r1 certificates can not be loaded any more

### DIFF
--- a/tls/test_tls_cert.py
+++ b/tls/test_tls_cert.py
@@ -204,7 +204,7 @@ class ECDSA_SHA256_SECP192(X509):
         self.cgen = CertGenerator()
         self.cgen.key = {
             'alg': 'ecdsa',
-            'curve': ec.SECP192R1() # Unsupported curve
+            'curve': ec.SECP192R1() # Deprecated curve, RFC 8422 5.1.1
         }
         self.cgen.sign_alg = 'sha256'
         self.cgen.generate()
@@ -215,7 +215,8 @@ class ECDSA_SHA256_SECP192(X509):
         tester.TempestaTest.setUp(self)
 
     def test(self):
-        self.check_bad_alg("Warning: None of the common ciphersuites is usable")
+        self.check_cannot_start("ERROR: tls_certificate: "
+                                + "Invalid certificate specified")
 
 
 class ECDSA_SHA256_SECP256(X509):


### PR DESCRIPTION
RFC 8422 5.1.1 deprecates curves 1..22 (the indexes are defined in RFC 4492 5.1.1), so SECP192r1 was completely removed from Tempesta TLS and certificates can not be loaded any more.

This is a test change for https://github.com/tempesta-tech/tempesta/pull/1363