### PR TITLE
Functional tests for cookie http_chain rules

### DIFF
--- a/http_rules/test_http.py
+++ b/http_rules/test_http.py
@@ -33,6 +33,9 @@ class HttpRules(functional.FunctionalTest):
         '  hdr referer ==  "http://example.com*" -> hdr_r_p;\n'
         '  hdr From ==  "testuser@example.com" -> hdr_raw_e;\n'
         '  hdr Warning ==  "172 *" -> hdr_raw_p;\n'
+        '  cookie ""foo_items_in_cart" == "*" -> $cache = 0;\n'
+        '  cookie "comment_author_*" == "*" -> $cache = 0;\n'
+        '  cookie "wordpress_logged_in*" == "*" -> $cache = 0;\n'
         '  -> default;\n'
         '}\n'
         '\n')

--- a/http_rules/test_http.py
+++ b/http_rules/test_http.py
@@ -33,9 +33,6 @@ class HttpRules(functional.FunctionalTest):
         '  hdr referer ==  "http://example.com*" -> hdr_r_p;\n'
         '  hdr From ==  "testuser@example.com" -> hdr_raw_e;\n'
         '  hdr Warning ==  "172 *" -> hdr_raw_p;\n'
-        '  cookie "foo_items_in_cart" == "*" -> $cache = 0;\n'
-        '  cookie "comment_author_*" == "*" -> $cache = 0;\n'
-        '  cookie "wordpress_logged_in*" == "*" -> $cache = 0;\n'
         '  -> default;\n'
         '}\n'
         '\n')

--- a/http_rules/test_http.py
+++ b/http_rules/test_http.py
@@ -33,7 +33,7 @@ class HttpRules(functional.FunctionalTest):
         '  hdr referer ==  "http://example.com*" -> hdr_r_p;\n'
         '  hdr From ==  "testuser@example.com" -> hdr_raw_e;\n'
         '  hdr Warning ==  "172 *" -> hdr_raw_p;\n'
-        '  cookie ""foo_items_in_cart" == "*" -> $cache = 0;\n'
+        '  cookie "foo_items_in_cart" == "*" -> $cache = 0;\n'
         '  cookie "comment_author_*" == "*" -> $cache = 0;\n'
         '  cookie "wordpress_logged_in*" == "*" -> $cache = 0;\n'
         '  -> default;\n'

--- a/http_rules/test_http_tables.py
+++ b/http_rules/test_http_tables.py
@@ -7,7 +7,7 @@ from helpers import chains, remote
 from framework import tester
 
 __author__ = 'Tempesta Technologies, Inc.'
-__copyright__ = 'Copyright (C) 2018 Tempesta Technologies, Inc.'
+__copyright__ = 'Copyright (C) 2022 Tempesta Technologies, Inc.'
 __license__ = 'GPL2'
 
 class HttpTablesTest(tester.TempestaTest):
@@ -75,6 +75,15 @@ class HttpTablesTest(tester.TempestaTest):
             'response_content' :
             'HTTP/1.1 200 OK\r\n'
             'Content-Length: 0\r\n\r\n'
+        },
+        {
+            'id' : 7,
+            'type' : 'deproxy',
+            'port' : '8007',
+            'response' : 'static',
+            'response_content' :
+            'HTTP/1.1 200 OK\r\n'
+            'Content-Length: 0\r\n\r\n'
         }
     ]
 
@@ -103,6 +112,9 @@ class HttpTablesTest(tester.TempestaTest):
         srv_group grp7 {
         server ${server_ip}:8006;
         }
+        srv_group grp8 {
+        server ${server_ip}:8007;
+        }
         vhost vh1 {
         proxy_pass grp1;
         }
@@ -124,6 +136,9 @@ class HttpTablesTest(tester.TempestaTest):
         vhost vh7 {
         proxy_pass grp7;
         }
+        vhost vh8 {
+        proxy_pass grp8;
+        }
         http_chain chain1 {
         uri == "/static*" -> vh1;
         uri == "*.php" -> vh2;
@@ -143,6 +158,7 @@ class HttpTablesTest(tester.TempestaTest):
         hdr referer == "http://example.*" -> chain3;
         hdr host == "bad.host.com" -> block;
         hdr host == "bar*" -> vh5;
+        cookie "tempesta" == "*" -> vh8;
         mark == 1 -> vh7;
         mark == 2 -> vh6;
         mark == 3 -> vh5;
@@ -196,6 +212,12 @@ class HttpTablesTest(tester.TempestaTest):
             'type' : 'deproxy',
             'addr' : "${tempesta_ip}",
             'port' : '80'
+        },
+        {
+            'id' : 7,
+            'type' : 'deproxy',
+            'addr' : "${tempesta_ip}",
+            'port' : '80'
         }
     ]
 
@@ -241,7 +263,13 @@ class HttpTablesTest(tester.TempestaTest):
             ('host'),
             ('bad.host.com'),
             True
-        )
+        ),
+                (
+            ('/baz/index.html'),
+            ('cookie'),
+            ('tempesta=test'),
+            False
+        ),
     ]
 
     chains = []


### PR DESCRIPTION
Fixes [tempesta-tech/tempesta#1544](https://github.com/tempesta-tech/tempesta/issues/1544)

Functional tests for cookie rule: matching part (field name and value) and action.

Matching part tests in test_http_tables tests and `$cache` action tests in test_cache_control_tests.

All test tasks from linked issue are done.

Signed-off-by: Aleksey Mikhaylov <aym@tempesta-tech.com>