### PR TITLE
disable failing `h2spec` tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ To run requirements autoinstallation run setup.sh
 `ab` is Apache benchmark tool, that can be found in `apache2-utils` package.
 
 `h2spec` is HTTP/2 conformance test suite. Can't be installed from package
-manager and must be retrieved from [GitHub](https://github.com/summerwind/h2spec/releases/latest).
+manager and must be [compiled from sources](https://github.com/tempesta-tech/h2spec#build).
 
 `tls-perf` can be downloaded from our GitHub [repository](https://github.com/tempesta-tech/tls-perf).
 

--- a/framework/client.py
+++ b/framework/client.py
@@ -81,22 +81,23 @@ class Client(stateful.Stateful, metaclass=abc.ABCMeta):
         for (name, content) in self.files:
             self.node.copy_file(name, content)
 
-    def is_busy(self):
+    def is_busy(self, verbose=True):
         busy = not self.exit_event.is_set()
-        if busy:
-            tf_cfg.dbg(4, "\tClient is running")
-        else:
-            tf_cfg.dbg(4, "\tClient is not running")
+        if verbose:
+            if busy:
+                tf_cfg.dbg(4, "\tClient is running")
+            else:
+                tf_cfg.dbg(4, "\tClient is not running")
         return busy
 
     def __on_finish(self):
-        if self.proc == None:
+        if not hasattr(self.proc, "terminate"):
             return
         tf_cfg.dbg(3, "Stopping client")
         self.proc.terminate()
-        self.proc.join()
         self.returncode = self.proc.exitcode
-        self.proc_results = self.resq.get(True, 1)
+        if not self.resq.empty():
+            self.proc_results = self.resq.get()
         self.proc = None
 
         if self.proc_results != None:
@@ -154,5 +155,7 @@ class Client(stateful.Stateful, metaclass=abc.ABCMeta):
         self.options.append('-H \'User-Agent: %s\'' % ua)
 
     def wait_for_finish(self):
-        self.proc.join()
+        # until we explicitly get `self.exit_event` flag set
+        while self.is_busy(verbose=False):
+            pass
         self.returncode = self.proc.exitcode

--- a/h2/test_h2_specs.py
+++ b/h2/test_h2_specs.py
@@ -2,7 +2,7 @@ from helpers import tf_cfg
 from framework import tester
 
 __author__ = 'Tempesta Technologies, Inc.'
-__copyright__ = 'Copyright (C) 2020 Tempesta Technologies, Inc.'
+__copyright__ = 'Copyright (C) 2022 Tempesta Technologies, Inc.'
 __license__ = 'GPL2'
 
 NGINX_CONFIG = """
@@ -94,9 +94,40 @@ class H2Spec(tester.TempestaTest):
 
     def test_h2_specs(self):
         h2spec = self.get_client('h2spec')
-        # TODO #88: for now run only simple test to check http2 connectivity
-        # After all h2-related issues will be fixed, remove the line
-        h2spec.options.append('generic/4')
+        # For different reasons there's still a bunch of `h2spec` tests that fail.
+        # To let the vast majority of the remaining passing test to work and help us catch
+        # unexpected regressions, we only disable some specific tests. We will enable those
+        # again after Tempesta gets required updates.
+        # FYI: there are tests that would fail just occasionally, not every time, so please
+        # before enabling a test from this list, ensure that it actually passes a decent
+        # amount of runs in a row.
+        h2spec.options.extend([
+            "-x generic/2/2",
+            "-x generic/2/3",
+            "-x generic/3.10/2",
+            "-x http2/4.3/3",
+            "-x http2/5.1/5",
+            "-x http2/5.1/6",
+            "-x http2/5.1/11",
+            "-x http2/5.1/12",
+            "-x http2/5.3.1/1", # causes dmesg warning
+            "-x http2/5.3.1/2",
+            "-x http2/5.5/2",
+            "-x http2/6.1/2",
+            "-x http2/6.2/2",
+            "-x http2/6.9.1/2",
+            "-x http2/6.9.1/3",
+            "-x http2/8.1/1",
+            "-x http2/8.1.2/1",
+            "-x http2/8.1.2.1/3", # causes dmesg warning
+            "-x http2/8.1.2.2/2",
+            "-x http2/8.1.2.3/5", # causes dmesg warning
+            "-x http2/8.1.2.3/6", # causes dmesg warning
+            "-x http2/8.1.2.3/7", # causes dmesg warning
+            "-x hpack/4.2/1",
+            "-x hpack/5.2/3", # causes dmesg warning
+        ])
+
 
         self.start_all_servers()
         self.start_tempesta()

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -114,10 +114,6 @@
             "reason" : "Disabled by issue #673"
         },
         {
-            "name" : "h2.test_h2_specs",
-            "reason" : "Disabled by issue #250"
-        },
-        {
             "name" : "health_monitoring",
             "reason" : "Disabled by issue #198"
         },


### PR DESCRIPTION
Now that we have `--exclude` flag in our `h2spec` fork, we can gracefully
disable some failing `h2spec` tests.