### PR TITLE
Tests for configuration variables in custom redirects.

### DIFF
--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -122,10 +122,6 @@
             "reason" : "Disabled by issue #198"
         },
         {
-            "name" : "http_rules",
-            "reason" : "Disabled by issue #214"
-        },
-        {
             "name" : "leaks.test_leak.LeakTest.test_kmemleak",
             "reason" : "Disabled by issue #198"
         },


### PR DESCRIPTION
Added tests according to #214's description and disabled a test for an abstract base class.
As for now with Tempesta from [this](https://github.com/tempesta-tech/tempesta/pull/1628) branch:
```
root@nick-vm:~/tempesta-test# ./run_tests.py http_rules.test_http_tables
...
----------------------------------------------------------------------
Running functional tests...
----------------------------------------------------------------------

.s..........F....
======================================================================
FAIL: test_chains (http_rules.test_http_tables.HttpTablesTestMarkRules)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/tempesta-test/http_rules/test_http_tables.py", line 373, in test_chains
    self.process(self.get_client(i),
  File "/root/tempesta-test/http_rules/test_http_tables.py", line 312, in process
    self.assertEqual(server.last_request, chain.fwd_request)
AssertionError: None != <helpers.deproxy.Request object at 0x7f27125ece50>

----------------------------------------------------------------------
Ran 17 tests in 59.317s

FAILED (failures=1, skipped=1)
```

`http_rules.test_http_tables.HttpTablesTestMarkRules` is out of the scope of this PR, but if there's any hints on how that test can be easily fixed, I could do that too.