### PR TITLE
Caching responses to authenticated requests and responses with set-cookie headers

### DIFF
--- a/cache/test_cache_control.py
+++ b/cache/test_cache_control.py
@@ -138,8 +138,9 @@ class TestCacheControl(tester.TempestaTest):
         req = (f"{self.request_method} {self.uri} HTTP/1.1\r\n"
                "Host: localhost\r\n"
                "%s\r\n" % req_headers)
-
+        print(req)
         response = self.client_send_req(client, req)
+        print(response)
         self.assertEqual(response.status, self.response_status,
                          "request failed: {}, expected {}" \
                          .format(response.status, self.response_status))
@@ -155,7 +156,9 @@ class TestCacheControl(tester.TempestaTest):
         req2 = (f"{self.request_method} {self.uri} HTTP/1.1\r\n"
                "Host: localhost\r\n"
                "%s\r\n" % req_headers2)
+        print(req2)
         cached_response = self.client_send_req(client, req2)
+        print(cached_response)
         self.assertEqual(cached_response.status, self.cached_status,
                          "request for cache failed: {}, expected {}" \
                          .format(response.status, self.cached_status))
@@ -1037,3 +1040,19 @@ class StoringResponsesToAuthenticatedRequestsSMaxAgeCache2(TestCacheControl, Sin
     sleep_interval = 1.5
     requests_to_server = 2
     response_headers = {'Cache-control': 's-maxage=1'}
+
+
+class StoringResponsesToRequestsWithCookiesCache(TestCacheControl, SingleTest):
+    """This test sends two requests with different basic authentication headers and without cache-control header to
+    the same resource and check that the second one wasn't serviced from the cache."""
+    tempesta_config = '''
+        cache_fulfill * *;
+        '''
+    should_be_cached = True
+    request_headers = {'Cookie': 'session=1'}
+    response_headers = {'Set-Cookie': 'session=2', 'Cache-control': 'private'}
+    second_request_headers = {'Cookie': response_headers['Set-Cookie']}
+    cached_headers = {'Set-Cookie': 'session=3'}
+
+    requests_to_server = 2
+

--- a/cache/test_cache_control.py
+++ b/cache/test_cache_control.py
@@ -1,71 +1,74 @@
 """Functional tests for custom processing of cached responses."""
-
-from __future__ import print_function
-from framework import tester
+import abc
 import copy
 import time
+
+from framework import tester
+from framework.deproxy_client import DeproxyClient
+from framework.deproxy_server import StaticDeproxyServer
 
 __author__ = 'Tempesta Technologies, Inc.'
 __copyright__ = 'Copyright (C) 2022 Tempesta Technologies, Inc.'
 __license__ = 'GPL2'
 
-class TestCacheControl(tester.TempestaTest):
+TEMPESTA_CONFIG = """
+cache 2;
+
+srv_group default {
+    server ${general_ip}:8000;
+}
+
+vhost vh1 {
+    proxy_pass default;
+}
+
+%(tempesta_config)s"""
+
+
+class TestCacheControl(tester.TempestaTest, base=True):
     clients = [
         {
-            'id' : 'deproxy',
-            'type' : 'deproxy',
-            'addr' : "${tempesta_ip}",
-            'port' : '80'
-        }
-    ]
-
-    tempesta_template = {
-        'config' :
-            """
-            cache 2;
-            srv_group default {
-                server ${general_ip}:8000;
-            }
-            vhost vh1 {
-                proxy_pass default;
-            }
-            %(tempesta_config)s
-            """
-    }
-
-    backends_template = [
-        {
-            'id' : 'deproxy',
-            'type' : 'deproxy',
-            'port' : '8000',
-            'response' : 'static',
-            'response_content' :
-                'HTTP/1.1 200 OK\r\n'
-                'Server-id: deproxy\r\n'
-                'Content-Length: 0\r\n'
-                '%(response_headers)s\r\n'
+            'id': 'deproxy',
+            'type': 'deproxy',
+            'addr': '${tempesta_ip}',
+            'port': '80',
         },
     ]
 
-    tempesta_config = '''
+    tempesta_template = {'config': TEMPESTA_CONFIG}
+
+    backends_template = [
+        {
+            'id': 'deproxy',
+            'type': 'deproxy',
+            'port': '8000',
+            'response': 'static',
+            'response_content':
+                'HTTP/1.1 200 OK\r\n'
+                + 'Server-id: deproxy\r\n'
+                + 'Content-Length: 0\r\n'
+                + '%(response_headers)s\r\n',
+        },
+    ]
+
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
 
     uri = '/'
     request_headers = {}
-    request_method = "GET"
+    request_method = 'GET'
     response_headers = {}
     response_status = '200'
-    should_be_cached = False # True means Tempesta Fw should make no forward the
-                             # request upstream and serve it from cache only.
-    sleep_interval = None # between the first and second request.
-    second_request_headers = None # When the two requests differ.
-    cached_headers = None # Reference headers to compare with actual cached
-                          # response. Empty if cached/second response is same as
-                          # first one.
+    should_be_cached = False  # True means Tempesta Fw should make no forward the
+    # request upstream and serve it from cache only.
+    sleep_interval = None  # between the first and second request.
+    second_request_headers = None  # When the two requests differ.
+    cached_headers = None  # Reference headers to compare with actual cached response.
+    # Empty if cached/second response is same as first one.
     cached_status = '200'
-    requests_to_server = None  # Estimated number of requests to the server. if the should_be_cached is True - 1,
-                               # if the should_be_cached is false - 2
+    requests_to_server = None  # Estimated number of requests to the server.
+    # if the should_be_cached is True - 1, if the should_be_cached is false - 2
 
     def start_all(self):
         self.start_all_servers()
@@ -76,14 +79,17 @@ class TestCacheControl(tester.TempestaTest):
 
     def setUp(self):
         self.tempesta = copy.deepcopy(self.tempesta_template)
-        self.tempesta['config'] = self.tempesta['config'] % \
-                        {'tempesta_config': self.tempesta_config or ''}
+        self.tempesta['config'] = (
+            self.tempesta['config'] % {'tempesta_config': self.tempesta_config or ''}
+        )
         self.backends = copy.deepcopy(self.backends_template)
-        headers = ''
-        for name, val in self.response_headers.items():
-            headers += '%s: %s\r\n' % (name, '' if val is None else val)
-        self.backends[0]['response_content'] = \
+        headers = ''.join(
+            '{0}: {1}\r\n'.format(header, '' if header_value is None else header_value)
+            for header, header_value in self.response_headers.items()
+        )
+        self.backends[0]['response_content'] = (
             self.backends[0]['response_content'] % {'response_headers': headers}
+        )
         # apply default values for optional fields
         if getattr(self, 'cached_headers', None) is None:
             self.cached_headers = self.response_headers
@@ -94,81 +100,100 @@ class TestCacheControl(tester.TempestaTest):
         elif not self.should_be_cached and not self.requests_to_server:
             self.requests_to_server = 2
 
-        super(TestCacheControl, self).setUp()
+        super().setUp()
 
-    def client_send_req(self, client, req):
+    def client_send_req(self, client, headers: dict):
+
+        req_headers = ''.join(
+            '{0}: {1}\r\n'.format(header, header_value if header_value else '')
+            for header, header_value in headers.items()
+        )
+        req = (
+            f'{self.request_method} {self.uri} HTTP/1.1\r\n'
+            + 'Host: localhost\r\n'
+            + f'{req_headers}\r\n'
+        )
         curr_responses = len(client.responses)
         client.make_requests(req)
         client.wait_for_response(timeout=1)
-        self.assertEqual(curr_responses + 1, len(client.responses))
+        self.assertEqual(curr_responses + 1, len(client.responses), 'response lost')
 
         return client.last_response
 
     def check_response_headers(self, response):
-        for name, val in self.response_headers.items():
-            actual_val = response.headers.get(name, None)
+        for header in self.response_headers.keys():
+            actual_val = response.headers.get(header, None)
             if actual_val is None:
-                self.assertIsNone(actual_val,
-                    "{} header is missing in the response".format(name))
+                self.assertIsNone(
+                    actual_val,
+                    '{0} header is missing in the response'.format(header),
+                )
             else:
-                self.assertIsNotNone(actual_val,
-                    "{} header is present in the response".format(name))
+                self.assertIsNotNone(
+                    actual_val,
+                    '{0} header is present in the response'.format(header),
+                )
 
     def check_cached_response_headers(self, response):
-        for name, val in self.cached_headers.items():
-            actual_val = response.headers.get(name, None)
+        for header in self.cached_headers.keys():
+            actual_val = response.headers.get(header, None)
             if actual_val is None:
-                self.assertIsNone(actual_val,
-                    "{} header is missing in the cached response". \
-                        format(name))
+                self.assertIsNone(
+                    actual_val,
+                    '{0} header is missing in the cached response'.format(header),
+                )
             else:
-                self.assertIsNotNone(actual_val,
-                    "{} header is present in the cached response". \
-                        format(name))
+                self.assertIsNotNone(
+                    actual_val,
+                    '{0} header is present in the cached response'.format(header),
+                )
 
     def _test(self):
         self.start_all()
-        client = self.get_client('deproxy')
-        srv = self.get_server('deproxy')
+        client: DeproxyClient = self.get_client('deproxy')
+        srv: StaticDeproxyServer = self.get_server('deproxy')
 
-        req_headers = ''
-        if self.request_headers:
-            for name, val in self.request_headers.items():
-                req_headers += '%s: %s\r\n' % (name, '' if val is None else val)
-        req = (f"{self.request_method} {self.uri} HTTP/1.1\r\n"
-               "Host: localhost\r\n"
-               "%s\r\n" % req_headers)
-        response = self.client_send_req(client, req)
-        self.assertEqual(response.status, self.response_status,
-                         "request failed: {}, expected {}" \
-                         .format(response.status, self.response_status))
+        response = self.client_send_req(client, self.request_headers)
+        self.assertEqual(
+            response.status,
+            self.response_status,
+            'request failed: {0}, expected {1}'.format(response.status, self.response_status),
+        )
         self.check_response_headers(response)
 
         if self.sleep_interval:
             time.sleep(self.sleep_interval)
 
-        req_headers2 = ''
-        if self.second_request_headers:
-            for name, val in self.second_request_headers.items():
-                req_headers2 += '%s: %s\r\n' % (name, '' if val is None else val)
-        req2 = (f"{self.request_method} {self.uri} HTTP/1.1\r\n"
-               "Host: localhost\r\n"
-               "%s\r\n" % req_headers2)
-        cached_response = self.client_send_req(client, req2)
-        self.assertEqual(cached_response.status, self.cached_status,
-                         "request for cache failed: {}, expected {}" \
-                         .format(response.status, self.cached_status))
-        self.assertEqual(2, len(client.responses), "response lost")
-        self.assertEqual(self.requests_to_server,
-                         len(srv.requests), "response not cached as expected")
+        cached_response = self.client_send_req(client, self.second_request_headers)
+        self.assertEqual(
+            cached_response.status,
+            self.cached_status,
+            'request for cache failed: {0}, expected {1}'.format(
+                cached_response.status,
+                self.cached_status,
+            ),
+        )
+        self.assertEqual(
+            self.requests_to_server,
+            len(srv.requests),
+            'response not cached as expected',
+        )
         if self.should_be_cached:
             self.check_cached_response_headers(cached_response)
         else:
             self.check_response_headers(cached_response)
 
-class SingleTest(object):
+
+class SingleTest(abc.ABC):
+    """This abstract class for run one test"""
+
     def test(self):
         self._test()
+
+    @abc.abstractmethod
+    def _test(self):
+        pass
+
 
 # Naming convension for test class name:
 #   NameSuffix
@@ -187,54 +212,60 @@ class SingleTest(object):
 #########################################################
 #  cache_resp_hdr_del
 class CacheHdrDelBypass(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_bypass * *;
         cache_resp_hdr_del set-cookie Remove-me-2;
-        '''
+        """
     response_headers = {'Set-Cookie': 'cookie=2; a=b', 'Remove-me-2': ''}
     should_be_cached = False
 
+
 class CacheHdrDelCached(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
         cache_resp_hdr_del set-cookie Remove-me-2;
-        '''
+        """
     response_headers = {'Set-Cookie': 'cookie=2; a=b', 'Remove-me-2': ''}
     cached_headers = {'Set-Cookie': None, 'Remove-me-2': None}
     should_be_cached = True
 
+
 class CacheHdrDelCached2(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
         cache_resp_hdr_del set-cookie Remove-me-2;
-        '''
+        """
     response_headers = {'Set-Cookie': 'cookie=2; a=b', 'Remove-me-2': '2'}
     cached_headers = {'Set-Cookie': None, 'Remove-me-2': None}
     should_be_cached = True
+
 
 # This test does a regular caching without additional processing,
 # however, the regular caching might not work correctly for
 # empty 'Remove-me' header value due to a bug in message fixups (see #530).
 class TestCacheBypass(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_bypass * *;
-        '''
+        """
     response_headers = {'Remove-me': '', 'Remove-me-2': ''}
     should_be_cached = False
 
+
 class TestCache(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     response_headers = {'Remove-me': '', 'Remove-me-2': ''}
     should_be_cached = True
 
+
 class TestCache2(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     response_headers = {'Remove-me': '2', 'Remove-me-2': '2'}
     should_be_cached = True
+
 
 #########################################################
 #  cache_control_ignore
@@ -247,11 +278,13 @@ class RequestMaxAgeNoCached(TestCacheControl, SingleTest):
     sleep_interval = 1.5
     should_be_cached = False
 
+
 class RequestMaxAgeCached(TestCacheControl, SingleTest):
     request_headers = {'Cache-control': 'max-age=1'}
     response_headers = {'Cache-control': 'max-age=3'}
     sleep_interval = None
     should_be_cached = True
+
 
 # max-age, max-stale
 class RequestMaxAgeMaxStaleNotCached(TestCacheControl, SingleTest):
@@ -260,17 +293,20 @@ class RequestMaxAgeMaxStaleNotCached(TestCacheControl, SingleTest):
     sleep_interval = 3
     should_be_cached = False
 
+
 class RequestMaxAgeMaxStaleCached(TestCacheControl, SingleTest):
     request_headers = {'Cache-control': 'max-age=3, max-stale=2'}
     response_headers = {'Cache-control': 'max-age=1'}
     sleep_interval = 1.5
     should_be_cached = True
 
+
 class RequestMaxStaleCached(TestCacheControl, SingleTest):
     request_headers = {'Cache-control': 'max-stale'}
     response_headers = {'Cache-control': 'max-age=1'}
     sleep_interval = 1.5
     should_be_cached = True
+
 
 # min-fresh
 class RequestMinFreshNotCached(TestCacheControl, SingleTest):
@@ -279,11 +315,13 @@ class RequestMinFreshNotCached(TestCacheControl, SingleTest):
     sleep_interval = 1.5
     should_be_cached = False
 
+
 class RequestMinFreshCached(TestCacheControl, SingleTest):
     request_headers = {'Cache-control': 'min-fresh=1'}
     response_headers = {'Cache-control': 'max-age=2'}
     sleep_interval = None
     should_be_cached = True
+
 
 # max-age
 class RequestOnlyIfCachedCached(TestCacheControl, SingleTest):
@@ -293,6 +331,7 @@ class RequestOnlyIfCachedCached(TestCacheControl, SingleTest):
     second_request_headers = {'Cache-control': 'max-age=1, only-if-cached'}
     cached_status = '200'
     should_be_cached = True
+
 
 class RequestOnlyIfCached504(TestCacheControl, SingleTest):
     request_headers = {'Cache-control': 'max-age=1'}
@@ -307,9 +346,11 @@ class RequestNoStoreNotCached(TestCacheControl, SingleTest):
     request_headers = {'Cache-control': 'no-store'}
     should_be_cached = False
 
-class RequestNoStoreNotCached(TestCacheControl, SingleTest):
+
+class RequestNoChacheNotCached(TestCacheControl, SingleTest):
     request_headers = {'Cache-control': 'no-cache'}
     should_be_cached = False
+
 
 ##########
 # response
@@ -326,317 +367,346 @@ class RequestNoStoreNotCached(TestCacheControl, SingleTest):
 # Here we test the cache behaviour for stale responses with
 # "max-age=1, must-revalidate", which mandates revalidation after 1 second.
 class ResponseMustRevalidateNotCached(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     request_headers = {}
     response_headers = {'Cache-control': 'max-age=1, must-revalidate'}
     sleep_interval = 1.5
     should_be_cached = False
 
+
 class ResponseMustRevalidateStaleNotCached(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     request_headers = {'Cache-control': 'max-stale=2'}
     response_headers = {'Cache-control': 'max-age=1, must-revalidate'}
     sleep_interval = 1.5
     should_be_cached = False
+
 
 # RFC 7234 Sections 3.2, 4.2.4:
 # "cached responses that contain the "must-revalidate" and/or
 #  "s-maxage" response directives are not allowed to be served stale
 #  by shared caches"
 class ResponseMustRevalidateStaleCached(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     request_headers = {'Cache-control': 'max-stale=2'}
     response_headers = {'Cache-control': 'max-age=1, must-revalidate'}
     should_be_cached = True
     sleep_interval = None
 
+
 class ResponseMustRevalidateCached(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     request_headers = {}
     response_headers = {'Cache-control': 'max-age=1, must-revalidate'}
     sleep_interval = None
     should_be_cached = True
 
+
 class ResponseMustRevalidateIgnore(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
         cache_control_ignore must-revalidate;
-        '''
+        """
     # Although must-revalidate is ignored, max-age=1 remains active.
     request_headers = {}
     response_headers = {'Cache-control': 'max-age=1, must-revalidate'}
     sleep_interval = 1.5
     should_be_cached = False
 
+
 class ResponseMustRevalidateStaleIgnore(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
         cache_control_ignore must-revalidate;
-        '''
-    request_headers = {}
+        """
     request_headers = {'Cache-control': 'max-stale=2'}
     response_headers = {'Cache-control': 'max-age=1, must-revalidate'}
     sleep_interval = 1.5
     should_be_cached = True
 
+
 # proxy-revalidate
 class ResponseProxyRevalidateNotCached(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     request_headers = {}
     response_headers = {'Cache-control': 'max-age=1, proxy-revalidate'}
     sleep_interval = 1.5
     should_be_cached = False
 
+
 class ResponseProxyRevalidateStaleNotCached(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     request_headers = {'Cache-control': 'max-stale=2'}
     response_headers = {'Cache-control': 'max-age=1, proxy-revalidate'}
     sleep_interval = 1.5
     should_be_cached = False
 
+
 class ResponseProxyRevalidateIgnore(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
         cache_control_ignore proxy-revalidate;
-        '''
+        """
     request_headers = {}
     response_headers = {'Cache-control': 'max-age=1, proxy-revalidate'}
     sleep_interval = 1.5
     should_be_cached = False
 
+
 class ResponseStaleCached(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     request_headers = {'Cache-control': 'max-stale=2'}
     response_headers = {'Cache-control': 'max-age=1'}
     sleep_interval = 1.5
     should_be_cached = True
 
+
 class ResponseProxyRevalidateStaleIgnore(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
         cache_control_ignore proxy-revalidate;
-        '''
+        """
     request_headers = {'Cache-control': 'max-stale=2'}
     response_headers = {'Cache-control': 'max-age=1, proxy-revalidate'}
     sleep_interval = 1.5
     should_be_cached = True
+
 
 # Support for "max-stale" + "max-age=1, proxy-revalidate" is questionable and
 # already tested above. So we test multiple directives with a more reliable
 # logic of "Authorizarion" caching.
-class ResponseMustRevalidateNotCached(TestCacheControl, SingleTest):
-    tempesta_config = '''
+class ResponseForAuthorizationUserMustRevalidateNotCached(TestCacheControl, SingleTest):
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     request_headers = {'Authorization': 'asd'}
-    response_headers = {'Cache-control':
-                        'max-age=1, must-revalidate'}
+    response_headers = {'Cache-control': 'max-age=1, must-revalidate'}
     sleep_interval = 1.5
     should_be_cached = False
 
+
 class ResponseMustRevalidateHalfIgnore(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
         cache_control_ignore max-age;
-        '''
+        """
     request_headers = {'Authorization': 'asd'}
-    response_headers = {'Cache-control':
-                        'max-age=1, must-revalidate'}
+    response_headers = {'Cache-control': 'max-age=1, must-revalidate'}
     sleep_interval = 1.5
     should_be_cached = True
 
+
 class ResponseMustRevalidateMultiIgnore(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
         cache_control_ignore max-age must-revalidate;
-        '''
+        """
     request_headers = {'Authorization': 'asd'}
-    response_headers = {'Cache-control':
-                        'max-age=1, must-revalidate'}
+    response_headers = {'Cache-control': 'max-age=1, must-revalidate'}
     sleep_interval = 1.5
     should_be_cached = False
 
+
 # max-age/s-maxage
 class ResponseMaxAgeNotCached(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     response_headers = {'Cache-control': 'max-age=1'}
     sleep_interval = 1.5
     should_be_cached = False
 
+
 class ResponseMaxAgeCached(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     response_headers = {'Cache-control': 'max-age=1'}
     sleep_interval = None
     should_be_cached = True
 
+
 class ResponseMaxAgeIgnore(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
         cache_control_ignore max-age;
-        '''
+        """
     response_headers = {'Cache-control': 'max-age=1'}
     sleep_interval = 1.5
     should_be_cached = True
 
+
 class ResponseSMaxageNotCached(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     response_headers = {'Cache-control': 's-maxage=1'}
     sleep_interval = 1.5
     should_be_cached = False
 
+
 # s-maxage forbids serving stale responses (implies proxy-revalidate)
 class ResponseSMaxageNotCached2(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     request_headers = {'Cache-control': 'max-stale=2'}
     response_headers = {'Cache-control': 's-maxage=1'}
     sleep_interval = 1.5
     should_be_cached = False
 
+
 class ResponseSMaxageCached(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     response_headers = {'Cache-control': 's-maxage=1'}
     sleep_interval = None
     should_be_cached = True
 
+
 # Authorization interacts with s-maxage, but not with max-age.
 # See RFC 7234 Section 3.2.
 class ResponseMaxAgeNotCached2(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     request_headers = {'Authorization': 'asd'}
     response_headers = {'Cache-control': 's-maxage=0'}
     sleep_interval = None
     should_be_cached = False
 
+
 class ResponseMaxAgeCached2(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     request_headers = {'Authorization': 'asd'}
     response_headers = {'Cache-control': 's-maxage=1'}
     sleep_interval = None
     should_be_cached = True
 
+
 class ResponseSMaxageIgnore(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
         cache_control_ignore s-maxage;
-        '''
+        """
     response_headers = {'Cache-control': 's-maxage=1'}
     sleep_interval = 1.5
     should_be_cached = True
 
+
 class ResponseSMaxageMaxAgeNotCached(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
         cache_control_ignore max-age;
-        '''
+        """
     response_headers = {'Cache-control': 'max-age=1, s-maxage=1'}
     sleep_interval = 1.5
     should_be_cached = False
 
+
 class ResponseSMaxageMaxAgeIgnore(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
         cache_control_ignore max-age s-maxage;
-        '''
+        """
     response_headers = {'Cache-control': 'max-age=1, s-maxage=1'}
     sleep_interval = 1.5
     should_be_cached = True
+
 
 # private/no-cache/no-store
 class ResponsePrivate(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     response_headers = {'Cache-control': 'private'}
     should_be_cached = False
 
+
 class ResponseNoCache(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     response_headers = {'Cache-control': 'no-cache'}
     should_be_cached = False
 
+
 class ResponseNoStore(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     response_headers = {'Cache-control': 'no-store'}
     should_be_cached = False
 
+
 class ResponseNoCacheIgnore(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
         cache_control_ignore no-cache;
-        '''
+        """
     response_headers = {'Cache-control': 'no-cache'}
     should_be_cached = True
+
 
 # multiple cache_control_ignore directives
 class ResponseNoCacheIgnoreMulti(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
         cache_control_ignore max-age no-cache;
-        '''
+        """
     response_headers = {'Cache-control': 'no-cache'}
     should_be_cached = True
 
+
 class ResponseMultipleNoCacheIgnore(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
         cache_control_ignore no-cache private no-store;
-        '''
+        """
     response_headers = {'Cache-control': 'no-cache, private, no-store'}
     should_be_cached = True
 
+
 # public directive and Authorization header
 class ResponsePublicNotCached(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     request_headers = {'Authorization': 'asd'}
     response_headers = {}
     should_be_cached = False
 
+
 class ResponsePublicCached(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     request_headers = {'Authorization': 'asd'}
     response_headers = {'Cache-control': 'public'}
     should_be_cached = True
 
+
 class ResponsePublicCached2(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     request_headers = {}
     response_headers = {}
     # Interestingly enough, RFC 7234 does not forbid serving cached response for
@@ -644,118 +714,166 @@ class ResponsePublicCached2(TestCacheControl, SingleTest):
     second_request_headers = {'Authorization': 'asd'}
     should_be_cached = True
 
+
 class ResponsePublicIgnore(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
         cache_control_ignore public;
-        '''
+        """
     request_headers = {'Authorization': 'asd'}
     response_headers = {'Cache-control': 'public'}
     should_be_cached = False
 
+
 # multiple cache_control_ignore directives
 class ResponsePublicIgnore2(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
         cache_control_ignore must-revalidate public;
-        '''
+        """
     request_headers = {'Authorization': 'asd'}
     response_headers = {'Cache-control': 'public'}
     should_be_cached = False
+
 
 #########################################################
 #  Cache-Control: no-cache and private with arguments
 #############
 # no-cache
 class CCArgNoCacheBypass(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_bypass * *;
-        '''
-    response_headers = {'Remove-me': '', 'Remove-me-2': '',
-        'Cache-control': 'no-cache="remove-me"'}
+        """
+    response_headers = {
+        'Remove-me': '',
+        'Remove-me-2': '',
+        'Cache-control': 'no-cache="remove-me"',
+    }
     should_be_cached = False
 
+
 class CCArgNoCacheCached(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
-    response_headers = {'Remove-me': '', 'Remove-me-2': '',
-        'Cache-control': 'no-cache="remove-me"'}
-    cached_headers = {'Remove-me': None, 'Remove-me-2': '',
-        'Cache-control': 'no-cache="remove-me"'}
+        """
+    response_headers = {
+        'Remove-me': '',
+        'Remove-me-2': '',
+        'Cache-control': 'no-cache="remove-me"',
+    }
+    cached_headers = {
+        'Remove-me': None,
+        'Remove-me-2': '',
+        'Cache-control': 'no-cache="remove-me"',
+    }
     should_be_cached = True
+
 
 class CCArgNoCacheCached2(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
-    response_headers = {'Remove-me': '"arg"', 'Remove-me-2': '"arg"',
-        'Cache-control': 'no-cache="remove-me"'}
-    cached_headers = {'Remove-me': None, 'Remove-me-2': '"arg"',
-        'Cache-control': 'no-cache="remove-me"'}
+        """
+    response_headers = {
+        'Remove-me': '"arg"',
+        'Remove-me-2': '"arg"',
+        'Cache-control': 'no-cache="remove-me"',
+    }
+    cached_headers = {
+        'Remove-me': None,
+        'Remove-me-2': '"arg"',
+        'Cache-control': 'no-cache="remove-me"',
+    }
     should_be_cached = True
 
+
 class CCArgNoCacheCached3(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
-    response_headers = {'Cache-Control':
-        'public, no-cache="Set-Cookie", must-revalidate, max-age=120',
-        'Set-Cookie': 'some=cookie'}
+        """
+    response_headers = {
+        'Cache-Control': 'public, no-cache="Set-Cookie", must-revalidate, max-age=120',
+        'Set-Cookie': 'some=cookie',
+    }
     cached_headers = {
         'Cache-Control':
             'public, no-cache="Set-Cookie", must-revalidate, max-age=120',
-        'Set-Cookie': None
+        'Set-Cookie': None,
     }
     should_be_cached = True
+
 
 #############
 # private
 class CCArgPrivateBypass(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_bypass * *;
-        '''
-    response_headers = {'Set-cookie': 'some=cookie', 'remove-me-2': '',
-        'Cache-control': 'private="set-cookie"'}
+        """
+    response_headers = {
+        'Set-cookie': 'some=cookie',
+        'remove-me-2': '',
+        'Cache-control': 'private="set-cookie"',
+    }
     should_be_cached = False
 
+
 class CCArgPrivateCached(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
-    response_headers = {'Set-cookie': 'some=cookie', 'remove-me-2': '',
-        'Cache-control': 'private="set-cookie"'}
-    cached_headers = {'Set-cookie': None, 'remove-me-2': '',
-        'Cache-control': 'private="set-cookie"'}
+        """
+    response_headers = {
+        'Set-cookie': 'some=cookie',
+        'remove-me-2': '',
+        'Cache-control': 'private="set-cookie"',
+    }
+    cached_headers = {
+        'Set-cookie': None,
+        'remove-me-2': '',
+        'Cache-control': 'private="set-cookie"',
+    }
     should_be_cached = True
 
+
 class CCArgPrivateCached2(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
-    response_headers = {'Set-cookie': 'some=cookie', 'remove-me-2': '=',
-        'Cache-control': 'private="set-cookie"'}
-    cached_headers = {'Set-cookie': None, 'remove-me-2': '=',
-        'Cache-control': 'private="set-cookie"'}
+        """
+    response_headers = {
+        'Set-cookie': 'some=cookie',
+        'remove-me-2': '=',
+        'Cache-control': 'private="set-cookie"',
+    }
+    cached_headers = {
+        'Set-cookie': None,
+        'remove-me-2': '=',
+        'Cache-control': 'private="set-cookie"',
+    }
     should_be_cached = True
+
 
 # erase two headers
 class CCArgBothNoCacheCached(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
-    response_headers = {'Set-cookie': 'some=cookie', 'remove-me-2': '"',
-        'Cache-control': 'no-cache="set-cookie, Remove-me-2"'}
-    cached_headers = {'Set-cookie': None, 'remove-me-2': None,
-        'Cache-control': 'no-cache="set-cookie, Remove-me-2"'}
+        """
+    response_headers = {
+        'Set-cookie': 'some=cookie',
+        'remove-me-2': '"',
+        'Cache-control': 'no-cache="set-cookie, Remove-me-2"',
+    }
+    cached_headers = {
+        'Set-cookie': None,
+        'remove-me-2': None,
+        'Cache-control': 'no-cache="set-cookie, Remove-me-2"',
+    }
     should_be_cached = True
+
 
 #########################################################
 #  Http chain cache action test
 #########################################################
 # bypass cache
 class HttpChainCacheActionBypass(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
         http_chain {
             cookie "foo_items_in_cart" == "*" -> $$cache = 0;
@@ -763,14 +881,15 @@ class HttpChainCacheActionBypass(TestCacheControl, SingleTest):
             cookie "wordpress_logged_in*" == "*" -> $$cache = 0;
             -> vh1;
         }
-        '''
+        """
     request_headers = {'Cookie': 'foo_items_in_cart='}
     response_headers = {}
     should_be_cached = False
 
+
 # bypass cache due to override later
 class HttpChainCacheActionOverrideBypass(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
         http_chain {
             cookie "foo_items_in_cart" == "*" -> $$cache = 0;
@@ -778,14 +897,15 @@ class HttpChainCacheActionOverrideBypass(TestCacheControl, SingleTest):
             cookie "wordpress_logged_in*" == "*" -> $$cache = 0;
             -> vh1;
         }
-        '''
+        """
     request_headers = {'Cookie': 'comment_author_name=john; wordpress_logged_in=true'}
     response_headers = {}
     should_be_cached = False
 
+
 #  honour cache due to override later
 class HttpChainCacheActionOverrideCached(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
         http_chain {
             cookie "foo_items_in_cart" == "*" -> $$cache = 0;
@@ -793,14 +913,15 @@ class HttpChainCacheActionOverrideCached(TestCacheControl, SingleTest):
             cookie "wordpress_logged_in*" == "*" -> $$cache = 0;
             -> vh1;
         }
-        '''
+        """
     request_headers = {'Cookie': 'foo_items_in_cart=; comment_author_name=john'}
     response_headers = {}
     should_be_cached = True
 
+
 # honour cache
 class HttpChainCacheActionCached(TestCacheControl, SingleTest):
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
         http_chain {
             cookie "foo_items_in_cart" == "*" -> $$cache = 0;
@@ -808,43 +929,47 @@ class HttpChainCacheActionCached(TestCacheControl, SingleTest):
             cookie "wordpress_logged_in*" == "*" -> $$cache = 0;
             -> vh1;
         }
-        '''
+        """
     request_headers = {'Cookie': 'comment_author_name=john'}
     response_headers = {}
     should_be_cached = True
 
+
 class CacheLocationBase(TestCacheControl, SingleTest, base=True):
-    tempesta_template = {
-        "config":
-        """
-        server ${server_ip}:8000;
-        vhost default {
+
+    tempesta_config_sample = """
+    server ${server_ip}:8000;
+
+    vhost default {
+        proxy_pass default;
+
+        location prefix "/cached" {
             proxy_pass default;
-
-            location prefix "/cached" {
-                proxy_pass default;
-                cache_fulfill * *;
-            }
-
-            location prefix "/bypassed" {
-                proxy_pass default;
-                cache_bypass * *;
-            }
-            location prefix "/nonidempotent" {
-                proxy_pass default;
-                cache_fulfill * *;
-                nonidempotent GET * *;
-                nonidempotent HEAD * *;
-            }
-
+            cache_fulfill * *;
         }
-        """
+
+        location prefix "/bypassed" {
+            proxy_pass default;
+            cache_bypass * *;
+        }
+
+        location prefix "/nonidempotent" {
+            proxy_pass default;
+            cache_fulfill * *;
+            nonidempotent GET * *;
+            nonidempotent HEAD * *;
+        }
     }
+    """
+
+    tempesta_template = {'config': tempesta_config_sample}
     tempesta_config = ''
+
 
 class CacheLocationCached(CacheLocationBase):
     should_be_cached = True
     uri = '/cached'
+
 
 class CacheLocationBypass(CacheLocationBase):
     should_be_cached = False
@@ -855,21 +980,26 @@ class CacheLocationNonidempotentGetBypass(CacheLocationBase):
     should_be_cached = False
     uri = '/nonidempotent'
 
+
 class CacheLocationNonidempotentHeadBypass(CacheLocationBase):
     should_be_cached = False
     uri = '/nonidempotent'
-    request_method = "HEAD"
+    request_method = 'HEAD'
 
 
 #########################################################
 # 3.2 Storing Responses to Authenticated Requests. RFC 7234
 #########################################################
 class StoringResponsesToAuthenticatedRequestsDefaultCache(TestCacheControl, SingleTest):
-    """This test sends two requests with different basic authentication headers and without cache-control header to
-    the same resource and check that the second one wasn't serviced from the cache."""
-    tempesta_config = '''
+    """
+    This test sends two requests with different basic authentication headers and without
+    cache-control header to the same resource and check that the second one wasn't serviced
+    from the cache.
+    """
+
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     request_headers = {'Authorization': 'Basic dXNlcjE6cGFzc3dvcmQx'}
     second_request_headers = {'Authorization': 'Basic dXNlcjI6cGFzc3dvcmQy'}
     should_be_cached = True
@@ -877,11 +1007,15 @@ class StoringResponsesToAuthenticatedRequestsDefaultCache(TestCacheControl, Sing
 
 
 class StoringResponsesToAuthenticatedRequestsPublicCache(TestCacheControl, SingleTest):
-    """This test sends two requests with different basic authentication headers and with cache-control: public to
-    the same resource and check that the second one was serviced from the cache."""
-    tempesta_config = '''
+    """
+    This test sends two requests with different basic authentication headers and with
+    cache-control: public to the same resource and check that the second one was serviced
+    from the cache.
+    """
+
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     request_headers = {'Authorization': 'Basic dXNlcjE6cGFzc3dvcmQx'}
     second_request_headers = {'Authorization': 'Basic dXNlcjI6cGFzc3dvcmQy'}
     should_be_cached = True
@@ -889,26 +1023,16 @@ class StoringResponsesToAuthenticatedRequestsPublicCache(TestCacheControl, Singl
     response_headers = {'Cache-control': 'public'}
 
 
-class StoringResponsesToAuthenticatedRequestsMustRevalidateCache(TestCacheControl, SingleTest):
-    """This test sends two requests with different basic authentication headers and with cache-control must-revalidate
-    to the same resource and check that the second one wasn't serviced from the cache."""
-    tempesta_config = '''
-        cache_fulfill * *;
-        '''
-    request_headers = {'Authorization': 'Basic dXNlcjE6cGFzc3dvcmQx'}
-    second_request_headers = {'Authorization': 'Basic dXNlcjI6cGFzc3dvcmQy'}
-    should_be_cached = True
-    sleep_interval = 1.5
-    requests_to_server = 2
-    response_headers = {'Cache-control': 'must-revalidate, max-age=1'}
-
-
 class StoringResponsesToAuthenticatedRequestsMustRevalidateCache2(TestCacheControl, SingleTest):
-    """This test sends two requests with different basic authentication headers and with cache-control must-revalidate
-    to the same resource and check that the second one was serviced from the cache."""
-    tempesta_config = '''
+    """
+    This test sends two requests with different basic authentication headers and with
+    cache-control must-revalidate to the same resource and check that the second one was
+    serviced from the cache.
+    """
+
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     request_headers = {'Authorization': 'Basic dXNlcjE6cGFzc3dvcmQx'}
     second_request_headers = {'Authorization': 'Basic dXNlcjI6cGFzc3dvcmQy'}
     should_be_cached = True
@@ -917,12 +1041,16 @@ class StoringResponsesToAuthenticatedRequestsMustRevalidateCache2(TestCacheContr
     response_headers = {'Cache-control': 'must-revalidate, max-age=1'}
 
 
-class StoringResponsesToAuthenticatedRequestsNoCache(TestCacheControl, SingleTest):
-    """This test sends two requests with different basic authentication headers and with cache-control no-cache
-    to the same resource and check that the second one wasn't serviced from the cache."""
-    tempesta_config = '''
+class StoringResponsesToAuthenticatedRequestsNoCacheCache(TestCacheControl, SingleTest):
+    """
+    This test sends two requests with different basic authentication headers and with
+    cache-control no-cache to the same resource and check that the second one wasn't
+    serviced from the cache.
+    """
+
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     request_headers = {'Authorization': 'Basic dXNlcjE6cGFzc3dvcmQx'}
     second_request_headers = {'Authorization': 'Basic dXNlcjI6cGFzc3dvcmQy'}
     should_be_cached = True
@@ -931,11 +1059,15 @@ class StoringResponsesToAuthenticatedRequestsNoCache(TestCacheControl, SingleTes
 
 
 class StoringResponsesToAuthenticatedRequestsNoStoreCache(TestCacheControl, SingleTest):
-    """This test sends two requests with different basic authentication headers and with cache-control no-store
-    to the same resource and check that the second one wasn't serviced from the cache."""
-    tempesta_config = '''
+    """
+    This test sends two requests with different basic authentication headers and with
+    cache-control no-store to the same resource and check that the second one wasn't
+    serviced from the cache.
+    """
+
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     request_headers = {'Authorization': 'Basic dXNlcjE6cGFzc3dvcmQx'}
     second_request_headers = {'Authorization': 'Basic dXNlcjI6cGFzc3dvcmQy'}
     should_be_cached = True
@@ -944,11 +1076,15 @@ class StoringResponsesToAuthenticatedRequestsNoStoreCache(TestCacheControl, Sing
 
 
 class StoringResponsesToAuthenticatedRequestsNoTransformCache(TestCacheControl, SingleTest):
-    """This test sends two requests with different basic authentication headers and with cache-control no-transform
-    to the same resource and check that the second one wasn't serviced from the cache."""
-    tempesta_config = '''
+    """
+    This test sends two requests with different basic authentication headers and with
+    cache-control no-transform to the same resource and check that the second one wasn't
+    serviced from the cache.
+    """
+
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     request_headers = {'Authorization': 'Basic dXNlcjE6cGFzc3dvcmQx'}
     second_request_headers = {'Authorization': 'Basic dXNlcjI6cGFzc3dvcmQy'}
     should_be_cached = True
@@ -957,11 +1093,15 @@ class StoringResponsesToAuthenticatedRequestsNoTransformCache(TestCacheControl, 
 
 
 class StoringResponsesToAuthenticatedRequestsPrivateCache(TestCacheControl, SingleTest):
-    """This test sends two requests with different basic authentication headers and with cache-control private
-    to the same resource and check that the second one wasn't serviced from the cache."""
-    tempesta_config = '''
+    """
+    This test sends two requests with different basic authentication headers and with
+    cache-control private to the same resource and check that the second one wasn't serviced
+    from the cache.
+    """
+
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     request_headers = {'Authorization': 'Basic dXNlcjE6cGFzc3dvcmQx'}
     second_request_headers = {'Authorization': 'Basic dXNlcjI6cGFzc3dvcmQy'}
     should_be_cached = True
@@ -970,11 +1110,15 @@ class StoringResponsesToAuthenticatedRequestsPrivateCache(TestCacheControl, Sing
 
 
 class StoringResponsesToAuthenticatedRequestsProxyRevalidateCache(TestCacheControl, SingleTest):
-    """This test sends two requests with different basic authentication headers and with cache-control proxy-revalidate
-    to the same resource and check that the second one was serviced from the cache."""
-    tempesta_config = '''
+    """
+    This test sends two requests with different basic authentication headers and with
+    cache-control proxy-revalidate to the same resource and check that the second one was
+    serviced from the cache.
+    """
+
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     request_headers = {'Authorization': 'Basic dXNlcjE6cGFzc3dvcmQx'}
     second_request_headers = {'Authorization': 'Basic dXNlcjI6cGFzc3dvcmQy'}
     should_be_cached = True
@@ -983,26 +1127,16 @@ class StoringResponsesToAuthenticatedRequestsProxyRevalidateCache(TestCacheContr
     response_headers = {'Cache-control': 'proxy-revalidate, max-age=1'}
 
 
-class StoringResponsesToAuthenticatedRequestsProxyRevalidateCache2(TestCacheControl, SingleTest):
-    """This test sends two requests with different basic authentication headers and with cache-control proxy-revalidate
-    to the same resource and check that the second one wasn't serviced from the cache."""
-    tempesta_config = '''
-        cache_fulfill * *;
-        '''
-    request_headers = {'Authorization': 'Basic dXNlcjE6cGFzc3dvcmQx'}
-    second_request_headers = {'Authorization': 'Basic dXNlcjI6cGFzc3dvcmQy'}
-    should_be_cached = True
-    sleep_interval = 1.5
-    requests_to_server = 2
-    response_headers = {'Cache-control': 'proxy-revalidate, max-age=1'}
-
-
 class StoringResponsesToAuthenticatedRequestsMaxAgeCache(TestCacheControl, SingleTest):
-    """This test sends two requests with different basic authentication headers and with cache-control max-age
-    to the same resource and check that the second one wasn't serviced from the cache."""
-    tempesta_config = '''
+    """
+    This test sends two requests with different basic authentication headers and with
+    cache-control max-age to the same resource and check that the second one wasn't serviced
+    from the cache.
+    """
+
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     request_headers = {'Authorization': 'Basic dXNlcjE6cGFzc3dvcmQx'}
     second_request_headers = {'Authorization': 'Basic dXNlcjI6cGFzc3dvcmQy'}
     should_be_cached = True
@@ -1011,11 +1145,15 @@ class StoringResponsesToAuthenticatedRequestsMaxAgeCache(TestCacheControl, Singl
 
 
 class StoringResponsesToAuthenticatedRequestsSMaxAgeCache(TestCacheControl, SingleTest):
-    """This test sends two requests with different basic authentication headers and with cache-control s-maxage
-    to the same resource and check that the second one was serviced from the cache."""
-    tempesta_config = '''
+    """
+    This test sends two requests with different basic authentication headers and with
+    cache-control s-maxage to the same resource and check that the second one was serviced
+    from the cache.
+    """
+
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     request_headers = {'Authorization': 'Basic dXNlcjE6cGFzc3dvcmQx'}
     second_request_headers = {'Authorization': 'Basic dXNlcjI6cGFzc3dvcmQy'}
     should_be_cached = True
@@ -1024,63 +1162,46 @@ class StoringResponsesToAuthenticatedRequestsSMaxAgeCache(TestCacheControl, Sing
     response_headers = {'Cache-control': 's-maxage=1'}
 
 
-class StoringResponsesToAuthenticatedRequestsSMaxAgeCache2(TestCacheControl, SingleTest):
-    """This test sends two requests with different basic authentication headers and with cache-control s-maxage
-    to the same resource and check that the second one wasn't serviced from the cache."""
-    tempesta_config = '''
-        cache_fulfill * *;
-        '''
-    request_headers = {'Authorization': 'Basic dXNlcjE6cGFzc3dvcmQx'}
-    second_request_headers = {'Authorization': 'Basic dXNlcjI6cGFzc3dvcmQy'}
-    should_be_cached = True
-    sleep_interval = 1.5
-    requests_to_server = 2
-    response_headers = {'Cache-control': 's-maxage=1'}
+class StoringResponsesWithSetCookieHeaderDefaultCache(TestCacheControl, SingleTest):
+    """
+    This test sends two requests to the same resource, which responds with set-cookie headers,
+    and check that second request wasn't serviced from the cache.
+    """
 
-
-class StoringResponsesToRequestsWithCookiesDefaultCache(TestCacheControl, SingleTest):
-    """This test sends two requests to the same resource, which responds with set-cookie headers, and check that
-    second request wasn't serviced from the cache."""
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     should_be_cached = True
     response_headers = {'Set-Cookie': 'session=1'}
     second_request_headers = {'Cookie': response_headers['Set-Cookie']}
     requests_to_server = 2
 
 
-class StoringResponsesToRequestsWithCookiesPublicCache(TestCacheControl, SingleTest):
-    """This test sends two requests to the same resource, which responds with public cache-control and set-cookie
-     headers, and check that second request was serviced from the cache."""
-    tempesta_config = '''
+class StoringResponsesWithSetCookieHeaderPublicCache(TestCacheControl, SingleTest):
+    """
+    This test sends two requests to the same resource, which responds with public cache-control
+    and set-cookie headers, and check that second request was serviced from the cache.
+    """
+
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     should_be_cached = True
     response_headers = {'Set-Cookie': 'session=1', 'Cache-control': 'public'}
     second_request_headers = {'Cookie': response_headers['Set-Cookie']}
     requests_to_server = 1
 
 
-class StoringResponsesToRequestsWithCookiesMustRevalidateCache(TestCacheControl, SingleTest):
-    """This test sends two requests to the same resource, which responds with must-revalidate cache-control and
-    set-cookie headers, and check that second request wasn't serviced from the cache."""
-    tempesta_config = '''
-        cache_fulfill * *;
-        '''
-    response_headers = {'Set-Cookie': 'session=1', 'Cache-control': 'must-revalidate, max-age=1'}
-    second_request_headers = {'Cookie': response_headers['Set-Cookie']}
-    should_be_cached = True
-    sleep_interval = 1.5
-    requests_to_server = 2
+class StoringResponsesWithSetCookieHeaderMustRevalidateCache(TestCacheControl, SingleTest):
+    """
+    This test sends two requests to the same resource, which responds with must-revalidate
+    cache-control and set-cookie headers, and check that second request was serviced from
+    the cache.
+    """
 
-
-class StoringResponsesToRequestsWithCookiesMustRevalidateCache2(TestCacheControl, SingleTest):
-    """This test sends two requests to the same resource, which responds with must-revalidate cache-control and
-    set-cookie headers, and check that second request was serviced from the cache."""
-    tempesta_config = '''
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     response_headers = {'Set-Cookie': 'session=1', 'Cache-control': 'must-revalidate, max-age=1'}
     second_request_headers = {'Cookie': response_headers['Set-Cookie']}
     should_be_cached = True
@@ -1088,120 +1209,113 @@ class StoringResponsesToRequestsWithCookiesMustRevalidateCache2(TestCacheControl
     requests_to_server = 1
 
 
-class StoringResponsesToRequestsWithCookiesNoCache(TestCacheControl, SingleTest):
-    """This test sends two requests to the same resource, which responds with no-cache cache-control and
-    set-cookie headers, and check that second request wasn't serviced from the cache."""
-    tempesta_config = '''
+class StoringResponsesWithSetCookieHeaderNoCacheCache(TestCacheControl, SingleTest):
+    """
+    This test sends two requests to the same resource, which responds with no-cache
+    cache-control and set-cookie headers, and check that second request wasn't serviced
+    from the cache.
+    """
+
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     response_headers = {'Set-Cookie': 'session=1', 'Cache-control': 'no-cache'}
     second_request_headers = {'Cookie': response_headers['Set-Cookie']}
     should_be_cached = True
     requests_to_server = 2
 
 
-class StoringResponsesToRequestsWithCookiesNoStoreCache(TestCacheControl, SingleTest):
-    """This test sends two requests to the same resource, which responds with no-store cache-control and
-    set-cookie headers, and check that second request wasn't serviced from the cache."""
-    tempesta_config = '''
+class StoringResponsesWithSetCookieHeaderNoStoreCache(TestCacheControl, SingleTest):
+    """
+    This test sends two requests to the same resource, which responds with no-store
+    cache-control and set-cookie headers, and check that second request wasn't serviced
+    from the cache.
+    """
+
+    tempesta_config = """
         cache_fulfill * *;
-        '''
+        """
     response_headers = {'Set-Cookie': 'session=1', 'Cache-control': 'no-store'}
     second_request_headers = {'Cookie': response_headers['Set-Cookie']}
     should_be_cached = True
     requests_to_server = 2
 
 
-class StoringResponsesToAuthenticatedRequestsNoTransformCache(TestCacheControl, SingleTest):
-    """This test sends two requests with different basic authentication headers and with cache-control no-transform
-    to the same resource and check that the second one wasn't serviced from the cache."""
-    tempesta_config = '''
+class StoringResponsesWithSetCookieHeaderNoTransformCache(TestCacheControl, SingleTest):
+    """
+    This test sends two requests to the same resource, which responds with no-transform
+    cache-control and set-cookie headers, and check that second request wasn't serviced
+    from the cache.
+    """
+
+    tempesta_config = """
         cache_fulfill * *;
-        '''
-    request_headers = {'Authorization': 'Basic dXNlcjE6cGFzc3dvcmQx'}
-    second_request_headers = {'Authorization': 'Basic dXNlcjI6cGFzc3dvcmQy'}
+        """
+    response_headers = {'Set-Cookie': 'session=1', 'Cache-control': 'no-transform'}
+    second_request_headers = {'Cookie': response_headers['Set-Cookie']}
     should_be_cached = True
     requests_to_server = 2
-    response_headers = {'Cache-control': 'no-transform'}
 
 
-class StoringResponsesToAuthenticatedRequestsPrivateCache(TestCacheControl, SingleTest):
-    """This test sends two requests with different basic authentication headers and with cache-control private
-    to the same resource and check that the second one wasn't serviced from the cache."""
-    tempesta_config = '''
+class StoringResponsesWithSetCookieHeaderPrivateCache(TestCacheControl, SingleTest):
+    """
+    This test sends two requests to the same resource, which responds with private cache-control
+    and set-cookie headers, and check that second request wasn't serviced from the cache.
+    """
+
+    tempesta_config = """
         cache_fulfill * *;
-        '''
-    request_headers = {'Authorization': 'Basic dXNlcjE6cGFzc3dvcmQx'}
-    second_request_headers = {'Authorization': 'Basic dXNlcjI6cGFzc3dvcmQy'}
+        """
+    response_headers = {'Set-Cookie': 'session=1', 'Cache-control': 'private'}
+    second_request_headers = {'Cookie': response_headers['Set-Cookie']}
     should_be_cached = True
     requests_to_server = 2
-    response_headers = {'Cache-control': 'private'}
 
 
-class StoringResponsesToAuthenticatedRequestsProxyRevalidateCache(TestCacheControl, SingleTest):
-    """This test sends two requests with different basic authentication headers and with cache-control proxy-revalidate
-    to the same resource and check that the second one was serviced from the cache."""
-    tempesta_config = '''
+class StoringResponsesWithSetCookieHeaderProxyRevalidateCache(TestCacheControl, SingleTest):
+    """
+    This test sends two requests to the same resource, which responds with proxy-revalidate
+    cache-control and set-cookie headers, and check that second request was serviced
+    from the cache.
+    """
+
+    tempesta_config = """
         cache_fulfill * *;
-        '''
-    request_headers = {'Authorization': 'Basic dXNlcjE6cGFzc3dvcmQx'}
-    second_request_headers = {'Authorization': 'Basic dXNlcjI6cGFzc3dvcmQy'}
+        """
+    response_headers = {'Set-Cookie': 'session=1', 'Cache-control': 'proxy-revalidate, max-age=1'}
+    second_request_headers = {'Cookie': response_headers['Set-Cookie']}
     should_be_cached = True
     sleep_interval = None
     requests_to_server = 1
-    response_headers = {'Cache-control': 'proxy-revalidate, max-age=1'}
 
 
-class StoringResponsesToAuthenticatedRequestsProxyRevalidateCache2(TestCacheControl, SingleTest):
-    """This test sends two requests with different basic authentication headers and with cache-control proxy-revalidate
-    to the same resource and check that the second one wasn't serviced from the cache."""
-    tempesta_config = '''
+class StoringResponsesWithSetCookieHeaderMaxAgeCache(TestCacheControl, SingleTest):
+    """
+    This test sends two requests to the same resource, which responds with max-age cache-control
+    and set-cookie headers, and check that second request wasn't serviced from the cache.
+    """
+
+    tempesta_config = """
         cache_fulfill * *;
-        '''
-    request_headers = {'Authorization': 'Basic dXNlcjE6cGFzc3dvcmQx'}
-    second_request_headers = {'Authorization': 'Basic dXNlcjI6cGFzc3dvcmQy'}
-    should_be_cached = True
-    sleep_interval = 1.5
-    requests_to_server = 2
-    response_headers = {'Cache-control': 'proxy-revalidate, max-age=1'}
-
-
-class StoringResponsesToAuthenticatedRequestsMaxAgeCache(TestCacheControl, SingleTest):
-    """This test sends two requests with different basic authentication headers and with cache-control max-age
-    to the same resource and check that the second one wasn't serviced from the cache."""
-    tempesta_config = '''
-        cache_fulfill * *;
-        '''
-    request_headers = {'Authorization': 'Basic dXNlcjE6cGFzc3dvcmQx'}
-    second_request_headers = {'Authorization': 'Basic dXNlcjI6cGFzc3dvcmQy'}
+        """
+    response_headers = {'Set-Cookie': 'session=1', 'Cache-control': 'max-age=1'}
+    second_request_headers = {'Cookie': response_headers['Set-Cookie']}
     should_be_cached = True
     requests_to_server = 2
-    response_headers = {'Cache-control': 'max-age=1'}
 
 
-class StoringResponsesToAuthenticatedRequestsSMaxAgeCache(TestCacheControl, SingleTest):
-    """This test sends two requests with different basic authentication headers and with cache-control s-maxage
-    to the same resource and check that the second one was serviced from the cache."""
-    tempesta_config = '''
+class StoringResponsesWithSetCookieHeaderSMaxAgeCache(TestCacheControl, SingleTest):
+    """
+    This test sends two requests to the same resource, which responds with s-maxage
+    cache-control and set-cookie headers, and check that second request was serviced
+    from the cache.
+    """
+
+    tempesta_config = """
         cache_fulfill * *;
-        '''
-    request_headers = {'Authorization': 'Basic dXNlcjE6cGFzc3dvcmQx'}
-    second_request_headers = {'Authorization': 'Basic dXNlcjI6cGFzc3dvcmQy'}
+        """
+    response_headers = {'Set-Cookie': 'session=1', 'Cache-control': 's-maxage=1'}
+    second_request_headers = {'Cookie': response_headers['Set-Cookie']}
     should_be_cached = True
     sleep_interval = None
     requests_to_server = 1
-    response_headers = {'Cache-control': 's-maxage=1'}
-
-
-class StoringResponsesToAuthenticatedRequestsSMaxAgeCache2(TestCacheControl, SingleTest):
-    """This test sends two requests with different basic authentication headers and with cache-control s-maxage
-    to the same resource and check that the second one wasn't serviced from the cache."""
-    tempesta_config = '''
-        cache_fulfill * *;
-        '''
-    request_headers = {'Authorization': 'Basic dXNlcjE6cGFzc3dvcmQx'}
-    second_request_headers = {'Authorization': 'Basic dXNlcjI6cGFzc3dvcmQy'}
-    should_be_cached = True
-    sleep_interval = 1.5
-    requests_to_server = 2
-    response_headers = {'Cache-control': 's-maxage=1'}

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -339,6 +339,18 @@
         {
             "name" : "cache.test_cache_control.CacheLocationNonidempotentHeadBypass",
             "reason": "Disabled by issue #1663"
+        },
+        {
+            "name": "cache.test_cache_control.StoringResponsesWithSetCookieHeaderMaxAgeCache",
+            "reason": "Disabled by issue #1678"
+        },
+        {
+            "name": "cache.test_cache_control.StoringResponsesWithSetCookieHeaderNoTransformCache",
+            "reason": "Disabled by issue #1678"
+        },
+        {
+            "name": "cache.test_cache_control.StoringResponsesWithSetCookieHeaderDefaultCache",
+            "reason": "Disabled by issue #1678"
         }
     ]
 }

--- a/tox.ini
+++ b/tox.ini
@@ -9,11 +9,21 @@ max-awaits = 8
 max-local-variables = 10
 max-cognitive-score = 15
 
-ignore = WPS100, N805, WPS430, WPS420, WPS442, WPS410, WPS437
-  #  WPS100 Found wrong module name
-  #  N805 first argument of a method should be named 'self'
-  #  WPS430 Found nested function
-  #  WPS420 Found wrong keyword: global
-  #  WPS442 Found outer scope names shadowing
-  #  WPS410 Found wrong metadata variable
-  #  WPS437 Found protected attribute usage:
+ignore = D205,D400,N805,W293,W503,WPS100,WPS118,WPS202,WPS226,WPS305,WPS323,WPS410,WPS420,WPS430,WPS437,WPS442,WPS601
+;  D205 1 blank line required between summary line and description
+;  D400 First line should end with a period
+;  N805 first argument of a method should be named 'self'
+;  W293 blank line contains whitespace
+;  W503 line break before binary operator
+;  WPS100 Found wrong module name
+;  WPS118 Found too long name
+;  WPS202 Found too many module members: 91 > 7
+;  WPS226 Found string literal over-use
+;  WPS305 Found `f` string
+;  WPS323 Found `%` string formatting
+;  WPS410 Found wrong metadata variable
+;  WPS420 Found wrong keyword: global
+;  WPS430 Found nested function
+;  WPS437 Found protected attribute usage:
+;  WPS442 Found outer scope names shadowing
+;  WPS601 Found shadowed class attribute


### PR DESCRIPTION
I added functional tests for issue #167. And i did formatting `test_cache_control.py` as required by linter. I didn't added docstring for old tests and methods.