### PR TITLE
read_chunked_body: fixed chunked body trailer parsing

### DIFF
--- a/helpers/deproxy.py
+++ b/helpers/deproxy.py
@@ -312,6 +312,17 @@ class HttpMessage(object, metaclass=abc.ABCMeta):
             except:
                 raise ParseError('Error in chunked body')
 
+        """
+        if trailer is not present don't pass the last CRLF to parse_trailer,
+        we must append it to body
+        """
+        pos = stream.tell()
+        end = stream.read(2)
+        if end and end.rstrip('\r\n') == '':
+            self.body += end
+            return
+
+        stream.seek(pos)
         # Parsing trailer will eat last CRLF
         self.parse_trailer(stream)
 

--- a/selftests/test_responses.py
+++ b/selftests/test_responses.py
@@ -256,7 +256,7 @@ class ParseBody(unittest.TestCase):
         self.try_body(PARSE_CHUNKED_EMPTY, '0\n\n')
 
     def test_chunked(self):
-        self.try_body(PARSE_CHUNKED, self.chunked_body())
+        self.try_body(PARSE_CHUNKED, self.chunked_body() + '\n')
 
     def test_chunked_and_trailer(self):
         self.try_body(PARSE_CHUNKED_AND_TRAILER, self.chunked_body(),


### PR DESCRIPTION
Now we try to determine end of chunked body before pass stream to parse_trailer and append the final CRLF to the body. When the final CRLF passed to parse_trailer, it will be dropped this implies chunked body without trailer will be invalid.