### PR TITLE
"wrk" does not receive results

### DIFF
--- a/framework/client.py
+++ b/framework/client.py
@@ -3,9 +3,9 @@ import os
 import multiprocessing
 
 from helpers import remote, tf_cfg, stateful
-from .templates import fill_template
 
-def _run_client(client, exit_event, resq):
+
+def _run_client(client, resq: multiprocessing.Queue):
     try:
         res = remote.client.run_cmd(client.cmd, timeout=(client.duration + 5))
     except remote.CmdError as e:
@@ -13,7 +13,7 @@ def _run_client(client, exit_event, resq):
         client.returncode = e.returncode
     resq.put(res)
     tf_cfg.dbg(3, "\tClient exit")
-    exit_event.set()
+
 
 class Client(stateful.Stateful, metaclass=abc.ABCMeta):
     """ Base class for managing HTTP benchmark utilities.
@@ -48,8 +48,6 @@ class Client(stateful.Stateful, metaclass=abc.ABCMeta):
         # Process
         self.proc = None
         self.returncode = 0
-        self.exit_event = multiprocessing.Event()
-        self.exit_event.clear()
         self.resq = multiprocessing.Queue()
         self.proc_results = None
         # List of files to be removed from remote node after client finish.
@@ -86,7 +84,7 @@ class Client(stateful.Stateful, metaclass=abc.ABCMeta):
             self.node.copy_file(name, content)
 
     def is_busy(self, verbose=True):
-        busy = not self.exit_event.is_set()
+        busy = self.proc.is_alive()
         if verbose:
             if busy:
                 tf_cfg.dbg(4, "\tClient is running")
@@ -104,10 +102,10 @@ class Client(stateful.Stateful, metaclass=abc.ABCMeta):
         self.proc = None
 
         if self.proc_results != None:
-            tf_cfg.dbg(3, '\tclient stdout:\n%s' % self.proc_results[0])
+            tf_cfg.dbg(3, '\tclient stdout:\n%s' % self.proc_results[0].decode())
 
             if len(self.proc_results[1]) > 0:
-                tf_cfg.dbg(2, '\tclient stderr:\n%s' % self.proc_results[1])
+                tf_cfg.dbg(2, '\tclient stderr:\n%s' % self.proc_results[1].decode())
 
             self.parse_out(self.proc_results[0], self.proc_results[1])
 
@@ -116,10 +114,11 @@ class Client(stateful.Stateful, metaclass=abc.ABCMeta):
     def run_start(self):
         """ Run client """
         tf_cfg.dbg(3, "Running client")
-        self.exit_event.clear()
         self.prepare()
-        self.proc = multiprocessing.Process(target = _run_client,
-                                    args=(self, self.exit_event, self.resq))
+        self.proc = multiprocessing.Process(
+            target=_run_client,
+            args=(self, self.resq)
+        )
         self.proc.start()
 
     @abc.abstractmethod
@@ -158,6 +157,5 @@ class Client(stateful.Stateful, metaclass=abc.ABCMeta):
         self.options.append('-H \'User-Agent: %s\'' % ua)
 
     def wait_for_finish(self):
-        # until we explicitly get `self.exit_event` flag set
         while self.is_busy(verbose=False):
             pass

--- a/framework/external_client.py
+++ b/framework/external_client.py
@@ -28,5 +28,5 @@ class ExternalTester(client.Client):
         return cmd
 
     def parse_out(self, stdout, stderr):
-        self.response_msg = stdout.decode()
+        self.response_msg = stdout.decode() if stdout else stderr.decode()
         return True

--- a/framework/external_client.py
+++ b/framework/external_client.py
@@ -21,10 +21,12 @@ class ExternalTester(client.Client):
     def __init__(self, cmd_args, **kwargs):
         client.Client.__init__(self, **kwargs)
         self.options = [cmd_args]
+        self.response_msg: str = None
 
     def form_command(self):
         cmd = ' '.join([self.bin] + self.options)
         return cmd
 
     def parse_out(self, stdout, stderr):
+        self.response_msg = stdout.decode()
         return True

--- a/selftests/test_framework.py
+++ b/selftests/test_framework.py
@@ -270,7 +270,7 @@ server ${server_ip}:8000;
         self.assertIn(
             '403',
             curl.response_msg,
-            f'"curl" client did received {curl.response_msg} status code, and it expected 403.',
+            'HTTP response status codes mismatch',
         )
 
     def test_double_curl(self):

--- a/selftests/test_framework.py
+++ b/selftests/test_framework.py
@@ -1,11 +1,14 @@
-import time
-
-from helpers import tf_cfg, deproxy
-from framework import tester, nginx_server, deproxy_server
+""" Example tests and checking functionality of services """
 
 __author__ = 'Tempesta Technologies, Inc.'
-__copyright__ = 'Copyright (C) 2018 Tempesta Technologies, Inc.'
+__copyright__ = 'Copyright (C) 2022 Tempesta Technologies, Inc.'
 __license__ = 'GPL2'
+
+from helpers import tf_cfg, deproxy, remote
+from helpers.control import Tempesta
+from helpers.remote import CmdError
+from framework import tester, nginx_server, wrk_client, deproxy_server, external_client
+
 
 class ExampleTest(tester.TempestaTest):
     backends = [
@@ -104,41 +107,81 @@ server ${server_ip}:8000;
             'type' : 'deproxy',
             'addr' : "${server_ip}",
             'port' : '8000'
-        }
+        },
+        {
+            'id': 'curl',
+            'type': 'external',
+            'binary': 'curl',
+            'cmd_args': '-Ikf http://127.0.0.1:80/',
+        },
+        {
+            'id': 'curl_1',
+            'type': 'external',
+            'binary': 'curl',
+            'cmd_args': '-Ikf http://127.0.0.2:80/',
+        },
     ]
 
-    def test(self):
-        """ Simple test """
-        nginx = self.get_server('nginx')
+    def test_wrk_client(self):
+        """ Check results for 'wrk' client """
+        nginx: nginx_server.Nginx = self.get_server('nginx')
         nginx.start()
         self.start_tempesta()
         self.assertTrue(nginx.wait_for_connections(timeout=1))
-        wrk1 = self.get_client('wrk_1')
+        wrk1: wrk_client.Wrk = self.get_client('wrk_1')
         wrk1.start()
         self.wait_while_busy(wrk1)
+        wrk1.stop()
 
-    def test2(self):
-        """ Simple test 2 """
-        nginx = self.get_server('nginx')
+        self.assertNotEqual(
+            0,
+            wrk1.requests,
+            msg='"wrk" client has not sent requests or received results.',
+        )
+
+    def test_double_wrk(self):
+        """ Check the parallel work of two "wrk" clients """
+        nginx: nginx_server.Nginx = self.get_server('nginx')
         nginx.start()
         self.start_tempesta()
         self.assertTrue(nginx.wait_for_connections(timeout=1))
-        wrk1 = self.get_client('wrk_1')
-        wrk2 = self.get_client('wrk_2')
+
+        wrk1: wrk_client.Wrk = self.get_client('wrk_1')
+        wrk2: wrk_client.Wrk = self.get_client('wrk_2')
+
         wrk1.start()
         wrk2.start()
+        wrk1_cmd = f'ps -fp {wrk1.proc.pid}'
+        wrk2_cmd = f'ps -fp {wrk2.proc.pid}'
+        remote.client.run_cmd(wrk1_cmd)
+        remote.client.run_cmd(wrk2_cmd)
         self.wait_while_busy(wrk1, wrk2)
+        self.assertRaises(CmdError, remote.client.run_cmd, wrk1_cmd)
+        self.assertRaises(CmdError, remote.client.run_cmd, wrk2_cmd)
+        wrk1.stop()
+        wrk2.stop()
 
     def test_deproxy_srv(self):
-        """ Simple test with deproxy server """
-        deproxy = self.get_server('deproxy')
+        """ Simple test with deproxy server and check tempesta stats"""
+        deproxy: deproxy_server.StaticDeproxyServer = self.get_server('deproxy')
         deproxy.start()
         self.start_tempesta()
         self.deproxy_manager.start()
         self.assertTrue(deproxy.wait_for_connections(timeout=1))
-        wrk1 = self.get_client('wrk_1')
+
+        wrk1: wrk_client.Wrk = self.get_client('wrk_1')
         wrk1.start()
         self.wait_while_busy(wrk1)
+        wrk1.stop()
+
+        tempesta: Tempesta = self.get_tempesta()
+        tempesta.get_stats()
+
+        self.assertAlmostEqual(
+            len(deproxy.requests),
+            tempesta.stats.srv_msg_received,
+            msg='Count of server request does not match tempesta stats.'
+        )
 
     def test_deproxy_srv_direct(self):
         """ Simple test with deproxy server """
@@ -148,6 +191,7 @@ server ${server_ip}:8000;
         wrk0 = self.get_client('wrk_0')
         wrk0.start()
         self.wait_while_busy(wrk0)
+        wrk0.stop()
 
     def test_deproxy_client(self):
         """ Simple test with deproxy client """
@@ -210,3 +254,55 @@ server ${server_ip}:8000;
         send = deproxy.Response(dsrv.response)
         send.set_expected()
         self.assertEqual(cl.last_response, send)
+
+    def test_curl(self):
+        """  Check results for 'curl' client """
+        nginx: nginx_server.Nginx = self.get_server('nginx')
+        nginx.start()
+        self.start_tempesta()
+        self.assertTrue(nginx.wait_for_connections(timeout=1))
+
+        curl: external_client.ExternalTester = self.get_client('curl')
+        curl.start()
+        self.wait_while_busy(curl)
+        curl.stop()
+
+        self.assertIn(
+            '403',
+            curl.response_msg,
+            f'"curl" client did received {curl.response_msg} status code, and it expected 403.',
+        )
+
+    def test_double_curl(self):
+        """ Check the parallel work of two "curl" clients """
+        nginx: nginx_server.Nginx = self.get_server('nginx')
+        nginx.start()
+        self.start_tempesta()
+        self.assertTrue(nginx.wait_for_connections(timeout=1))
+
+        curl: external_client.ExternalTester = self.get_client('curl')
+        curl1: external_client.ExternalTester = self.get_client('curl_1')
+
+        curl.start()
+        curl1.start()
+        curl_cmd = f'ps -fp {curl.proc.pid}'
+        curl1_cmd = f'ps -fp {curl1.proc.pid}'
+        remote.client.run_cmd(curl_cmd)
+        remote.client.run_cmd(curl1_cmd)
+        self.wait_while_busy(curl, curl1)
+        self.assertRaises(CmdError, remote.client.run_cmd, curl_cmd)
+        self.assertRaises(CmdError, remote.client.run_cmd, curl1_cmd)
+        curl.stop()
+        curl1.stop()
+
+        err_msg = '"Curl" client did not response message.'
+        self.assertNotEqual(
+            None,
+            curl.response_msg,
+            err_msg,
+        )
+        self.assertNotEqual(
+            None,
+            curl1.response_msg,
+            err_msg,
+        )

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -142,26 +142,6 @@
             "reason" : "Disabled by issue #73"
         },
         {
-            "name" : "selftests.test_framework.ExampleTest.test",
-            "reason" : "Disabled by issue #73"
-        },
-        {
-            "name" : "selftests.test_framework.ExampleTest.test2",
-            "reason" : "Disabled by issue #73"
-        },
-        {
-            "name" : "selftests.test_framework.ExampleTest.test_deproxy_client",
-            "reason" : "Disabled by issue #73"
-        },
-        {
-            "name" : "selftests.test_framework.ExampleTest.test_deproxy_srv",
-            "reason" : "Disabled by issue #73"
-        },
-        {
-            "name" : "selftests.test_framework.ExampleTest.test_deproxy_srvclient",
-            "reason" : "Disabled by issue #73"
-        },
-        {
             "name" : "http2_general",
             "reason" : "Disabled by issue #261"
         },


### PR DESCRIPTION
I fixed the issue with get results for the 'wrk' client. 
I changed the expectations of clients 'wrk' and 'curl'. Now we wait for end of life for client process.
I added 'wrk' and 'curl' client work tests to 'selftests' and enabled them.