### PR TITLE
Tests on sticky cookies and JS challenge

### DIFF
--- a/sessions/test_js_challenge.py
+++ b/sessions/test_js_challenge.py
@@ -222,7 +222,7 @@ class JSChallenge(BaseJSChallenge):
     def test_get_challenge(self):
         """Not all requests are challengeable. Tempesta sends the challenge
         only if the client can accept it, i.e. request should has GET method and
-        'Accept: text/html OR */*'. In other cases normal browsers don't eval
+        'Accept: text/html'. In other cases normal browsers don't eval
         JS code and TempestaFW is not trying to send the challenge to bots.
         """
         self.start_all()

--- a/sessions/test_js_challenge.py
+++ b/sessions/test_js_challenge.py
@@ -238,7 +238,7 @@ class JSChallenge(BaseJSChallenge):
                          "Unexpected response status code")
         self.assertIsNotNone(resp.headers.get('Set-Cookie', None),
                              "Set-Cookie header is missing in the response")
-        match = re.search(r'(location\.reload)', resp.body)
+        match = re.search(r'(location\.replace)', resp.body)
         self.assertIsNotNone(match,
                              "Can't extract redirect target from response body")
 

--- a/sessions/test_js_challenge.py
+++ b/sessions/test_js_challenge.py
@@ -2,6 +2,7 @@
 Tests for JavaScript challenge.
 """
 
+import abc
 import re
 import time
 from helpers import tf_cfg, remote
@@ -11,7 +12,116 @@ __author__ = 'Tempesta Technologies, Inc.'
 __copyright__ = 'Copyright (C) 2020 Tempesta Technologies, Inc.'
 __license__ = 'GPL2'
 
-class JSChallenge(tester.TempestaTest):
+class BaseJSChallenge(tester.TempestaTest):
+    def wait_all_connections(self, tmt=1):
+        sids = self.get_servers_id()
+        for sid in sids:
+            srv = self.get_server(sid)
+            if not srv.wait_for_connections(timeout=tmt):
+                return False
+        return True
+
+    def client_send_req(self, client, req):
+        curr_responses = len(client.responses)
+        client.make_requests(req)
+        client.wait_for_response(timeout=1)
+        self.assertEqual(curr_responses + 1, len(client.responses))
+
+        return client.responses[-1]
+
+    def client_expect_block(self, client, req):
+        curr_responses = len(client.responses)
+        client.make_requests(req)
+        client.wait_for_response(timeout=1)
+        self.assertEqual(curr_responses, len(client.responses))
+        self.assertTrue(client.connection_is_closed())
+
+    @abc.abstractmethod
+    def prepare_js_templates(self):
+        pass
+
+    def start_all(self):
+        self.prepare_js_templates()
+        self.start_all_servers()
+        self.start_tempesta()
+        self.start_all_clients()
+        self.deproxy_manager.start()
+        self.assertTrue(self.wait_all_connections(1))
+
+    def expect_restart(self, client, req, status_code, last_cookie):
+        """We tried to pass JS challenge, but the cookie we have was generated
+        too long time ago. We can't pass JS challenge now, but Tempesta
+        doesn't block us, but gives second chance to pass the challenge.
+
+        Expect a new redirect response with new sticky cookie value.
+        """
+        resp = self.client_send_req(client, req)
+        self.assertEqual(resp.status, '%d' % status_code,
+                         "unexpected response status code")
+        c_header = resp.headers.get('Set-Cookie', None)
+        self.assertIsNotNone(c_header,
+                             "Set-Cookie header is missing in the response")
+        match = re.search(r'([^;\s]+)=([^;\s]+)', c_header)
+        self.assertIsNotNone(match,
+                             "Can't extract value from Set-Cookie header")
+        new_cookie = (match.group(1), match.group(2))
+        self.assertNotEqual(last_cookie, new_cookie,
+                            "Challenge is not restarted")
+
+    def process_js_challenge(self, client, host, delay_min, delay_range,
+                             status_code, expect_pass, req_delay,
+                             restart_on_fail=False):
+        """Our tests can't pass the JS challenge with propper configuration,
+        enlarge delay limit to not recommended values to make it possible to
+        hardcode the JS challenge.
+        """
+        req = ("GET / HTTP/1.1\r\n"
+               "Host: %s\r\n"
+               "Accept: text/html\r\n"
+               "\r\n" % (host))
+        resp = self.client_send_req(client, req)
+        self.assertEqual(resp.status, '%d' % status_code,
+                         "unexpected response status code")
+        c_header = resp.headers.get('Set-Cookie', None)
+        self.assertIsNotNone(c_header,
+                             "Set-Cookie header is missing in the response")
+        match = re.search(r'([^;\s]+)=([^;\s]+)', c_header)
+        self.assertIsNotNone(match,
+                             "Cant extract value from Set-Cookie header")
+        cookie = (match.group(1), match.group(2))
+
+        # Check that all the variables are passed correctly into JS challenge
+        # code:
+        js_vars = ['var c_name = "%s";' % cookie[0],
+                   'var delay_min = %d;' % delay_min,
+                   'var delay_range = %d;' % delay_range]
+        for js_var in js_vars:
+            self.assertIn(js_var, resp.body,
+                          "Can't find JS Challenge parameter in response body")
+
+        # Pretend we can eval JS code and pass the challenge, but we can't set
+        # reliable timeouts and pass the challenge on CI or in virtual
+        # environments. Instead increase the JS parameters to make hardcoding
+        # easy and reliable.
+        if req_delay:
+            time.sleep(req_delay)
+
+        req = ("GET / HTTP/1.1\r\n"
+               "Host: %s\r\n"
+               "Accept: text/html\r\n"
+               "Cookie: %s=%s\r\n"
+               "\r\n" % (host, cookie[0], cookie[1]))
+        if not expect_pass:
+            if restart_on_fail:
+                self.expect_restart(client, req, status_code, cookie)
+            else:
+                self.client_expect_block(client, req)
+            return
+        resp = self.client_send_req(client, req)
+        self.assertEqual(resp.status, '200',
+                         "unexpected response status code")
+
+class JSChallenge(BaseJSChallenge):
     """
     With sticky sessions enabled, client will be pinned to the same server,
     and only that server will respond to all its requests.
@@ -95,29 +205,6 @@ class JSChallenge(tester.TempestaTest):
         }
     ]
 
-    def wait_all_connections(self, tmt=1):
-        sids = self.get_servers_id()
-        for sid in sids:
-            srv = self.get_server(sid)
-            if not srv.wait_for_connections(timeout=tmt):
-                return False
-        return True
-
-    def client_send_req(self, client, req):
-        curr_responses = len(client.responses)
-        client.make_requests(req)
-        client.wait_for_response(timeout=1)
-        self.assertEqual(curr_responses + 1, len(client.responses))
-
-        return client.responses[-1]
-
-    def client_expect_block(self, client, req):
-        curr_responses = len(client.responses)
-        client.make_requests(req)
-        client.wait_for_response(timeout=1)
-        self.assertEqual(curr_responses, len(client.responses))
-        self.assertTrue(client.connection_is_closed())
-
     def prepare_js_templates(self):
         """
         Templates for JS challenge are modified by start script, create a copy
@@ -131,14 +218,6 @@ class JSChallenge(tester.TempestaTest):
         remote.tempesta.run_cmd("cp %s %s/js1.tpl" % (template, workdir))
         remote.tempesta.run_cmd("cp %s %s/js2.tpl" % (template, workdir))
         remote.tempesta.run_cmd("cp %s %s/js3.tpl" % (template, workdir))
-
-    def start_all(self):
-        self.prepare_js_templates()
-        self.start_all_servers()
-        self.start_tempesta()
-        self.start_all_clients()
-        self.deproxy_manager.start()
-        self.assertTrue(self.wait_all_connections(1))
 
     def test_get_challenge(self):
         """Not all requests are challengeable. Tempesta sends the challenge
@@ -176,79 +255,6 @@ class JSChallenge(tester.TempestaTest):
                "Accept: text/plain\r\n"
                "\r\n")
         self.client_expect_block(client, req)
-
-    def expect_restart(self, client, req, status_code, last_cookie):
-        """We tried to pass JS challenge, but the cookie we have was generated
-        too long time ago. We can't pass JS challenge now, but Tempesta
-        doesn't block us, but gives second chance to pass the challenge.
-
-        Expect a new redirect response with new sticky cookie value.
-        """
-        resp = self.client_send_req(client, req)
-        self.assertEqual(resp.status, '%d' % status_code,
-                         "unexpected response status code")
-        c_header = resp.headers.get('Set-Cookie', None)
-        self.assertIsNotNone(c_header,
-                             "Set-Cookie header is missing in the response")
-        match = re.search(r'([^;\s]+)=([^;\s]+)', c_header)
-        self.assertIsNotNone(match,
-                             "Can't extract value from Set-Cookie header")
-        new_cookie = (match.group(1), match.group(2))
-        self.assertNotEqual(last_cookie, new_cookie,
-                            "Challenge is not restarted")
-
-    def process_js_challenge(self, client, host, delay_min, delay_range,
-                             status_code, expect_pass, req_delay,
-                             restart_on_fail=False):
-        """Our tests can't pass the JS challenge with propper configuration,
-        enlarge delay limit to not recommended values to make it possible to
-        hardcode the JS challenge.
-        """
-        req = ("GET / HTTP/1.1\r\n"
-               "Host: %s\r\n"
-               "Accept: text/html\r\n"
-               "\r\n" % (host))
-        resp = self.client_send_req(client, req)
-        self.assertEqual(resp.status, '%d' % status_code,
-                         "unexpected response status code")
-        c_header = resp.headers.get('Set-Cookie', None)
-        self.assertIsNotNone(c_header,
-                             "Set-Cookie header is missing in the response")
-        match = re.search(r'([^;\s]+)=([^;\s]+)', c_header)
-        self.assertIsNotNone(match,
-                             "Cant extract value from Set-Cookie header")
-        cookie = (match.group(1), match.group(2))
-
-        # Check that all the variables are passed correctly into JS challenge
-        # code:
-        js_vars = ['var c_name = "%s";' % cookie[0],
-                   'var delay_min = %d;' % delay_min,
-                   'var delay_range = %d;' % delay_range]
-        for js_var in js_vars:
-            self.assertIn(js_var, resp.body,
-                          "Can't find JS Challenge parameter in response body")
-
-        # Pretend we can eval JS code and pass the challenge, but we can't set
-        # reliable timeouts and pass the challenge on CI or in virtual
-        # environments. Instead increase the JS parameters to make hardcoding
-        # easy and reliable.
-        if req_delay:
-            time.sleep(req_delay)
-
-        req = ("GET / HTTP/1.1\r\n"
-               "Host: %s\r\n"
-               "Accept: text/html\r\n"
-               "Cookie: %s=%s\r\n"
-               "\r\n" % (host, cookie[0], cookie[1]))
-        if not expect_pass:
-            if restart_on_fail:
-                self.expect_restart(client, req, status_code, cookie)
-            else:
-                self.client_expect_block(client, req)
-            return
-        resp = self.client_send_req(client, req)
-        self.assertEqual(resp.status, '200',
-                         "unexpected response status code")
 
     def test_pass_challenge(self):
         """ Clients send the validating request just in time and pass the

--- a/sessions/test_redir_mark.py
+++ b/sessions/test_redir_mark.py
@@ -75,6 +75,12 @@ class BaseRedirectMark(tester.TempestaTest):
                              "Cant extract value from Set-Cookie header")
         cookie = (match.group(1), match.group(2))
 
+        # Checking default path option of cookies
+        match = re.search(r'path=([^;\s]+)', c_header)
+        self.assertIsNotNone(match,
+                             "Cant extract path from Set-Cookie header")
+        self.assertEqual(match.group(1), "/")
+
         uri = response.headers.get('Location', None)
         self.assertIsNotNone(uri,
                              "Location header is missing in the response")

--- a/sessions/test_redir_mark.py
+++ b/sessions/test_redir_mark.py
@@ -150,3 +150,20 @@ class RedirectMark(BaseRedirectMark):
                "Host: localhost\r\n"
                "\r\n" % uri)
         self.client_expect_block(client, req)
+
+    def test_rmark_invalid(self):
+        # Requests w/ incorrect rmark and w/o cookies, must be blocked
+        self.start_all()
+
+        client = self.get_client('deproxy')
+        uri = '/'
+        uri, _ = self.client_send_first_req(client, uri)
+        m = re.match(r"(.*=)([0-9a-f]*)(/)", uri)
+
+        req = ("GET %s HTTP/1.1\r\n"
+               "Host: localhost\r\n"
+               "\r\n" % (m.group(1) +
+                         ''.join(random.choice(string.hexdigits)
+                         for i in range(len(m.group(2)))) +
+                         m.group(3)))
+        self.client_expect_block(client, req)

--- a/sessions/test_redir_mark.py
+++ b/sessions/test_redir_mark.py
@@ -122,6 +122,9 @@ class RedirectMark(BaseRedirectMark):
         client = self.get_client('deproxy')
         uri = '/'
         uri, cookie = self.client_send_first_req(client, uri)
+        uri, _ = self.client_send_custom_req(client, uri, cookie)
+        hostname = tf_cfg.cfg.get('Tempesta', 'hostname')
+        self.assertEqual(uri, 'http://%s/' % hostname)
 
         req = ("GET %s HTTP/1.1\r\n"
                "Host: localhost\r\n"
@@ -207,6 +210,9 @@ class RedirectMarkTimeout(BaseRedirectMark):
         time.sleep(3)
 
         uri, cookie = self.client_send_first_req(client, uri)
+        uri, _ = self.client_send_custom_req(client, uri, cookie)
+        hostname = tf_cfg.cfg.get('Tempesta', 'hostname')
+        self.assertEqual(uri, 'http://%s/' % hostname)
 
         req = ("GET %s HTTP/1.1\r\n"
                "Host: localhost\r\n"

--- a/sessions/test_redir_mark.py
+++ b/sessions/test_redir_mark.py
@@ -11,11 +11,7 @@ __license__ = 'GPL2'
 
 DFLT_COOKIE_NAME = '__tfw'
 
-class RedirectMark(tester.TempestaTest):
-    """
-    Sticky cookies are not enabled on Tempesta, so all clients may access the
-    requested resources. No cookie challenge is used to check clients behaviour.
-    """
+class BaseRedirectMark(tester.TempestaTest):
 
     backends = [
         {
@@ -28,17 +24,6 @@ class RedirectMark(tester.TempestaTest):
             'Content-Length: 0\r\n\r\n'
         }
     ]
-
-    tempesta = {
-        'config' :
-        """
-        server ${server_ip}:8000;
-
-        sticky {
-            cookie enforce max_misses=5;
-        }
-        """
-    }
 
     clients = [
         {
@@ -97,6 +82,23 @@ class RedirectMark(tester.TempestaTest):
         self.start_all_clients()
         self.deproxy_manager.start()
         self.assertTrue(self.wait_all_connections(1))
+
+class RedirectMark(BaseRedirectMark):
+    """
+    Sticky cookies are not enabled on Tempesta, so all clients may access the
+    requested resources. No cookie challenge is used to check clients behaviour.
+    """
+
+    tempesta = {
+        'config' :
+        """
+        server ${server_ip}:8000;
+
+        sticky {
+            cookie enforce max_misses=5;
+        }
+        """
+    }
 
     def test_good_rmark_value(self):
         """Client fully process the challenge: redirect is followed correctly,

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -86,8 +86,8 @@
             "reason" : "#1325: the test fails before the issue is fixed. Probably there is a reason for the behavior and the test should be reworked."
         },
         {
-            "name" : "sessions.test_redir_mark.RedirectMark.test_rmark_without_cookie",
-            "reason" : "Client is blocked by ip address, and the framework loses ssh connection to Tempesta"
+            "name" : "sessions.test_redir_mark.RedirectMark.test_rmark_wo_or_incorrect_cookie",
+            "reason" : "#861: TCP: reset blocked connections"
         }
     ]
 }

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -88,6 +88,10 @@
         {
             "name" : "sessions.test_redir_mark.RedirectMark.test_rmark_wo_or_incorrect_cookie",
             "reason" : "#861: TCP: reset blocked connections"
+        },
+        {
+            "name" : "sessions.test_redir_mark.RedirectMark.test_rmark_invalid",
+            "reason" : "#861: TCP: reset blocked connections"
         }
     ]
 }


### PR DESCRIPTION
https://github.com/tempesta-tech/tempesta/issues/1398

- adding tests for blocking when the number of redirected requests is exceeded and resetting the counter of redirected requests after a timeout during which the client must block if the number of redirected requests is exceeded
- creating a base class for JS challenge
- test on enable JS Challenge after reload 