### PR TITLE
Access logs curl hang-up fix

### DIFF
--- a/access_log/test_access_log_h2.py
+++ b/access_log/test_access_log_h2.py
@@ -114,6 +114,9 @@ class CurlTestBase(tester.TempestaTest):
         curl = self.get_client('curl')
         curl.run_start()
         curl.proc_results = curl.resq.get(True, 1)
+        self.assertEqual(0, curl.returncode,
+                         msg=("Curl return code is not 0 (%d)." %
+                              (curl.returncode)))
 
     def run_test(self, status_code=200, is_frang=False):
         klog = dmesg.DmesgFinder(ratelimited=False)

--- a/access_log/test_access_log_h2.py
+++ b/access_log/test_access_log_h2.py
@@ -109,14 +109,11 @@ def remove_certs(cert_files_):
 # Some tests for access_log over HTTP/2.0
 class CurlTestBase(tester.TempestaTest):
     clients = clients()
-
-    def run_curl(self, curl):
-        self.start_all_clients()
-        self.wait_while_busy(curl)
-        self.assertEqual(0, curl.returncode,
-                         msg=("Curl return code is not 0 (%d)." %
-                              (curl.returncode)))
-        curl.stop()
+    
+    def run_curl(self):
+        curl = self.get_client('curl')
+        curl.run_start()
+        curl.proc_results = curl.resq.get(True, 1)
 
     def run_test(self, status_code=200, is_frang=False):
         klog = dmesg.DmesgFinder(ratelimited=False)
@@ -131,11 +128,11 @@ class CurlTestBase(tester.TempestaTest):
 
         if is_frang:
             try:
-                self.run_curl(curl)
+                self.run_curl()
             except Exception:
                 pass
         else:
-            self.run_curl(curl)
+            self.run_curl()
 
         nginx = self.get_server('nginx')
         nginx.get_stats()

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -346,10 +346,6 @@
             "reason" : "Disabled by issue #198"
         },
         {
-            "name" : "access_log.test_access_log.AccessLogTest.test_bad_user_agent",
-            "reason" : "Disabled by issue #198"
-        },
-        {
             "name" : "ws.test_ws_ping.CacheTest.test_ping_websockets",
             "reason" : "Disabled by issue #198"
         },

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -178,10 +178,6 @@
             "reason" : "Disabled by issue #261"
         },
         {
-            "name" : "access_log",
-            "reason" : "Disabled by issue #261"
-        },
-        {
             "name" : "selftests.test_responses.ParseBody.test_chunked_empty",
             "reason" : "Disabled by issue #73"
         },


### PR DESCRIPTION
Old code:
**tester.wait_while_busy -> client.wait_for_finish() -> client.is_busy() -> self.exit_event**

    def wait_while_busy(self, *items):
        if items is None:
            return

        for item in items:
            if item.is_running():
                item.wait_for_finish() ->

    def wait_for_finish(self):
        # until we explicitly get `self.exit_event` flag set
        while self.is_busy(verbose=False): -> Always True
            pass
        self.returncode = self.proc.exitcode

    def is_busy(self, verbose=True):
        busy = not self.exit_event.is_set() -> Always True cause exit_event.set() is unreacheable
        if verbose:
            if busy:
                tf_cfg.dbg(4, "\tClient is running")
            else:
                tf_cfg.dbg(4, "\tClient is not running")
        return busy



**client.run_start -> client.run_start() -> client._run_client -> ok**

```
def run_curl(self):
    curl = self.get_client('curl')
    curl.run_start() ->
    curl.proc_results = curl.resq.get(True, 1)
    self.assertEqual(0, curl.returncode,
                     msg=("Curl return code is not 0 (%d)." %
                          (curl.returncode)))

def run_start(self):
    """ Run client """
    tf_cfg.dbg(3, "Running client")
    self.exit_event.clear()
    self.prepare()
    self.proc = multiprocessing.Process(target = _run_client, args=(self, self.exit_event, self.resq)) ->
    self.proc.start()

def _run_client(client, exit_event, resq):
    res = remote.client.run_cmd(client.cmd, timeout=(client.duration + 5)) -> Running ok with Exception 52 errorcode
    tf_cfg.dbg(3, "\tClient exit")
    resq.put(res)
    exit_event.set() -> Code execute correctly, old code was unreacheable
```
Old problem was

is_busy - False
wait_for_finish - True

In _run_client we got Exception and exit_event.set() was never executed and we get infinite wait_while_busy()

