### PR TITLE
Remove test for secp384

### DIFF
--- a/tls/test_tls_cert.py
+++ b/tls/test_tls_cert.py
@@ -240,26 +240,6 @@ class ECDSA_SHA256_SECP256(X509):
         self.check_good_cert()
 
 
-class ECDSA_SHA512_SECP384(X509):
-
-    def setUp(self):
-        self.cgen = CertGenerator()
-        self.cgen.key = {
-            'alg': 'ecdsa',
-            'curve': ec.SECP384R1()
-        }
-        self.cgen.sign_alg = 'sha512'
-        self.cgen.generate()
-        self.tempesta = {
-            'config' : X509.tempesta_tmpl % self.cgen.get_file_paths(),
-            'custom_cert': True
-        }
-        tester.TempestaTest.setUp(self)
-
-    def test(self):
-        self.check_good_cert()
-
-
 class ECDSA_SHA384_SECP521(X509):
     """ The curve secp521r1 isn't recommended by IANA, so it isn't supported
     by Tempesta FW.


### PR DESCRIPTION
https://github.com/tempesta-tech/tempesta/issues/1335 deprecates the curve while the test suite already has the test for unsupported secp521, so just remove the test for secp384.

See commit https://github.com/tempesta-tech/tempesta/commit/3a8d8c5e6b46a68dfefcbd6bff1135749ef5f601