### PR TITLE
add description of ${general_ip} and set its default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ There is 4 sections in configuration: `General`, `Client`, `Tempesta`, `Server`.
 
 `General` section describes the options related to testing framework itself.
 
+`ip` — IPv4/IPv6 address of the host running the testing framework, as reachable
+from the host running TempestaFW.
+
 `verbose`: verbose level of output:
 - `0` — quiet mode, result of each test is shown by symbols. `.` — passed, `F` -
 failed, `u` — unexpected success, `x` — expected failure. `s` — skipped;

--- a/helpers/tf_cfg.py
+++ b/helpers/tf_cfg.py
@@ -44,7 +44,8 @@ class TestFrameworkCfg(object):
 
     def defaults(self):
         self.config = configparser.ConfigParser()
-        self.config.read_dict({'General': {'verbose': '0',
+        self.config.read_dict({'General': {'ip': '127.0.0.1',
+                                           'verbose': '0',
                                            'workdir': '/tmp/host',
                                            'duration': '10',
                                            'concurrent_connections': '10',

--- a/tests_config.ini.sample
+++ b/tests_config.ini.sample
@@ -1,6 +1,14 @@
 [General]
 # This section refer to testing framework itself.
 
+# IPv4/IPv6 address of the host that runs the testing framework.
+# This is the address deproxy's server will be listening at.
+# This value will be used internally, in command lines and configuration files.
+#
+# ex.: ip = 192.168.11.6 (default 127.0.0.1)
+#
+ip = 127.0.0.1
+
 # Verbose level:
 # 0 - quiet mode, result of each test is shown by symbols:
 #   `.` - passed,


### PR DESCRIPTION
Some tests use `${general_ip}` as an address where deproxy's server is listening, but that option wasn't mentioned in `tests_config.ini.sample`.