### PR TITLE
Add basic h2 proto tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ deproxy server, and workload tests should use wrk client and nginx server.
 
 - Host for testing framework: `Python2`, `python2-paramiko`,
 `python-configparser`, `python-subprocess32`, `wrk`, `ab`, `python-scapy`,
-`python-cryptography`, `scapy-ssl_tls` (installed with `pip`)
+`python-cryptography`, `scapy-ssl_tls` (installed with `pip`), `h2spec`
 - All hosts except previous one: `sftp-server`
 - Host for running TempestaFW: Linux kernel with Tempesta, TempestaFW sources,
 `systemtap`, `tcpdump`, `bc`
@@ -82,6 +82,9 @@ deproxy server, and workload tests should use wrk client and nginx server.
 
 `ab` is Apache benchmark tool, that can be found in `apache2-utils` package in
 Debian or `httpd-tools` in CentOS.
+
+`h2spec` is HTTP/2 conformance test suite. Can't be installed from package
+manager and must be retrieved from [GitHub](https://github.com/summerwind/h2spec/releases/latest).
 
 Unfortunately, CentOS does not have `python-subprocess32` package, but it can be
 downloaded from [CentOS CBS](https://cbs.centos.org/koji/buildinfo?buildID=10904)
@@ -151,7 +154,7 @@ names available in PATH.
 #### Tempesta Section
 
 `ip` — IPv4/IPv6 address of the TempestaFW host in test network, as reachable
-from the client and server hosts. 
+from the client and server hosts.
 
 `hostname`, `port`, `user` — address and credentials used to reach the host via
 SSH. If hostname is `localhost`, TempestaFW will be ran locally.

--- a/framework/__init__.py
+++ b/framework/__init__.py
@@ -1,2 +1,3 @@
 __all__ = ['client', 'deproxy_client', 'deproxy_manager', 'deproxy_server',
-           'nginx_server', 'templates', 'tester', 'wrk_client', 'port_checks']
+           'nginx_server', 'templates', 'tester', 'wrk_client', 'port_checks',
+           'external_client']

--- a/framework/client.py
+++ b/framework/client.py
@@ -63,6 +63,9 @@ class Client(stateful.Stateful):
         They use file with list of uris instead. Don't force clients to use
         uri field.
         """
+        if not uri:
+            self.uri = ''
+            return
         proto = 'https://' if self.ssl else 'http://'
         self.uri = ''.join([proto, self.server_addr, uri])
 

--- a/framework/external_client.py
+++ b/framework/external_client.py
@@ -6,6 +6,17 @@ __copyright__ = 'Copyright (C) 2020 Tempesta Technologies, Inc.'
 __license__ = 'GPL2'
 
 class ExternalTester(client.Client):
+    """The class allows to run various 3d-party test suites or any programs
+    against Tempesta. Required properties of `client` definitions inside
+    `tester.TempestaTest` class:
+    - `type` - common attribute for all definitions. Must have value `external`
+    - `binary` - binary to run. The `binary` value is checked against tests
+        config file and alias from `Client` section can be used for that
+        `binary` value. Thus full path mustn't apper in test description just
+        in config file.
+    - `cmd_args` - initial list of command line arguments. Can be updated
+        in runtime via modifying `options` (list of strings) member.
+    """
 
     def __init__(self, cmd_args, **kwargs):
         client.Client.__init__(self, **kwargs)

--- a/framework/external_client.py
+++ b/framework/external_client.py
@@ -1,0 +1,19 @@
+from . import client
+
+
+__author__ = 'Tempesta Technologies, Inc.'
+__copyright__ = 'Copyright (C) 2020 Tempesta Technologies, Inc.'
+__license__ = 'GPL2'
+
+class ExternalTester(client.Client):
+
+    def __init__(self, cmd_args, **kwargs):
+        client.Client.__init__(self, **kwargs)
+        self.options = [cmd_args]
+
+    def form_command(self):
+        cmd = ' '.join([self.bin] + self.options)
+        return cmd
+
+    def parse_out(self, stdout, stderr):
+        return True

--- a/framework/tester.py
+++ b/framework/tester.py
@@ -7,6 +7,8 @@ from helpers import control, tf_cfg, dmesg, remote
 import framework.wrk_client as wrk_client
 import framework.deproxy_client as deproxy_client
 import framework.deproxy_manager as deproxy_manager
+import framework.external_client as external_client
+
 from framework.templates import fill_template, populate_properties
 
 import socket
@@ -150,6 +152,14 @@ class TempestaTest(unittest.TestCase):
         wrk.set_script(client['id']+"_script", content="")
         return wrk
 
+    def __create_client_external(self, client_descr):
+        cmd_args = fill_template(client_descr['cmd_args'], client_descr)
+        ext_client = external_client.ExternalTester(binary=client_descr['binary'],
+                                                    cmd_args=cmd_args,
+                                                    server_addr=None,
+                                                    uri=None)
+        return ext_client
+
     def __create_client(self, client):
         populate_properties(client)
         ssl = client.setdefault('ssl', False)
@@ -167,6 +177,8 @@ class TempestaTest(unittest.TestCase):
             self.__clients[cid].set_rps(client.get('rps', 0))
         elif client['type'] == 'wrk':
             self.__clients[cid] = self.__create_client_wrk(client, ssl)
+        elif client['type'] == 'external':
+            self.__clients[cid] = self.__create_client_external(client)
 
     def __create_backend(self, server):
         srv = None

--- a/h2/__init__.py
+++ b/h2/__init__.py
@@ -1,0 +1,3 @@
+__all__ = ['test_h2_specs']
+
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/h2/test_h2_specs.py
+++ b/h2/test_h2_specs.py
@@ -94,7 +94,7 @@ class H2Spec(tester.TempestaTest):
 
     def test_h2_specs(self):
         h2spec = self.get_client('h2spec')
-        # TODO: for now run only simple test to check http2 connectivity
+        # TODO #88: for now run only simple test to check http2 connectivity
         # After all h2-related issues will be fixed, remove the line
         h2spec.options.append('generic/4')
 

--- a/h2/test_h2_specs.py
+++ b/h2/test_h2_specs.py
@@ -1,0 +1,104 @@
+from helpers import tf_cfg
+from framework import tester
+
+__author__ = 'Tempesta Technologies, Inc.'
+__copyright__ = 'Copyright (C) 2020 Tempesta Technologies, Inc.'
+__license__ = 'GPL2'
+
+NGINX_CONFIG = """
+pid ${pid};
+worker_processes  auto;
+
+events {
+    worker_connections   1024;
+    use epoll;
+}
+
+http {
+    keepalive_timeout ${server_keepalive_timeout};
+    keepalive_requests ${server_keepalive_requests};
+    sendfile         on;
+    tcp_nopush       on;
+    tcp_nodelay      on;
+
+    open_file_cache max=1000;
+    open_file_cache_valid 30s;
+    open_file_cache_min_uses 2;
+    open_file_cache_errors off;
+
+    # [ debug | info | notice | warn | error | crit | alert | emerg ]
+    # Fully disable log errors.
+    error_log /dev/null emerg;
+
+    # Disable access log altogether.
+    access_log off;
+
+    server {
+        listen        ${server_ip}:8000;
+
+        location / {
+            return 200;
+        }
+        location /nginx_status {
+            stub_status on;
+        }
+    }
+}
+"""
+
+TEMPESTA_CONFIG = """
+listen 443 proto=h2;
+
+srv_group default {
+    server ${server_ip}:8000;
+}
+vhost default {
+    tls_certificate ${general_workdir}/tempesta.crt;
+    tls_certificate_key ${general_workdir}/tempesta.key;
+
+    proxy_pass default;
+}
+
+cache 0;
+
+"""
+
+class H2Spec(tester.TempestaTest):
+    '''Tests for h2 proto implementation. Run h2spec utility against Tempesta.
+    Simply check return code and warnings in system log for test errors.
+    '''
+
+    clients = [
+        {
+            'id' : 'h2spec',
+            'type' : 'external',
+            'binary' : 'h2spec',
+            'ssl' : True,
+            'cmd_args' : '-tkh ${tempesta_ip}'
+        },
+    ]
+
+    backends = [
+        {
+            'id' : 'nginx',
+            'type' : 'nginx',
+            'port' : '8000',
+            'status_uri' : 'http://${server_ip}:8000/nginx_status',
+            'config' : NGINX_CONFIG,
+        }
+    ]
+
+    tempesta = {
+        'config' : TEMPESTA_CONFIG,
+    }
+
+    def test_h2_specs(self):
+        h2spec = self.get_client('h2spec')
+        # TODO: for now run only simple test to check http2 connectivity
+        # After all h2-related issues will be fixed, remove the line
+        h2spec.options.append('generic/4')
+
+        self.start_all_servers()
+        self.start_tempesta()
+        self.start_all_clients()
+        self.wait_while_busy(h2spec)

--- a/helpers/remote.py
+++ b/helpers/remote.py
@@ -79,7 +79,8 @@ class LocalNode(Node):
                               stderr=stderr_pipe, env=env_full) as p:
             try:
                 stdout, stderr = p.communicate(timeout)
-                assert p.returncode == 0, "Return code is not 0."
+                assert p.returncode == 0, \
+                    "Cmd: '%s' return code is not 0 (%d)." % (cmd, p.returncode)
             except Exception as e:
                 if not err_msg:
                     err_msg = ("Error running command '%s' on %s" %
@@ -221,7 +222,7 @@ class RemoteNode(Node):
 
     def wait_available(self):
         tf_cfg.dbg(3, '\tWaiting for %s node' % self.type)
-        timeout = float(tf_cfg.cfg.get(self.type, 'unavaliable_timeout'))        
+        timeout = float(tf_cfg.cfg.get(self.type, 'unavaliable_timeout'))
         t0 = time.time()
         while True:
             t = time.time()

--- a/helpers/tempesta.py
+++ b/helpers/tempesta.py
@@ -245,7 +245,8 @@ class Config(object):
                 "Two or more certificates configured, please use custom_cert" \
                 " option in Tempesta configuration"
             cfg[k] = v
-        if not cfg.has_key('listen') or not 'https' in cfg['listen']:
+        if not cfg.has_key('listen') or not \
+            any(proto in cfg['listen'] for proto in ['https', 'h2']):
             return
         cert_path, key_path = cfg['tls_certificate'], cfg['tls_certificate_key']
         cgen = CertGenerator(cert_path, key_path, True)

--- a/tests_config.ini.sample
+++ b/tests_config.ini.sample
@@ -78,6 +78,12 @@ ab = ab
 #
 wrk = wrk
 
+# h2spec conformance testing tool for HTTP/2 implementation.
+#
+# ex.: h2spec = /home/user/bin/h2spec
+#
+h2spec = h2spec
+
 
 [Tempesta]
 # Configuration for the host running TempestaFW. It may be configured to run


### PR DESCRIPTION
Run h2spec utility against Tempesta and evaluate return code. Increase
debug level to get h2spec detailed results.

A new directive in `tests_config.ini` under section `[Client]` may be
required since h2spec is never available through pacage manager and
need to be installed from https://github.com/summerwind/h2spec :

    h2spec = /path/to/h2spec

Fix tempesta-tech/tempesta#739