### PR TITLE
Test config generator

### DIFF
--- a/config_generator/autogen_1.txt
+++ b/config_generator/autogen_1.txt
@@ -1,0 +1,25 @@
+"""
+127.0.0.1:8765 proto=https;
+127.0.2.1:8764 proto=h2;
+
+srv_group default {
+    server 127.0.0.1:80;
+}
+
+vhost tempesta-cat {
+    proxy_pass default;
+}
+
+tls_match_any_server_name;
+tls_certificate root.crt;
+tls_certificate_key root.key;
+
+cache 0;
+cache_fulfill * *;
+block_action attack reply;
+
+http_chain {
+    -> tempesta-cat;
+}
+
+"""

--- a/config_generator/autogen_2.txt
+++ b/config_generator/autogen_2.txt
@@ -1,0 +1,27 @@
+"""
+127.0.0.1:8765 proto=https;
+127.0.2.1:8764 proto=h2;
+198.3.3.3:8765 proto=https;
+202.0.2.1:8764 proto=h2;
+
+srv_group default {
+    server 127.0.0.1:80;
+}
+
+vhost tempesta-cat {
+    proxy_pass default;
+}
+
+tls_match_any_server_name;
+tls_certificate root.crt;
+tls_certificate_key root.key;
+
+cache 0;
+cache_fulfill * *;
+block_action attack reply;
+
+http_chain {
+    -> tempesta-cat;
+}
+
+"""

--- a/config_generator/autogenerated_config.py
+++ b/config_generator/autogenerated_config.py
@@ -1,0 +1,25 @@
+"""
+198.3.3.3:8765 proto=https;
+202.0.2.1:8764 proto=h2;
+
+srv_group default {
+    server 127.0.0.1:80;
+}
+
+vhost tempesta-cat {
+    proxy_pass default;
+}
+
+tls_match_any_server_name;
+tls_certificate root.crt;
+tls_certificate_key root.key;
+
+cache 0;
+cache_fulfill * *;
+block_action attack reply;
+
+http_chain {
+    -> tempesta-cat;
+}
+
+"""

--- a/config_generator/conf_generator.py
+++ b/config_generator/conf_generator.py
@@ -1,0 +1,174 @@
+"""Filter auto generator module."""
+import os
+import sys
+from config_generator.conf_tempesta import TempestaConf, ListenSocket
+from typing import List, Optional
+
+from jinja2 import Environment, FileSystemLoader
+
+
+TEMPLATE_FILE = 'conf_template.txt'
+
+# it should be global settings, current value as example
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+class ConfigAutoGenerator(object):
+    """Config auto generator."""
+
+    current_dir = BASE_DIR
+    template = TEMPLATE_FILE
+
+    def __init__(self, config: dict):
+        """
+        Init class instance.
+
+        """
+        self.config = TempestaConf(**config)
+        self.filter_source = []
+        self.all_clients = []
+        self.listen = []
+        self.counter = 0
+        self.port_number = 8080
+
+    def generate(self, output_file: Optional[str] = None):
+        """
+        Generate config
+
+        Raises:
+            NotImplementedError: if error
+
+        """
+        if output_file:
+            new_file = os.path.join(
+                os.path.dirname(os.path.abspath(__file__)),
+                output_file,
+            )
+            try:
+                new_config = self.make_config_file()
+            except Exception:
+                sys.stdout.write(
+                    '[ERROR] Config generating was failed.\n',
+                )
+                raise NotImplementedError
+            with open(new_file, 'w') as nf:
+                nf.write(new_config)
+        return self.config
+
+    def make_config_file(self) -> str:
+        """
+        Make config file.
+
+        Returns:
+            config (str): new config
+
+        """
+        j2_env = Environment(  # noqa:S701
+            loader=FileSystemLoader(self.current_dir),
+            trim_blocks=True,
+        )
+
+        return j2_env.get_template(
+            self.template,
+        ).render(
+            listen_sockets=self.config.listen_sockets,
+            server_groups=self.config.server_groups,
+            vhosts=self.config.vhosts,
+            tls_sert=self.config.tls_cert,
+            tls_key=self.config.tls_key,
+            cache=self.config.cache,
+            http_chain=self.config.http_chain,
+        )
+
+    def update_sockets(
+        self,
+        sockets: List[dict],
+        append: bool = False,
+        output_file: Optional[str] = None,
+    ):
+        if not append:
+            self.config.listen_sockets = []
+
+        for sock in sockets:
+            sock = ListenSocket(**sock)
+            self.config.listen_sockets.append(
+                sock,
+            )
+        return self.generate(
+            output_file=output_file,
+        )
+
+
+# base config we can set up onw time
+base_config_example = {
+    'listen_sockets': [
+        {
+            'address': '127.0.0.1',
+            'port': '8765',
+            'proto': 'https',
+        },
+        {
+            'address': '127.0.2.1',
+            'port': '8764',
+            'proto': 'h2',
+        },
+    ],
+    'server_groups': [
+        {
+            'name': 'default',
+            'address': '127.0.0.1',
+            'port': '80',
+        },
+    ],
+    'vhosts': [
+        {
+            'name': 'tempesta-cat',
+            'proxy_pass': 'default',
+        },
+    ],
+    'tls_cert': 'root.crt',
+    'tls_key': 'root.key',
+    'http_chain': [
+        '-> tempesta-cat',
+    ],
+}
+
+
+# create config gen instance (validations here)
+conf_gen = ConfigAutoGenerator(
+    config=base_config_example,
+)
+
+
+# return config and generate config file if needed
+print(
+    conf_gen.generate(output_file='autogen_1.txt'),
+)
+
+
+# for example if we want to change only sockets,
+# we should pass only new sockets data
+new_listen_sockets = [
+    {
+        'address': '198.3.3.3',
+        'port': '8765',
+        'proto': 'https',
+    },
+    {
+        'address': '202.0.2.1',
+        'port': '8764',
+        'proto': 'h2',
+    },
+]
+
+
+# update and generate new config
+print(
+    conf_gen.update_sockets(
+        sockets=new_listen_sockets,
+        output_file='autogen_2.txt',
+        append=True,
+    ),
+)
+
+# Let's check new generated files in current directory

--- a/config_generator/conf_tempesta.py
+++ b/config_generator/conf_tempesta.py
@@ -1,0 +1,35 @@
+from pydantic import BaseModel, validator
+from typing import List, Optional
+
+
+class ListenSocket(BaseModel):
+    address: str
+    port: str
+    proto: Optional[str]
+
+    @validator('proto')
+    def name_must_contain_space(cls, proto_value):
+        if proto_value:
+            return 'proto={0}'.format(proto_value)
+
+
+class ServerGroup(BaseModel):
+    name: str
+    address: str
+    port: str
+
+
+class VHost(BaseModel):
+    name: str
+    proxy_pass: str
+
+
+class TempestaConf(BaseModel):
+
+    listen_sockets: List[ListenSocket]
+    server_groups: Optional[List[ServerGroup]]
+    vhosts: Optional[List[VHost]]
+    tls_cert: Optional[str]
+    tls_key: Optional[str]
+    cache: int = 0
+    http_chain: Optional[List[str]]

--- a/config_generator/conf_template.txt
+++ b/config_generator/conf_template.txt
@@ -1,0 +1,32 @@
+"""
+{% for ls in listen_sockets %}
+{{ ls.address }}:{{ ls.port }} {{ ls.proto }};
+{% endfor %}
+
+{% for srv in server_groups %}
+srv_group {{ srv.name }} {
+    server {{ srv.address }}:{{ srv.port }};
+}
+{% endfor %}
+
+{% for vh in vhosts %}
+vhost {{ vh.name }} {
+    proxy_pass {{ vh.proxy_pass }};
+}
+{% endfor %}
+
+tls_match_any_server_name;
+tls_certificate {{ tls_sert }};
+tls_certificate_key {{ tls_key }};
+
+cache {{ cache }};
+cache_fulfill * *;
+block_action attack reply;
+
+http_chain {
+{% for chain in http_chain %}
+    {{ chain }};
+{% endfor %}
+}
+
+"""

--- a/t_frang/test___ip_block.py
+++ b/t_frang/test___ip_block.py
@@ -1,0 +1,127 @@
+"""Tests for Frang directive `ip_block`."""
+from framework import tester
+from helpers import dmesg
+
+ONE = 1
+
+
+class FrangIpBlockTestCase(tester.TempestaTest):
+    """Tests for 'ip_block' directive."""
+
+    clients = [
+        {
+            'id': 'curl-1',
+            'type': 'external',
+            'binary': 'curl',
+            'cmd_args': '-Ikf -v http://127.0.0.4:8765/',
+        },
+    ]
+
+    backends = [
+        {
+            'id': 'nginx',
+            'type': 'nginx',
+            'port': '8000',
+            'status_uri': 'http://${server_ip}:8000/nginx_status',
+            'config': """
+                pid ${pid};
+                worker_processes  auto;
+                events {
+                    worker_connections   1024;
+                    use epoll;
+                }
+                http {
+                    keepalive_timeout ${server_keepalive_timeout};
+                    keepalive_requests ${server_keepalive_requests};
+                    sendfile         on;
+                    tcp_nopush       on;
+                    tcp_nodelay      on;
+                    open_file_cache max=1000;
+                    open_file_cache_valid 30s;
+                    open_file_cache_min_uses 2;
+                    open_file_cache_errors off;
+                    error_log /dev/null emerg;
+                    access_log off;
+                    server {
+                        listen        ${server_ip}:8000;
+                        location / {
+                            return 200;
+                        }
+                        location /nginx_status {
+                            stub_status on;
+                        }
+                    }
+                }
+            """,
+        },
+    ]
+
+    tempesta = {
+        'config': """
+            frang_limits {
+                ip_block on;
+            }
+
+            listen 127.0.0.4:8765;
+
+            srv_group default {
+                server ${server_ip}:8000;
+            }
+
+            vhost tempesta-cat {
+                proxy_pass default;
+            }
+
+            tls_match_any_server_name;
+            tls_certificate RSA/tfw-root.crt;
+            tls_certificate_key RSA/tfw-root.key;
+
+            cache 0;
+            cache_fulfill * *;
+            block_action attack reply;
+
+            http_chain {
+                -> tempesta-cat;
+            }
+        """,
+    }
+
+    def setUp(self):
+        """Set up test."""
+        super().setUp()
+        self.klog = dmesg.DmesgFinder(ratelimited=False)
+
+    def test_ip_block(self):
+        """
+        Test 'ip_block'.
+
+        Curl sent request with header Host as ip (did not set up another).
+        It is reason for violation and trigger this limit.
+        """
+        curl = self.get_client('curl-1')
+
+        self.start_all_servers()
+        self.start_tempesta()
+
+        curl.start()
+        self.wait_while_busy(curl)
+
+        self.assertEqual(
+            curl.returncode,
+            ONE,
+        )
+
+        self.assertEqual(
+            self.klog.warn_count(
+                'Warning: block client:',
+            ),
+            ONE,
+        )
+        self.assertEqual(
+            self.klog.warn_count(
+                'frang: Host header field contains IP address',
+            ),
+            ONE,
+        )
+
+        curl.stop()

--- a/t_frang/test___request_rate_burst.py
+++ b/t_frang/test___request_rate_burst.py
@@ -1,0 +1,138 @@
+"""Tests for Frang directive `request_rate` and 'request_burst'."""
+import time
+
+from framework import tester
+from helpers import dmesg
+
+ONE = 1
+DELAY = 0.125
+
+
+class FrangRequestRateTestCase(tester.TempestaTest):
+    """Tests for 'request_rate' and 'request_burst' directive."""
+
+    clients = [
+        {
+            'id': 'curl-1',
+            'type': 'external',
+            'binary': 'curl',
+            'cmd_args': '-Ikf -v http://127.0.0.4:8765/ -H "Host: tempesta-tech.com:8765"',  # noqa:E501
+        },
+    ]
+
+    backends = [
+        {
+            'id': 'nginx',
+            'type': 'nginx',
+            'port': '8000',
+            'status_uri': 'http://${server_ip}:8000/nginx_status',
+            'config': """
+                pid ${pid};
+                worker_processes  auto;
+                events {
+                    worker_connections   1024;
+                    use epoll;
+                }
+                http {
+                    keepalive_timeout ${server_keepalive_timeout};
+                    keepalive_requests ${server_keepalive_requests};
+                    sendfile         on;
+                    tcp_nopush       on;
+                    tcp_nodelay      on;
+                    open_file_cache max=1000;
+                    open_file_cache_valid 30s;
+                    open_file_cache_min_uses 2;
+                    open_file_cache_errors off;
+                    error_log /dev/null emerg;
+                    access_log off;
+                    server {
+                        listen        ${server_ip}:8000;
+                        location / {
+                            return 200;
+                        }
+                        location /nginx_status {
+                            stub_status on;
+                        }
+                    }
+                }
+            """,
+        },
+    ]
+
+    tempesta = {
+        'config': """
+            frang_limits {
+                request_rate 4;
+                request_burst 2;
+            }
+
+            listen 127.0.0.4:8765;
+
+            srv_group default {
+                server ${server_ip}:8000;
+            }
+
+            vhost tempesta-cat {
+                proxy_pass default;
+            }
+
+            tls_match_any_server_name;
+            tls_certificate RSA/tfw-root.crt;
+            tls_certificate_key RSA/tfw-root.key;
+
+            cache 0;
+            cache_fulfill * *;
+            block_action attack reply;
+
+            http_chain {
+                -> tempesta-cat;
+            }
+        """,
+    }
+
+    def setUp(self):
+        """Set up test."""
+        super().setUp()
+        self.klog = dmesg.DmesgFinder(ratelimited=False)
+
+    def test_request_rate(self):
+        """Test 'request_rate'."""
+        curl = self.get_client('curl-1')
+
+        self.start_all_servers()
+        self.start_tempesta()
+
+        for _ in range(5):
+            curl.start()
+            self.wait_while_busy(curl)
+
+            # delay to split tests for `rate` and `burst`
+            time.sleep(DELAY)
+
+            curl.stop()
+
+        self.assertEqual(
+            self.klog.warn_count(
+                ' Warning: frang: request rate exceeded for',
+            ),
+            ONE,
+        )
+
+    def test_request_burst(self):
+        """Test 'request_rate'."""
+        curl = self.get_client('curl-1')
+
+        self.start_all_servers()
+        self.start_tempesta()
+
+        for _ in range(4):
+            curl.start()
+            self.wait_while_busy(curl)
+            curl.stop()
+
+        self.assertEqual(
+            self.klog.warn_count(
+                ' Warning: frang: requests burst exceeded for',
+            ),
+            ONE,
+        )

--- a/t_frang/test_client_header_timeout.py
+++ b/t_frang/test_client_header_timeout.py
@@ -1,0 +1,88 @@
+"""Tests for Frang directive `client_header_timeout`."""
+from framework import tester
+from helpers import dmesg
+
+RESPONSE_CONTENT = """
+HTTP/1.1 200 OK\r\n
+Content-Length: 0\r\n
+Connection: keep-alive\r\n\r\n
+"""
+
+REQUEST_SUCCESS = """
+GET / HTTP/1.1\r
+Host: tempesta-tech.com\r
+\r
+GET / HTTP/1.1\r
+Host:    tempesta-tech.com     \r
+\r
+GET http://tempesta-tech.com/ HTTP/1.1\r
+Host: tempesta-tech.com\r
+\r
+GET http://user@tempesta-tech.com/ HTTP/1.1\r
+Host: tempesta-tech.com\r
+\r
+"""
+
+TEMPESTA_CONF = """
+cache 0;
+listen 80;
+
+frang_limits {
+    client_header_timeout 1;
+}
+
+server ${server_ip}:8000;
+"""
+
+
+class ClientHeaderTimeoutTestCase(tester.TempestaTest):
+    """Tests 'client_header_timeout' directive."""
+
+    clients = [
+        {
+            'id': 'client',
+            'type': 'deproxy',
+            'addr': '${tempesta_ip}',
+            'port': '80',
+        },
+    ]
+
+    backends = [
+        {
+            'id': '0',
+            'type': 'deproxy',
+            'port': '8000',
+            'response': 'static',
+            'response_content': RESPONSE_CONTENT,
+        },
+    ]
+
+    tempesta = {
+        'config': TEMPESTA_CONF,
+    }
+
+    def setUp(self):
+        """Set up test."""
+        super().setUp()
+        self.klog = dmesg.DmesgFinder(ratelimited=False)
+
+    def start_all(self):
+        """Start all requirements."""
+        self.start_all_servers()
+        self.start_tempesta()
+        self.deproxy_manager.start()
+        srv = self.get_server('0')
+        self.assertTrue(
+            srv.wait_for_connections(timeout=1),
+        )
+
+    def test_host_header_set_ok(self):  # TODO
+        """Test with header `host`, success."""
+        self.start_all()
+
+        deproxy_cl = self.get_client('client')
+        deproxy_cl.start()
+        deproxy_cl.make_requests(
+            REQUEST_SUCCESS,
+        )
+        deproxy_cl.wait_for_response()

--- a/t_frang/test_header_cnt.py
+++ b/t_frang/test_header_cnt.py
@@ -1,0 +1,117 @@
+"""Tests for Frang directive `http_header_cnt`."""
+from framework import tester
+from helpers import dmesg
+
+backends = [
+    {
+        'id': 'nginx',
+        'type': 'nginx',
+        'port': '8000',
+        'status_uri': 'http://${server_ip}:8000/nginx_status',
+        'config': """
+            pid ${pid};
+            worker_processes  auto;
+            events {
+                worker_connections   1024;
+                use epoll;
+            }
+            http {
+                keepalive_timeout ${server_keepalive_timeout};
+                keepalive_requests ${server_keepalive_requests};
+                sendfile         on;
+                tcp_nopush       on;
+                tcp_nodelay      on;
+                open_file_cache max=1000;
+                open_file_cache_valid 30s;
+                open_file_cache_min_uses 2;
+                open_file_cache_errors off;
+                error_log /dev/null emerg;
+                access_log off;
+                server {
+                    listen        ${server_ip}:8000;
+                    location / {
+                        return 200;
+                    }
+                    location /nginx_status {
+                        stub_status on;
+                    }
+                }
+            }
+        """,
+    },
+]
+
+clients = [
+    {
+        'id': 'curl-1',
+        'type': 'external',
+        'binary': 'curl',
+        'ssl': True,
+        'cmd_args': '-Ikf -v --http2 https://127.0.0.4:443/ -H "Host: tempesta-tech.com" -H "User-agent: {0}"'.format(
+            '123' * 10000,
+        ),
+    },
+]
+
+tempesta_conf = """
+frang_limits {
+    http_header_cnt 20;
+}
+
+listen 127.0.0.4:443 proto=h2;
+
+srv_group default {
+    server ${server_ip}:8000;
+}
+
+vhost tempesta-cat {
+    proxy_pass default;
+}
+
+tls_match_any_server_name;
+tls_certificate RSA/tfw-root.crt;
+tls_certificate_key RSA/tfw-root.key;
+
+cache 0;
+cache_fulfill * *;
+block_action attack reply;
+
+http_chain {
+    -> tempesta-cat;
+}
+"""
+
+
+class FrangHeaderCntTestCase(tester.TempestaTest):
+    """Tests 'http_header_cnt' directive."""
+
+    header_cnt = 20
+
+    clients = clients
+
+    backends = backends
+
+    tempesta = {
+        'config': tempesta_conf,
+    }
+
+    def setUp(self):
+        """Set up test."""
+        super().setUp()
+        self.klog = dmesg.DmesgFinder(ratelimited=False)
+
+    def test_test(self):
+        curl = self.get_client('curl-1')
+
+        self.start_all_servers()
+        self.start_tempesta()
+        self.deproxy_manager.start()
+
+        curl.start()
+        self.wait_while_busy(curl)
+
+        print(
+            curl.resq.get(True, 1)[0].decode(),
+        )
+
+        curl.stop()

--- a/t_frang/test_host_required.py
+++ b/t_frang/test_host_required.py
@@ -1,0 +1,454 @@
+"""Tests for Frang directive `http_host_required`."""
+from framework import tester
+from helpers import dmesg
+
+
+CURL_CODE_OK = 0
+CURL_CODE_BAD = 1
+COUNT_WARNINGS_OK = 1
+COUNT_WARNINGS_ZERO = 0
+
+ERROR_MSG = 'Frang limits warning is not shown'
+ERROR_CURL = 'Curl return code is not `0`: {0}.'
+
+RESPONSE_CONTENT = """
+HTTP/1.1 200 OK\r\n
+Content-Length: 0\r\n
+Connection: keep-alive\r\n\r\n
+"""
+
+TEMPESTA_CONF = """
+cache 0;
+listen 80;
+
+frang_limits {
+    http_host_required;
+}
+
+server ${server_ip}:8000;
+"""
+
+WARN_OLD_PROTO = 'frang: Host header field in protocol prior to HTTP/1.1'
+WARN_UNKNOWN = 'frang: Request authority is unknown'
+WARN_DIFFER = 'frang: Request authority in URI differs from host header'
+WARN_IP_ADDR = 'frang: Host header field contains IP address'
+
+REQUEST_SUCCESS = """
+GET / HTTP/1.1\r
+Host: tempesta-tech.com\r
+\r
+GET / HTTP/1.1\r
+Host:    tempesta-tech.com     \r
+\r
+GET http://tempesta-tech.com/ HTTP/1.1\r
+Host: tempesta-tech.com\r
+\r
+GET http://user@tempesta-tech.com/ HTTP/1.1\r
+Host: tempesta-tech.com\r
+\r
+"""
+
+REQUEST_EMPTY_HOST = """
+GET / HTTP/1.1\r
+Host: \r
+\r
+"""
+
+REQUEST_MISMATCH = """
+GET http://user@tempesta-tech.com/ HTTP/1.1\r
+Host: example.com\r
+\r
+"""
+
+REQUEST_EMPTY_HOST_B = """
+GET http://user@tempesta-tech.com/ HTTP/1.1\r
+Host: \r
+\r
+"""
+
+
+class FrangHostRequiredTestCase(tester.TempestaTest):
+    """
+    Tests for non-TLS related checks in 'http_host_required' directive.
+
+    See TLSMatchHostSni test for other cases.
+    """
+
+    clients = [
+        {
+            'id': 'client',
+            'type': 'deproxy',
+            'addr': '${tempesta_ip}',
+            'port': '80',
+        },
+    ]
+
+    backends = [
+        {
+            'id': '0',
+            'type': 'deproxy',
+            'port': '8000',
+            'response': 'static',
+            'response_content': RESPONSE_CONTENT,
+        },
+    ]
+
+    tempesta = {
+        'config': TEMPESTA_CONF,
+    }
+
+    def setUp(self):
+        """Set up test."""
+        super().setUp()
+        self.klog = dmesg.DmesgFinder(ratelimited=False)
+
+    def start_all(self):
+        """Start all requirements."""
+        self.start_all_servers()
+        self.start_tempesta()
+        self.deproxy_manager.start()
+        srv = self.get_server('0')
+        self.assertTrue(
+            srv.wait_for_connections(timeout=1),
+        )
+
+    def test_host_header_set_ok(self):
+        """Test with header `host`, success."""
+        self.start_all()
+
+        deproxy_cl = self.get_client('client')
+        deproxy_cl.start()
+        deproxy_cl.make_requests(
+            REQUEST_SUCCESS,
+        )
+        deproxy_cl.wait_for_response()
+        self.assertEqual(
+            4,
+            len(deproxy_cl.responses),
+        )
+        self.assertFalse(
+            deproxy_cl.connection_is_closed(),
+        )
+
+    def test_empty_host_header(self):
+        """Test with empty header `host`."""
+        self._test_base_scenario(
+            request_body=REQUEST_EMPTY_HOST,
+        )
+
+    def test_host_header_missing(self):
+        """Test with missing header `host`."""
+        self._test_base_scenario(
+            request_body='GET / HTTP/1.1\r\n\r\n',
+        )
+
+    def test_host_header_with_old_proto(self):
+        """
+        Test with header `host` and http v 1.0.
+
+        Host header in http request below http/1.1. Restricted by
+        Tempesta security rules.
+        """
+        self._test_base_scenario(
+            request_body='GET / HTTP/1.0\r\nHost: tempesta-tech.com\r\n\r\n',
+            expected_warning=WARN_OLD_PROTO,
+        )
+
+    def test_host_header_mismatch(self):
+        """Test with mismatched header `host`."""
+        self._test_base_scenario(
+            request_body=REQUEST_MISMATCH,
+            expected_warning=WARN_DIFFER,
+        )
+
+    def test_host_header_mismatch_empty(self):
+        """
+        Test with Host header is empty.
+
+        Only authority in uri points to specific virtual host.
+        Not allowed by RFC.
+        """
+        self._test_base_scenario(
+            request_body=REQUEST_EMPTY_HOST_B,
+        )
+
+    def test_host_header_as_ip(self):
+        """Test with header `host` as ip address."""
+        self._test_base_scenario(
+            request_body='GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n',
+            expected_warning=WARN_IP_ADDR,
+        )
+
+    def test_host_header_as_ip6(self):
+        """Test with header `host` as ip v6 address."""
+        self._test_base_scenario(
+            request_body='GET / HTTP/1.1\r\nHost: [::1]:80\r\n\r\n',
+            expected_warning=WARN_IP_ADDR,
+        )
+
+    def _test_base_scenario(
+        self,
+        request_body: str,
+        expected_warning: str = WARN_UNKNOWN,
+    ):
+        """
+        Test base scenario for process different requests.
+
+        Args:
+            request_body (str): request body
+            expected_warning (str): expected warning in logs
+        """
+        self.start_all()
+
+        deproxy_cl = self.get_client('client')
+        deproxy_cl.start()
+        deproxy_cl.make_requests(
+            request_body,
+        )
+        deproxy_cl.wait_for_response()
+
+        self.assertEqual(
+            0,
+            len(deproxy_cl.responses),
+        )
+        self.assertTrue(
+            deproxy_cl.connection_is_closed(),
+        )
+        self.assertEqual(
+            self.klog.warn_count(expected_warning),
+            COUNT_WARNINGS_OK,
+            ERROR_MSG,
+        )
+
+
+CURL_A = '-Ikf -v --http2 https://127.0.0.4:443/ -H "Host: tempesta-tech.com"'
+CURL_B = '-Ikf -v --http2 https://127.0.0.4:443/'
+CURL_C = '-Ikf -v --http2 https://127.0.0.4:443/ -H "Host: "'
+CURL_D = '-Ikf -v --http2 https://127.0.0.4:443/ -H "Host: example.com"'
+CURL_E = '-Ikf -v --http2 https://127.0.0.4:443/ -H "Host: 127.0.0.1"'
+CURL_F = '-Ikf -v --http2 https://127.0.0.4:443/ -H "Host: [::1]"'
+
+
+backends = [
+    {
+        'id': 'nginx',
+        'type': 'nginx',
+        'port': '8000',
+        'status_uri': 'http://${server_ip}:8000/nginx_status',
+        'config': """
+            pid ${pid};
+            worker_processes  auto;
+            events {
+                worker_connections   1024;
+                use epoll;
+            }
+            http {
+                keepalive_timeout ${server_keepalive_timeout};
+                keepalive_requests ${server_keepalive_requests};
+                sendfile         on;
+                tcp_nopush       on;
+                tcp_nodelay      on;
+                open_file_cache max=1000;
+                open_file_cache_valid 30s;
+                open_file_cache_min_uses 2;
+                open_file_cache_errors off;
+                error_log /dev/null emerg;
+                access_log off;
+                server {
+                    listen        ${server_ip}:8000;
+                    location / {
+                        return 200;
+                    }
+                    location /nginx_status {
+                        stub_status on;
+                    }
+                }
+            }
+        """,
+    },
+]
+
+clients = [
+    {
+        'id': 'curl-1',
+        'type': 'external',
+        'binary': 'curl',
+        'ssl': True,
+        'cmd_args': CURL_A,
+    },
+    {
+        'id': 'curl-2',
+        'type': 'external',
+        'binary': 'curl',
+        'ssl': True,
+        'cmd_args': CURL_B,
+    },
+    {
+        'id': 'curl-3',
+        'type': 'external',
+        'binary': 'curl',
+        'ssl': True,
+        'cmd_args': CURL_C,
+    },
+    {
+        'id': 'curl-4',
+        'type': 'external',
+        'binary': 'curl',
+        'ssl': True,
+        'cmd_args': CURL_D,
+    },
+    {
+        'id': 'curl-5',
+        'type': 'external',
+        'binary': 'curl',
+        'ssl': True,
+        'cmd_args': CURL_E,
+    },
+    {
+        'id': 'curl-6',
+        'type': 'external',
+        'binary': 'curl',
+        'ssl': True,
+        'cmd_args': CURL_F,
+    },
+]
+
+tempesta = {
+    'config': """
+        frang_limits {
+            http_host_required;
+        }
+
+        listen 127.0.0.4:443 proto=h2;
+
+        srv_group default {
+            server ${server_ip}:8000;
+        }
+
+        vhost tempesta-cat {
+            proxy_pass default;
+        }
+
+        tls_match_any_server_name;
+        tls_certificate RSA/tfw-root.crt;
+        tls_certificate_key RSA/tfw-root.key;
+
+        cache 0;
+        cache_fulfill * *;
+        block_action attack reply;
+
+        http_chain {
+            -> tempesta-cat;
+        }
+    """,
+}
+
+
+class FrangHostRequiredH2TestCase(tester.TempestaTest):
+    """Tests for checks 'http_host_required' directive with http2."""
+
+    clients = clients
+
+    backends = backends
+
+    tempesta = tempesta
+
+    def setUp(self):
+        """Set up test."""
+        super().setUp()
+        self.klog = dmesg.DmesgFinder(ratelimited=False)
+
+    def test_h2_host_header_ok(self):
+        """Test with header `host`, success."""
+        curl = self.get_client('curl-1')
+
+        self.start_all_servers()
+        self.start_tempesta()
+
+        curl.start()
+        self.wait_while_busy(curl)
+
+        self.assertEqual(
+            CURL_CODE_OK,
+            curl.returncode,
+            ERROR_CURL.format(
+                str(curl.returncode),
+            ),
+        )
+        self.assertEqual(
+            self.klog.warn_count(WARN_IP_ADDR),
+            COUNT_WARNINGS_ZERO,
+            ERROR_MSG,
+        )
+        curl.stop()
+
+    def test_h2_empty_host_header(self):
+        """
+        Test with empty header `host`.
+
+        If there is no header `host`, curl set up it with ip address.
+        """
+        self._test_base_scenario(
+            curl_cli_id='curl-2',
+            expected_warning=WARN_IP_ADDR,
+        )
+
+    def test_h2_host_header_missing(self):  # TODO no warning in logs
+        """Test with missing header `host`."""
+        self._test_base_scenario(
+            curl_cli_id='curl-3',
+        )
+
+    def test_h2_host_header_mismatch(self):  # TODO return 200
+        """Test with mismatched header `host`."""
+        self._test_base_scenario(
+            curl_cli_id='curl-4',
+            expected_warning=WARN_DIFFER,
+        )
+
+    def test_h2_host_header_as_ip(self):
+        """Test with header `host` as ip address."""
+        self._test_base_scenario(
+            curl_cli_id='curl-5',
+            expected_warning=WARN_IP_ADDR,
+        )
+
+    def test_h2_host_header_as_ipv6(self):  # TODO return 200
+        """Test with header `host` as ip v6 address."""
+        self._test_base_scenario(
+            curl_cli_id='curl-6',
+            expected_warning=WARN_IP_ADDR,
+        )
+
+    def _test_base_scenario(
+        self,
+        curl_cli_id: str,
+        expected_warning: str = WARN_UNKNOWN,
+    ):
+        """
+        Test base scenario for process different requests.
+
+        Args:
+            curl_cli_id (str): curl client instance id
+            expected_warning (str): expected warning in logs
+        """
+        curl_cli = self.get_client(
+            curl_cli_id,
+        )
+
+        self.start_all_servers()
+        self.start_tempesta()
+
+        curl_cli.start()
+        self.wait_while_busy(curl_cli)
+
+        self.assertEqual(
+            CURL_CODE_BAD,
+            curl_cli.returncode,
+        )
+        self.assertEqual(
+            self.klog.warn_count(expected_warning),
+            COUNT_WARNINGS_OK,
+            ERROR_MSG,
+        )
+        curl_cli.stop()

--- a/t_frang/test_http_resp_code_block.py
+++ b/t_frang/test_http_resp_code_block.py
@@ -1,0 +1,215 @@
+"""
+Functional tests for http_resp_code_block.
+If your web application works with user accounts, then typically it requires
+a user authentication. If you implement the user authentication on your web
+site, then an attacker may try to use a brute-force password cracker to get
+access to accounts of your users. The second case is much harder to detect.
+It's worth mentioning that unsuccessful authorization requests typically
+produce error HTTP responses.
+
+Tempesta FW provides http_resp_code_block for efficient blocking of all types of
+password crackers
+"""
+
+from framework import tester
+
+__author__ = 'Tempesta Technologies, Inc.'
+__copyright__ = 'Copyright (C) 2019 Tempesta Technologies, Inc.'
+__license__ = 'GPL2'
+
+class HttpRespCodeBlockBase(tester.TempestaTest):
+    backends = [
+        {
+            'id' : 'nginx',
+            'type' : 'nginx',
+            'status_uri' : 'http://${server_ip}:8000/nginx_status',
+            'config' : """
+pid ${pid};
+worker_processes  auto;
+
+events {
+    worker_connections   1024;
+    use epoll;
+}
+
+http {
+    keepalive_timeout ${server_keepalive_timeout};
+    keepalive_requests 10;
+    sendfile         on;
+    tcp_nopush       on;
+    tcp_nodelay      on;
+
+    open_file_cache max=1000;
+    open_file_cache_valid 30s;
+    open_file_cache_min_uses 2;
+    open_file_cache_errors off;
+
+    # [ debug | info | notice | warn | error | crit | alert | emerg ]
+    # Fully disable log errors.
+    error_log /dev/null emerg;
+
+    # Disable access log altogether.
+    access_log off;
+
+    server {
+        listen        ${server_ip}:8000;
+
+        location /uri1 {
+            return 404;
+        }
+        location /uri2 {
+            return 200;
+        }
+        location /nginx_status {
+            stub_status on;
+        }
+    }
+}
+""",
+        }
+    ]
+
+    clients = [
+        {
+            'id' : 'deproxy',
+            'type' : 'deproxy',
+            'addr' : "${tempesta_ip}",
+            'port' : '80',
+            'interface' : True,
+            'rps': 6
+        },
+        {
+            'id' : 'deproxy2',
+            'type' : 'deproxy',
+            'addr' : "${tempesta_ip}",
+            'port' : '80',
+            'interface' : True,
+            'rps': 5
+        },
+    ]
+
+
+class HttpRespCodeBlock(HttpRespCodeBlockBase):
+    """Blocks an attacker's IP address if a protected web application return
+    5 error responses with codes 404 within 2 seconds. This is 2,5 per second.
+    """
+    tempesta = {
+        'config' : """
+server ${server_ip}:8000;
+
+frang_limits {
+    http_resp_code_block 404 5 2;
+}
+""",
+    }
+
+    """Two clients. One client sends 12 requests by 6 per second during
+    2 seconds. Of these, 6 requests by 3 per second give 404 responses and
+    should be blocked after 10 responses (5 with code 200 and 5 with code 404).
+    The second client sends 20 requests by 5 per second during 4 seconds.
+    Of these, 10 requests by 2.5 per second give 404 responses and should not be
+    blocked.
+    """
+    def test(self):
+        requests = "GET /uri1 HTTP/1.1\r\n" \
+                   "Host: localhost\r\n" \
+                   "\r\n" \
+                   "GET /uri2 HTTP/1.1\r\n" \
+                   "Host: localhost\r\n" \
+                   "\r\n" * 6
+        requests2 = "GET /uri1 HTTP/1.1\r\n" \
+                    "Host: localhost\r\n" \
+                    "\r\n" \
+                    "GET /uri2 HTTP/1.1\r\n" \
+                    "Host: localhost\r\n" \
+                    "\r\n" * 10
+        nginx = self.get_server('nginx')
+        nginx.start()
+        self.start_tempesta()
+
+        deproxy_cl = self.get_client('deproxy')
+        deproxy_cl.start()
+
+        deproxy_cl2 = self.get_client('deproxy2')
+        deproxy_cl2.start()
+
+        self.deproxy_manager.start()
+        self.assertTrue(nginx.wait_for_connections(timeout=1))
+
+        deproxy_cl.make_requests(requests)
+        deproxy_cl2.make_requests(requests2)
+
+        deproxy_cl.wait_for_response(timeout=2)
+        deproxy_cl2.wait_for_response(timeout=4)
+
+        self.assertEqual(10, len(deproxy_cl.responses))
+        self.assertEqual(20, len(deproxy_cl2.responses))
+
+        self.assertTrue(deproxy_cl.connection_is_closed())
+        self.assertFalse(deproxy_cl2.connection_is_closed())
+
+class HttpRespCodeBlockWithReply(HttpRespCodeBlockBase):
+    """Tempesta must return appropriate error status if a protected web
+    application return more 5 error responses with codes 404 within 2 seconds.
+    This is 2,5 per second.
+    """
+    tempesta = {
+        'config' : """
+server ${server_ip}:8000;
+
+frang_limits {
+    http_resp_code_block 404 5 2;
+}
+
+block_action attack reply;
+""",
+    }
+
+    """Two clients. One client sends 12 requests by 6 per second during
+    2 seconds. Of these, 6 requests by 3 per second give 404 responses.
+    Should be get 11 responses (5 with code 200, 5 with code 404 and
+    1 with code 403).
+    The second client sends 20 requests by 5 per second during 4 seconds.
+    Of these, 10 requests by 2.5 per second give 404 responses. All requests
+    should be get responses.
+    """
+    def test(self):
+        requests = "GET /uri1 HTTP/1.1\r\n" \
+                   "Host: localhost\r\n" \
+                   "\r\n" \
+                   "GET /uri2 HTTP/1.1\r\n" \
+                   "Host: localhost\r\n" \
+                   "\r\n" * 6
+        requests2 = "GET /uri1 HTTP/1.1\r\n" \
+                    "Host: localhost\r\n" \
+                    "\r\n" \
+                    "GET /uri2 HTTP/1.1\r\n" \
+                    "Host: localhost\r\n" \
+                    "\r\n" * 10
+        nginx = self.get_server('nginx')
+        nginx.start()
+        self.start_tempesta()
+
+        deproxy_cl = self.get_client('deproxy')
+        deproxy_cl.start()
+
+        deproxy_cl2 = self.get_client('deproxy2')
+        deproxy_cl2.start()
+
+        self.deproxy_manager.start()
+        self.assertTrue(nginx.wait_for_connections(timeout=1))
+
+        deproxy_cl.make_requests(requests)
+        deproxy_cl2.make_requests(requests2)
+
+        deproxy_cl.wait_for_response(timeout=2)
+        deproxy_cl2.wait_for_response(timeout=4)
+
+        self.assertEqual(11, len(deproxy_cl.responses))
+        self.assertEqual(20, len(deproxy_cl2.responses))
+
+        self.assertEqual('403', deproxy_cl.responses[-1].status,
+                         "Unexpected response status code")
+
+        self.assertTrue(deproxy_cl.connection_is_closed())
+        self.assertFalse(deproxy_cl2.connection_is_closed())


### PR DESCRIPTION
Simple implementation of Tempesta config generator with fields validation.
Run `config_generator/conf_generator.py` for getting example of invoking.
It is very simple example fro simple Tempesta config with not much validation. Main purpose is show my approach.
It is returns config data after validation and create config file if it's required.
For example you can map config one time for test case and while testing change only one required parameter (in my example is is listen socket).