### PR TITLE
Fix minor tests issues

### DIFF
--- a/long_body/test_response_wrong_length.py
+++ b/long_body/test_response_wrong_length.py
@@ -107,14 +107,13 @@ class TesterMissingEmptyBodyLength(deproxy.Deproxy):
         chain = generate_chain_200(method='GET', response_body=self.reply_body)
         chain.server_response.headers.delete_all('Content-Length')
         chain.server_response.update()
+        chain.response.headers.delete_all('Content-Length')
+        chain.response.headers['Transfer-Encoding'] = 'chunked'
+        chain.response.body = '0\r\n\r\n'
+        chain.response.update()
+
         self.message_chains = [chain]
         self.cookies = []
-
-
-class TesterMissingBodyLength(TesterMissingEmptyBodyLength):
-    """ Tester """
-    reply_body = "abcdefgh"
-
 
 class TesterSmallBodyLength(TesterCorrectBodyLength):
     """ Tester """

--- a/sessions/test_js_challenge.py
+++ b/sessions/test_js_challenge.py
@@ -244,14 +244,14 @@ class JSChallenge(tester.TempestaTest):
         self.process_js_challenge(client, 'vh1.com',
                                   delay_min=1000, delay_range=1500,
                                   status_code=503, expect_pass=True,
-                                  req_delay=2)
+                                  req_delay=2.5)
 
         tf_cfg.dbg(3, "Send request to vhost 2 with timeout 4s...")
         client = self.get_client('client-2')
         self.process_js_challenge(client, 'vh2.com',
                                   delay_min=2000, delay_range=1200,
                                   status_code=302, expect_pass=True,
-                                  req_delay=4)
+                                  req_delay=3.5)
         # Vhost 3 has very strict window to receive the request, skip it in
         # this test.
 

--- a/sessions/test_js_challenge.py
+++ b/sessions/test_js_challenge.py
@@ -119,14 +119,18 @@ class JSChallenge(tester.TempestaTest):
         self.assertTrue(client.connection_is_closed())
 
     def prepare_js_templates(self):
+        """
+        Templates for JS challenge are modified by start script, create a copy
+        of default template for each vhost.
+        """
         srcdir = tf_cfg.cfg.get('Tempesta', 'srcdir')
         workdir = tf_cfg.cfg.get('Tempesta', 'workdir')
         template = "%s/etc/js_challenge.tpl" % srcdir
         js_code = "%s/etc/js_challenge.js.tpl" % srcdir
-        remote.tempesta.copy_file_to_node(js_code, workdir)
-        remote.tempesta.copy_file_to_node(template, "%s/js1.tpl" % workdir)
-        remote.tempesta.copy_file_to_node(template, "%s/js2.tpl" % workdir)
-        remote.tempesta.copy_file_to_node(template, "%s/js3.tpl" % workdir)
+        remote.tempesta.run_cmd("cp %s %s"  % (js_code, workdir))
+        remote.tempesta.run_cmd("cp %s %s/js1.tpl" % (template, workdir))
+        remote.tempesta.run_cmd("cp %s %s/js2.tpl" % (template, workdir))
+        remote.tempesta.run_cmd("cp %s %s/js3.tpl" % (template, workdir))
 
     def start_all(self):
         self.prepare_js_templates()


### PR DESCRIPTION
4 tests failed on CI:

- `long_body.test_response_wrong_length.ResponseMissingEmptyBodyLength`: after recent changes TempestaFW never adds `Content-Length` header and always transforms message to chunked encoding, but the test expected the old behaviour. Fixed that. And removed a dead code.

- `sessions.test_js_challenge*` - A JS challenge template was supposed to be copied from `srcdir` to `workdr`, but instead of copying on `tempesta` node, the framework tried to copy file from `framework` to `tempesta` node. In local installations both nodes are the same virtual machine, so it worked, but on CI - two different, thus the copy operation failed. But there was one issue more: the `libtemplate-perl` package was absent on `tempesta` node and the template couldn't be processed.

With this fixes all the tests must pass on current master.