### PR TITLE
SECP521 has been removed from Tempesta TLS

### DIFF
--- a/tls/test_tls_cert.py
+++ b/tls/test_tls_cert.py
@@ -265,7 +265,7 @@ class ECDSA_SHA384_SECP521(X509):
         self.cgen = CertGenerator()
         self.cgen.key = {
             'alg': 'ecdsa',
-            'curve': ec.SECP521R1()
+            'curve': ec.SECP521R1() # Isn't supported any more.
         }
         self.cgen.sign_alg = 'sha384'
         self.cgen.generate()
@@ -276,7 +276,8 @@ class ECDSA_SHA384_SECP521(X509):
         tester.TempestaTest.setUp(self)
 
     def test(self):
-        self.check_good_cert()
+        self.check_cannot_start("ERROR: tls_certificate: "
+                                + "Invalid certificate specified")
 
 
 class InvalidHash(X509):

--- a/tls/test_tls_cert.py
+++ b/tls/test_tls_cert.py
@@ -260,12 +260,16 @@ class ECDSA_SHA512_SECP384(X509):
 
 
 class ECDSA_SHA384_SECP521(X509):
+    """ The curve secp521r1 isn't recommended by IANA, so it isn't supported
+    by Tempesta FW.
+    https://www.iana.org/assignments/tls-parameters/tls-parameters.xml#tls-parameters-8
+    """
 
     def setUp(self):
         self.cgen = CertGenerator()
         self.cgen.key = {
             'alg': 'ecdsa',
-            'curve': ec.SECP521R1() # Isn't supported any more.
+            'curve': ec.SECP521R1()
         }
         self.cgen.sign_alg = 'sha384'
         self.cgen.generate()


### PR DESCRIPTION
Changes according to https://github.com/tempesta-tech/tempesta/pull/1375