### PR TITLE
enable many_backends

### DIFF
--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -366,22 +366,6 @@
             "reason" : "Disabled by issue #198"
         },
         {
-            "name" : "very_many_backends.test_deadtime_1M.AddingBackendNewSG.test",
-            "reason" : "Disabled by issue #198"
-        },
-        {
-            "name" : "very_many_backends.test_deadtime_1M.ChangingSG.test",
-            "reason" : "Disabled by issue #198"
-        },
-        {
-            "name" : "very_many_backends.test_deadtime_1M.DontModifyBackend.test",
-            "reason" : "Disabled by issue #198"
-        },
-        {
-            "name" : "very_many_backends.test_deadtime_1M.RemovingBackendSG.test",
-            "reason" : "Disabled by issue #198"
-        },
-        {
             "name" : "access_log.test_access_log.AccessLogTest.test_bad_user_agent",
             "reason" : "Disabled by issue #198"
         },

--- a/very_many_backends/test_deadtime_1M.py
+++ b/very_many_backends/test_deadtime_1M.py
@@ -192,7 +192,7 @@ class DontModifyBackend(stress.StressTest):
     def setup_nginx_config(self, config):
         config.enable_multi_accept()
         config.set_worker_connections(32768)
-        config.set_workers(4096)
+        config.set_workers(16)
         config.set_worker_rlimit_nofile(16384)
         config.set_ka(timeout=180)
         for listener in config.listeners:


### PR DESCRIPTION
There is no fix

VM tempesta-test configuration changed for corresopnd current config

Also warning `Too much (4096) workers requested. Only 16 is possible` fixed by set workers count to 16