### PR TITLE
tls-perf: specify ECDHE-ECDSA-AES128-GCM-SHA256 explicitly

### DIFF
--- a/h2/test_h2_perf.py
+++ b/h2/test_h2_perf.py
@@ -70,7 +70,7 @@ class TLSPerf(tester.TempestaTest):
             'type' : 'external',
             'binary' : 'tls-perf',
             'cmd_args' : (
-                '-c ECDHE-ECDSA-AES128-GCM-SHA256 -l 1000 -t 2 -T %s ${server_ip} 443' % (tf_cfg.cfg.get('General', 'Duration'))
+                '-c ECDHE-ECDSA-AES128-GCM-SHA256 -C prime256v1 -l 1000 -t 2 -T %s ${server_ip} 443' % (tf_cfg.cfg.get('General', 'Duration'))
                 )
         },
     ]

--- a/h2/test_h2_perf.py
+++ b/h2/test_h2_perf.py
@@ -70,7 +70,7 @@ class TLSPerf(tester.TempestaTest):
             'type' : 'external',
             'binary' : 'tls-perf',
             'cmd_args' : (
-                '-l 1000 -t 2 -T %s ${server_ip} 443' % (tf_cfg.cfg.get('General', 'Duration'))
+                '-c ECDHE-ECDSA-AES128-GCM-SHA256 -l 1000 -t 2 -T %s ${server_ip} 443' % (tf_cfg.cfg.get('General', 'Duration'))
                 )
         },
     ]

--- a/tls/test_tls_limits.py
+++ b/tls/test_tls_limits.py
@@ -22,7 +22,7 @@ class TLSLimits(tester.TempestaTest):
             'type' : 'external',
             'binary' : 'tls-perf',
             'cmd_args' : (
-                '-l 1 -t 1 -n 11  --tickets off ${server_ip} 443'
+                '-c ECDHE-ECDSA-AES128-GCM-SHA256 -l 1 -t 1 -n 11  --tickets off ${server_ip} 443'
                 )
         },
         {
@@ -30,7 +30,7 @@ class TLSLimits(tester.TempestaTest):
             'type' : 'external',
             'binary' : 'tls-perf',
             'cmd_args' : (
-                '-l 1 -t 1 -n 20  --tickets on ${server_ip} 443'
+                '-c ECDHE-ECDSA-AES128-GCM-SHA256 -l 1 -t 1 -n 20  --tickets on ${server_ip} 443'
                 )
         },
         {

--- a/tls/test_tls_limits.py
+++ b/tls/test_tls_limits.py
@@ -22,7 +22,7 @@ class TLSLimits(tester.TempestaTest):
             'type' : 'external',
             'binary' : 'tls-perf',
             'cmd_args' : (
-                '-c ECDHE-ECDSA-AES128-GCM-SHA256 -l 1 -t 1 -n 11  --tickets off ${server_ip} 443'
+                '-c ECDHE-ECDSA-AES128-GCM-SHA256 -C prime256v1 -l 1 -t 1 -n 11  --tickets off ${server_ip} 443'
                 )
         },
         {
@@ -30,7 +30,7 @@ class TLSLimits(tester.TempestaTest):
             'type' : 'external',
             'binary' : 'tls-perf',
             'cmd_args' : (
-                '-c ECDHE-ECDSA-AES128-GCM-SHA256 -l 1 -t 1 -n 20  --tickets on ${server_ip} 443'
+                '-c ECDHE-ECDSA-AES128-GCM-SHA256 -C prime256v1 -l 1 -t 1 -n 20  --tickets on ${server_ip} 443'
                 )
         },
         {


### PR DESCRIPTION
With https://github.com/tempesta-tech/tls-perf/commit/11392a1da6f7cf715a624ebcb0efcb4b47af1e43fixing https://github.com/tempesta-tech/tls-perf/issues/9, by default tls-perf uses any ciphersuite, so add ECDHE-ECDSA-AES128-GCM-SHA256 explicitly in each tls-perf call to adjust the previous behavior.