### PR TITLE
fixing large data hangs in stdout

### DIFF
--- a/multiple_listeners/test_mixed.py
+++ b/multiple_listeners/test_mixed.py
@@ -161,14 +161,13 @@ class TestMixedListeners(tester.TempestaTest):
         client: ExternalTester = self.get_client(curl_client_id)
         client.start()
         self.wait_while_busy(client)
-        response = client.resq.get(True, 1)
-        if response[0].decode():
+        client.stop()
+        if client.response_msg:
             tf_cfg.dbg(4, f"\t{client.options[0]} request received response")
         else:
             tf_cfg.dbg(4, f"\t{client.options[0]} request did not receive response")
         client.stop()
-        self.wait_while_busy(client)
-        return response[0].decode()
+        return client.response_msg
 
     def check_curl_response(self, response: str, fail=False):
         """

--- a/multiple_listeners/test_multiple_listening.py
+++ b/multiple_listeners/test_multiple_listening.py
@@ -1615,10 +1615,10 @@ class TestMultipleListening(tester.TempestaTest):
                     cli[ID],
                 )
                 self.wait_while_busy(h2spec)
-                response_h2spec = h2spec.resq.get(True, 1)[0].decode()
+                h2spec.stop()
                 self.assertIn(
                     H2SPEC_OK,
-                    response_h2spec,
+                    h2spec.response_msg,
                 )
 
             # curl
@@ -1628,9 +1628,9 @@ class TestMultipleListening(tester.TempestaTest):
                 )
                 curl.start()
                 self.wait_while_busy(curl)
-                response = curl.resq.get(True, 1)[0].decode()
+                curl.stop()
                 self.assertIn(
                     STATUS_OK,
-                    response,
+                    curl.response_msg,
                 )
                 curl.stop()

--- a/multiple_listeners/test_on_the_fly.py
+++ b/multiple_listeners/test_on_the_fly.py
@@ -178,9 +178,8 @@ class TestOnTheFly(tester.TempestaTest):
         curl: ExternalTester = self.get_client(curl_client_id)
         curl.start()
         self.wait_while_busy(curl)
-        response = curl.resq.get(True, 1)[0].decode()
         curl.stop()
         self.assertIn(
             STATUS_OK,
-            response,
+            curl.response_msg,
         )


### PR DESCRIPTION
The problem of hangs is described in [Programming guidelines](https://docs.python.org/3/library/multiprocessing.html#programming-guidelines). I changed expectation for curl and wrk client, but because of [multithreading/multiprocessing semantics](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Queue.empty) we should not receive data from a queue before calling the `stop()` method.