### PR TITLE
long_body works fine except RequestTests

### DIFF
--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -46,6 +46,14 @@
             "reason" : ""
         },
         {
+            "name" : "long_body.test_long_request.RequestTest1M",
+            "reason" : "Disabled by issue #198"
+        },
+        {
+            "name" : "long_body.test_long_request.RequestTest1k",
+            "reason" : "Disabled by issue #198"
+        },
+        {
             "name" : "mixed_requests.test_mixed.MixedRequests.test_trace",
             "reason" : "Too many 502, sometimes no good answers at all"
         },
@@ -131,10 +139,6 @@
         },
         {
             "name" : "leaks.test_leak.LeakTest.test_used_memory",
-            "reason" : "Disabled by issue #198"
-        },
-        {
-            "name" : "long_body",
             "reason" : "Disabled by issue #198"
         },
         {


### PR DESCRIPTION
Long body have 2 tests which leads to FAIL condition:

long_body.test_long_request.RequestTest1M
long_body.test_long_request.RequestTest1k


```
[12199.646174] [tempesta fw] Warning: Parser error: state=RGen_BodyInit input(-8)=0xa('0.0.1
[12199.646175] [tempesta fw] Warning: failed to parse request: 127.0.0.1

```

Tests:
long_body.test_long_response.ResponseTest1k
long_body.test_long_response.ResponseTest1M

also was disabled by another issue

I think we have a problems with tempesta-fw parser which leads to test fails