### PR TITLE
Fix remote node availability check

### DIFF
--- a/helpers/remote.py
+++ b/helpers/remote.py
@@ -253,7 +253,7 @@ class RemoteNode(Node):
             try:
                 res,_ = self.run_cmd("echo -n check", timeout=1)
                 tf_cfg.dbg(4, "Result = [%s]" % res)
-                if res == "check":
+                if res.decode() == "check":
                     tf_cfg.dbg(2, "Node %s is available" % self.type)
                     return True
             except Exception:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ h2>=4.0.0
 hyperframe>=6.0.0
 wemake-python-styleguide>=0.16.1
 pycodestyle==2.8.0
+requests


### PR DESCRIPTION
Can't run tests in isolated framework mode.
For Python3, `RemoteNode.wait_available` is never completes successfully:

 - `RemoteNode.run_cmd` returns tuple of `bytes`, because subprocess stream is not in text mode: https://docs.python.org/3/library/subprocess.html#subprocess.Popen.communicate
 - `RemoteNode.wait_available` bytes to str comparison `b"check" != "check"` is always False (was True for Py2)
