### PR TITLE
enable tls.test_tls_handshake.TlsHandshakeTest.test_fuzzing

### DIFF
--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -84,10 +84,6 @@
         {
             "name" : "tls.test_tls_integrity.Proxy.test_tcp_segs",
             "reason" : "#1325: the test fails before the issue is fixed. Probably there is a reason for the behavior and the test should be reworked."
-        },
-        {
-            "name" : "tls.test_tls_handshake.TlsHandshakeTest.test_fuzzing",
-            "reason" : "Bug #1318: crash on ttls_recv()."
         }
     ]
 }


### PR DESCRIPTION
Enable fuzzing test since issues at https://github.com/tempesta-tech/tempesta/issues/1318 are fixed now.