### PR TITLE
Subject Alternative Name certificates

### DIFF
--- a/framework/x509.py
+++ b/framework/x509.py
@@ -50,7 +50,7 @@ class CertGenerator(object):
         self.cert = None
         self.pkey = None
         # Subject Alternative Name field: list of additional host names
-        self.san: list[str] = []
+        self.san = []
         if default:
             self.generate()
 

--- a/framework/x509.py
+++ b/framework/x509.py
@@ -49,6 +49,8 @@ class CertGenerator(object):
         self.format = 'pem'
         self.cert = None
         self.pkey = None
+        # Subject Alternative Name field: list of additional host names
+        self.san: list[str] = []
         if default:
             self.generate()
 
@@ -137,6 +139,13 @@ class CertGenerator(object):
         ).public_key(
             self.pkey.public_key(),
         )
+        if self.san:
+            builder = builder.add_extension(
+                x509.SubjectAlternativeName(
+                    [x509.DNSName(name) for name in self.san],
+                ),
+                critical=False
+            )
         self.cert = builder.sign(
             self.pkey,
             self.__hash(),

--- a/helpers/dmesg.py
+++ b/helpers/dmesg.py
@@ -53,14 +53,14 @@ class DmesgFinder(object):
     def _warn_match(self, warn_str):
         return re.findall(warn_str, self.log.decode())
 
-    def warn_count(self, warn_str: str) -> int:
+    def warn_count(self, warn_str):
         """Count occurrences of given string in system log. Normally used to
         count warnings during test.
         """
         self.update()
         return self._warn_count(warn_str)
 
-    def warn_match(self, warn_str: str) -> list[str]:
+    def warn_match(self, warn_str):
         """Returns list of occurrences of given string in system log."""
         self.update()
         return self._warn_match(warn_str)

--- a/helpers/dmesg.py
+++ b/helpers/dmesg.py
@@ -48,15 +48,22 @@ class DmesgFinder(object):
         print(self.log)
 
     def _warn_count(self, warn_str):
-        match = re.findall(warn_str, self.log.decode())
-        return len(match)
+        return len(self._warn_match(warn_str))
 
-    def warn_count(self, warn_str):
+    def _warn_match(self, warn_str):
+        return re.findall(warn_str, self.log.decode())
+
+    def warn_count(self, warn_str: str) -> int:
         """Count occurrences of given string in system log. Normally used to
         count warnings during test.
         """
         self.update()
         return self._warn_count(warn_str)
+
+    def warn_match(self, warn_str: str) -> list[str]:
+        """Returns list of occurrences of given string in system log."""
+        self.update()
+        return self._warn_match(warn_str)
 
     def msg_ratelimited(self, msg):
         """ Like previous, but returns binary found/not-found status and takes

--- a/selftests/test_x509.py
+++ b/selftests/test_x509.py
@@ -1,0 +1,44 @@
+import subprocess
+import unittest
+from pathlib import Path
+
+from framework.x509 import CertGenerator
+
+__author__ = 'Tempesta Technologies, Inc.'
+__copyright__ = 'Copyright (C) 2022 Tempesta Technologies, Inc.'
+__license__ = 'GPL2'
+
+
+class TestX509CertGenerator(unittest.TestCase):
+
+    @property
+    def cert_text(self) -> str:
+        """openssl text dump of the certificate."""
+        return subprocess.check_output([
+            'openssl', 'x509', '-text', '-noout', '-in',
+            self.cgen.get_file_paths()[0]
+        ], text=True)
+
+    def setUp(self):
+        self.cgen = CertGenerator()
+        self.remove_certs()
+
+    def tearDown(self):
+        self.remove_certs()
+
+    def remove_certs(self):
+        for path in self.cgen.get_file_paths():
+            Path(path).unlink(missing_ok=True)
+
+    def test_no_san_extentsion_in_cert_by_default(self):
+        self.cgen.generate()
+        self.assertNotIn('Subject Alternative Name', self.cert_text)
+
+    def test_san_extension_in_cert(self):
+        self.cgen.san = ['node1.tempesta-tech.com', 'node2.tempesta-tech.com']
+
+        self.cgen.generate()
+
+        cert_text = self.cert_text
+        self.assertIn('Subject Alternative Name', cert_text)
+        self.assertIn('DNS:node1.tempesta-tech.com, DNS:node2.tempesta-tech.com', cert_text)

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -370,6 +370,30 @@
             "reason": "Disable by issue #1688"
         },
         {
+            "name": "tls.test_tls_cert.TlsSniWithHttpTable",
+            "reason": "Disable by issue #1688"
+        },
+        {
+            "name": "tls.test_tls_cert.TlsSniWithHttpTableFrang",
+            "reason": "Disable by issue #1688"
+        },
+        {
+            "name": "tls.test_tls_cert.TlsSniWithHttpTableMulti",
+            "reason": "Disable by issue #1688"
+        },
+        {
+            "name": "tls.test_tls_cert.TlsSniWithHttpTableMultiH2",
+            "reason": "Disable by issue #1688"
+        },
+        {
+            "name": "tls.test_tls_cert.TlsSniWithHttpTableMultiFrang",
+            "reason": "Disable by issue #1688"
+        },
+        {
+            "name": "tls.test_tls_cert.TlsSniWithHttpTableMultiH2Frang",
+            "reason": "Disable by issue #1688"
+        },
+        {
             "name" : "tls.test_tls_handshake.TlsHandshakeTest.test_tls12_synthetic",
             "reason": "Disable by issue #154"
         },

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -366,6 +366,10 @@
             "reason": "Disable by issue #154"
         },
         {
+            "name": "tls.test_tls_cert.TlsCertSelectBySan",
+            "reason": "Disable by issue #1688"
+        },
+        {
             "name" : "tls.test_tls_handshake.TlsHandshakeTest.test_tls12_synthetic",
             "reason": "Disable by issue #154"
         },

--- a/tls/test_tls_cert.py
+++ b/tls/test_tls_cert.py
@@ -21,10 +21,10 @@ __license__ = 'GPL2'
 
 
 def generate_certificate(
-        cn: str = 'tempesta-tech.com',
-        san: list[str] = None,
-        cert_name: str = "tempesta"
-) -> CertGenerator:
+        cn = 'tempesta-tech.com',
+        san = None,
+        cert_name = "tempesta"
+):
     """Generate and upload certificate with given
     common name and  list of Subject Alternative Names.
     Name generated files as `cert_name`.crt and `cert_name`.key.
@@ -455,7 +455,7 @@ class TlsCertSelectBySan(tester.TempestaTest):
     def verbose(self):
         return tf_cfg.v_level() >= 3
 
-    def check_handshake_success(self, sni: str):
+    def check_handshake_success(self, sni):
         """Run TLS handshake with the given SNI and check it is completes successfully."""
         hs = TlsHandshake(verbose=self.verbose)
         hs.sni = [sni]
@@ -463,7 +463,7 @@ class TlsCertSelectBySan(tester.TempestaTest):
         hs._do_12_hs()
         self.assertTrue(x509_check_cn(hs.cert, 'tempesta-tech.com'))
 
-    def check_handshake_unrecognized_name(self, sni: str):
+    def check_handshake_unrecognized_name(self, sni):
         """
         Run TLS handshake with the given SNI
         and check server name is not recognised by the server.
@@ -877,7 +877,7 @@ class TlsSNIwithHttpTable(tester.TempestaTest):
         self.start_all_clients()
         self.assertTrue(self.wait_all_connections(1))
 
-    def make_request(self, host: str) -> str:
+    def make_request(self, host):
         """Make request with the specified `host` header and
         return the body of response."""
         client = self.get_client('deproxy')
@@ -990,7 +990,7 @@ class BaseTlsMultiTest(tester.TempestaTest, metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def build_requests(self, hosts: list[str]):
+    def build_requests(self, hosts):
         pass
 
     def setUp(self):
@@ -1064,7 +1064,7 @@ class TlsSNIwithHttpTableMulti(BaseTlsMultiTest):
 
     def test_alternating_access(self):
         """
-        Test for HTTP1 pipelined request: both 'example.com' and 'localhost'
+        Test for HTTP/1.1 pipelined request: both 'example.com' and 'localhost'
         vhosts are accessed in alternating order.
         """
         self.run_alterative_access()
@@ -1099,7 +1099,7 @@ class TlsSNIwithHttpTableMultiH2(BaseTlsMultiTest):
 
     def test_alternating_access(self):
         """
-        Test for HTTP1 pipelined request: both 'example.com' and 'localhost'
+        Test for HTTP/2 multiplexed requests: both 'example.com' and 'localhost'
         vhosts are accessed in alternating order.
         """
         # Ignore 'BUG tfw_stream_cache Tainted'


### PR DESCRIPTION
Tests for #212 . All tests should pass for the current Tempesta FW version.

Changes to the framework:
- new `CertGnerator` field: `san` - Subject Alternative Name extension
-  new `DmesgFinder` method: `warn_match` - get list of occurrences of given string in system log.