### PR TITLE
Properly handle errors that happen on external binary clients execution

### DIFF
--- a/http2_general/test_h2_specs.py
+++ b/http2_general/test_h2_specs.py
@@ -133,6 +133,7 @@ class H2Spec(tester.TempestaTest):
         self.start_tempesta()
         self.start_all_clients()
         self.wait_while_busy(h2spec)
+        self.assertEqual(0, h2spec.returncode)
 
 class H2Load(tester.TempestaTest):
     '''Tests for h2 proto implementation. Run h2load utility against Tempesta.


### PR DESCRIPTION
Now I believe we fully mitigated the vast majority of the issues that caused framework hang-ups.
Note, that there are still rare cases when tests will hang up due to some yet undiscovered bugs in Tempesta, usually those are indicated by `dmesg` warnings. This is 1) out of the scope of this PR, 2) simply suppressing errors is quite the opposite of our goal for testing, which is finding bugs, hence in those cases dedicated Tempesta issues have to be filed.
