### PR TITLE
sessions: add tests to check that sticky configuration can be inherited

### DIFF
--- a/sessions/test_cookies.py
+++ b/sessions/test_cookies.py
@@ -349,7 +349,7 @@ class VhostCookies(CookiesNotEnabled):
 
 class CookiesInherit(VhostCookies):
     """Cookies configuration can be inherited from global defaults. The test is
-    dentical to VhostCookies. But here 'sticky' directive is defined outside
+    identical to VhostCookies. But here 'sticky' directive is defined outside
     named vhosts, so updates default settings that must be inherited by
     named vhosts. If default settings are inherited multiple times, then only
     the last one is effective.

--- a/sessions/test_cookies.py
+++ b/sessions/test_cookies.py
@@ -347,6 +347,66 @@ class VhostCookies(CookiesNotEnabled):
                         "Client couldn't access resource")
 
 
+class CookiesInherit(VhostCookies):
+    """Cookies configuration can be inherited from global defaults. The test is
+    dentical to VhostCookies. But here 'sticky' directive is defined outside
+    named vhosts, so updates default settings that must be inherited by
+    named vhosts. If default settings are inherited multiple times, then only
+    the last one is effective.
+    """
+
+    tempesta = {
+        'config' :
+        """
+        srv_group vh_1_srvs {
+            server ${server_ip}:8000;
+        }
+        srv_group vh_2_srvs {
+            server ${server_ip}:8001;
+        }
+        srv_group vh_3_srvs {
+            server ${server_ip}:8002;
+        }
+
+        sticky {
+            cookie name=c_vh1 enforce;
+        }
+
+        vhost vh_1 {
+            proxy_pass vh_1_srvs;
+        }
+
+        sticky {
+            cookie name=c_vh2 enforce;
+        }
+
+        vhost vh_2 {
+            proxy_pass vh_2_srvs;
+        }
+
+        sticky {
+            cookie name=not_used;
+        }
+
+        sticky {
+            cookie name=c_vh3;
+        }
+
+        vhost vh_3 {
+            proxy_pass vh_3_srvs;
+        }
+
+        http_chain {
+            host == "vh1.com" -> vh_1;
+            host == "vh2.com" -> vh_2;
+            host == "vh3.com" -> vh_3;
+            -> block;
+        }
+
+        """
+    }
+
+
 class CookieLifetime(CookiesNotEnabled):
 
     tempesta = {
@@ -373,7 +433,8 @@ class CookieLifetime(CookiesNotEnabled):
                "\r\n")
         response = self.client_send_req(client, req)
         self.assertEqual(response.status, '302',
-                         "Unexpected redirect status code")
+                         ("Unexpected redirect status code: %s, expected 302"
+                          % response.status))
         cookie = self.extract_cookie(response)
         self.assertIsNotNone(cookie, "Can't find cookie in response")
         req = ("GET / HTTP/1.1\r\n"
@@ -382,7 +443,12 @@ class CookieLifetime(CookiesNotEnabled):
                "\r\n" % (cookie[0], cookie[1]))
         response = self.client_send_req(client, req)
         self.assertEqual(response.status, '200',
-                         "Unexpected response status code")
+                         ("Unexpected redirect status code: %s, expected 200"
+                          % response.status))
+        # Cookies are enforced, only the first response (redirect) has
+        # Set-Cookie header, following responses has no such header.
+        self.assertIsNone(response.headers.get('Set-Cookie', None),
+                          "Set-Cookie header is mistakenly set in the response")
         tf_cfg.dbg(3, "Sleep until session get expired...")
         time.sleep(5)
         req = ("GET / HTTP/1.1\r\n"

--- a/sessions/test_learn.py
+++ b/sessions/test_learn.py
@@ -187,3 +187,36 @@ class LearnSessions(tester.TempestaTest):
             self.assertEqual(s_id, new_s_id,
                              "Sticky session was forwarded to not-pinned server")
 
+
+class LearnSessionsVhost(LearnSessions):
+    """Same as LearnSessions, but 'sticky' configuration is inherited from
+    updated defaults for a named vhost.
+    """
+
+    tempesta = {
+        'config' :
+        """
+        srv_group vh_1_srvs {
+            server ${server_ip}:8000;
+            server ${server_ip}:8001;
+            server ${server_ip}:8002;
+        }
+
+        # Update defaults two times, only the last one must be applied.
+        sticky {
+            cookie name=c_vh2 enforce;
+        }
+        sticky {
+            learn name=client-id;
+        }
+
+        vhost vh_1 {
+            proxy_pass vh_1_srvs;
+        }
+
+        http_chain {
+            -> vh_1;
+        }
+
+        """
+    }

--- a/sessions/test_redir_mark.py
+++ b/sessions/test_redir_mark.py
@@ -178,6 +178,38 @@ class RedirectMark(BaseRedirectMark):
                          m.group(3)))
         self.client_expect_block(client, req)
 
+
+class RedirectMarkVhost(RedirectMark):
+    """ Same as RedirectMark, but , but 'sticky' configuration is inherited from
+    updated defaults for a named vhost.
+    """
+
+    tempesta = {
+        'config' :
+        """
+        srv_group vh_1_srvs {
+            server ${server_ip}:8000;
+        }
+
+        # Update defaults two times, only the last one must be applied.
+        sticky {
+            cookie name=c_vh2 enforce;
+        }
+        sticky {
+            cookie enforce max_misses=5;
+        }
+
+        vhost vh_1 {
+            proxy_pass vh_1_srvs;
+        }
+
+        http_chain {
+            -> vh_1;
+        }
+        """
+    }
+
+
 class RedirectMarkTimeout(BaseRedirectMark):
     """
     Current count of redirected requests should be reset if time has
@@ -221,3 +253,34 @@ class RedirectMarkTimeout(BaseRedirectMark):
         response = self.client_send_req(client, req)
         self.assertEqual(response.status,'200',
                          "unexpected response status code")
+
+
+class RedirectMarkTimeoutVhost(RedirectMarkTimeout):
+    """ Same as RedirectMarkTimeout, but , but 'sticky' configuration is
+    inherited from updated defaults for a named vhost.
+    """
+
+    tempesta = {
+        'config' :
+        """
+        srv_group vh_1_srvs {
+            server ${server_ip}:8000;
+        }
+
+        # Update defaults two times, only the last one must be applied.
+        sticky {
+            cookie name=c_vh2 enforce;
+        }
+        sticky {
+            cookie enforce max_misses=5 timeout=2;
+        }
+
+        vhost vh_1 {
+            proxy_pass vh_1_srvs;
+        }
+
+        http_chain {
+            -> vh_1;
+        }
+        """
+    }

--- a/sessions/test_sessions.py
+++ b/sessions/test_sessions.py
@@ -146,6 +146,41 @@ class StickySessions(tester.TempestaTest):
                              "Sticky session was forwarded to not-pinned server")
 
 
+class StickySessionsVhost(StickySessions):
+    """Same as StickySessions, but 'sticky' configuration is inherited from
+    updated defaults for a named vhost.
+    """
+
+    tempesta = {
+        'config' :
+        """
+        srv_group vh_1_srvs {
+            server ${server_ip}:8000;
+            server ${server_ip}:8001;
+            server ${server_ip}:8002;
+        }
+
+        # Update defaults two times, only the last one must be applied.
+        sticky {
+            cookie name=c_vh2 enforce;
+        }
+        sticky {
+            cookie enforce;
+            sticky_sessions;
+        }
+
+        vhost vh_1 {
+            proxy_pass vh_1_srvs;
+        }
+
+        http_chain {
+            -> vh_1;
+        }
+
+        """
+    }
+
+
 class StickySessionsPersistense(StickySessions):
     """
     Test how the sticky sessions are handled when a pinned server does down.
@@ -266,6 +301,48 @@ class StickySessionsPersistense(StickySessions):
                              "Sticky session was forwarded to not-pinned server")
 
 
+class StickySessionsPersistenseVhost(StickySessionsPersistense):
+    """Same as StickySessionsPersistense, but 'sticky' configuration is
+    inherited from updated defaults for a named vhost.
+
+    There is no test for implicit default vhost, since 'proxy_pass' directive
+    can't be defined outside vhost. Without this directive the whole test for
+    implicit default vhost has no sense.
+    """
+
+    tempesta = {
+        'config' :
+        """
+        srv_group primary {
+            server ${server_ip}:8000;
+            server ${server_ip}:8001;
+        }
+        srv_group reserved {
+            server ${server_ip}:8002;
+            server ${server_ip}:8003;
+        }
+
+        # Update defaults two times, only the last one must be applied.
+        sticky {
+            cookie name=c_vh2 enforce;
+        }
+        sticky {
+            cookie enforce;
+            sticky_sessions;
+        }
+
+        vhost main {
+            proxy_pass primary backup=reserved;
+        }
+
+        http_chain {
+            -> main;
+        }
+
+        """
+    }
+
+
 class StickySessionsFailover(StickySessions):
     """
     Test how the sticky sessions is moved to a new server when original one is
@@ -380,7 +457,6 @@ class StickySessionsFailover(StickySessions):
             self.assertEqual(failovered_s_id, new_s_id,
                              "Sticky session was forwarded to not-pinned server")
 
-
     def test_sessions_reserved_server(self):
         """
         Same as test_sessions(), but a server from a reserved server group picks
@@ -412,3 +488,45 @@ class StickySessionsFailover(StickySessions):
             new_s_id = self.client_send_next_req(client, cookie)
             self.assertEqual(failovered_s_id, new_s_id,
                              "Sticky session was forwarded to not-pinned server")
+
+
+class StickySessionsFailoverVhost(StickySessionsFailover):
+    """Same as StickySessionsFailover, but 'sticky' configuration is
+    inherited from updated defaults for a named vhost.
+
+    There is no test for implicit default vhost, since 'proxy_pass' directive
+    can't be defined outside vhost. Without this directive the whole test for
+    implicit default vhost has no sense.
+    """
+
+    tempesta = {
+        'config' :
+        """
+        srv_group primary {
+            server ${server_ip}:8000;
+            server ${server_ip}:8001;
+        }
+        srv_group reserved {
+            server ${server_ip}:8002;
+            server ${server_ip}:8003;
+        }
+
+        # Update defaults two times, only the last one must be applied.
+        sticky {
+            cookie name=c_vh2 enforce;
+        }
+        sticky {
+            cookie enforce;
+            sticky_sessions allow_failover;
+        }
+
+        vhost main {
+            proxy_pass primary backup=reserved;
+        }
+
+        http_chain {
+            -> main;
+        }
+
+        """
+    }

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -92,6 +92,14 @@
         {
             "name" : "sessions.test_redir_mark.RedirectMark.test_rmark_invalid",
             "reason" : "#861: TCP: reset blocked connections"
+        },
+        {
+            "name" : "sessions.test_redir_mark.RedirectMarkVhost.test_rmark_wo_or_incorrect_cookie",
+            "reason" : "#861: TCP: reset blocked connections"
+        },
+        {
+            "name" : "sessions.test_redir_mark.RedirectMarkVhost.test_rmark_invalid",
+            "reason" : "#861: TCP: reset blocked connections"
         }
     ]
 }


### PR DESCRIPTION
Inheriting for named vhosts and for implicit default vhost -- two different implementations, so need to test both.

Tests for tempesta-tech/tempesta#1460