### PR TITLE
Add CurlClient: wrapper to manage cURL

### DIFF
--- a/framework/client.py
+++ b/framework/client.py
@@ -77,6 +77,7 @@ class Client(stateful.Stateful, metaclass=abc.ABCMeta):
         self.requests = 0
         self.rate = -1
         self.errors = 0
+        self.statuses = {}
 
     def cleanup(self):
         for f in self.cleanup_files:

--- a/framework/client.py
+++ b/framework/client.py
@@ -59,6 +59,9 @@ class Client(stateful.Stateful, metaclass=abc.ABCMeta):
         # Stateful
         self.stop_procedures = [self.__on_finish]
 
+    def __str__(self):
+        return self.bin
+
     def set_uri(self, uri):
         """ For some clients uri is an optional parameter, e.g. for Siege.
         They use file with list of uris instead. Don't force clients to use

--- a/framework/curl_client.py
+++ b/framework/curl_client.py
@@ -58,8 +58,9 @@ class CurlResponse:
 
 @dataclass
 class CurlArguments:
-    """cURL client accepted arguments (fields)."""
-
+    """Interface class for cURL client.
+    Contains all accepted arguments (fields) supported by `CurlClient`.
+    """
     server_addr: str
     uri: str = "/"
     cmd_args: str = ""
@@ -72,6 +73,11 @@ class CurlArguments:
     ssl: bool = False
     http2: bool = False
     insecure: bool = True
+
+    @classmethod
+    def get_kwargs(cls) -> list[str]:
+        """Returns list of `CurlClient` argument names."""
+        return list(cls.__dataclass_fields__.keys())
 
 
 class CurlClient(CurlArguments, client.Client):

--- a/framework/curl_client.py
+++ b/framework/curl_client.py
@@ -18,6 +18,7 @@ __license__ = "GPL2"
 
 # Expected `curl --version`.
 # This value could be overriden by the 'Client.curl_version' config variable.
+# When updating, version in `setup.sh` should also be updated.
 CURL_BINARY_VERSION = "7.85.0"
 
 
@@ -301,6 +302,7 @@ class CurlClient(CurlArguments, client.Client):
         )
 
     def _parse_binary_version(self, version: str) -> str:
-        # Version string example:
+        # Version string examples:
         # "libcurl/7.85.0 OpenSSL/3.0.2 zlib/1.2.11 nghttp2/1.43.0"
-        return version.split()[0].split("/")[1]
+        # "libcurl/7.85.0-DEV OpenSSL/1.1.1f zlib/1.2.11"
+        return version.split()[0].split("/")[1].split("-")[0]

--- a/framework/curl_client.py
+++ b/framework/curl_client.py
@@ -1,0 +1,173 @@
+import email
+import io
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+from helpers import tf_cfg
+from . import client
+
+__author__ = "Tempesta Technologies, Inc."
+__copyright__ = "Copyright (C) 2022 Tempesta Technologies, Inc."
+__license__ = "GPL2"
+
+
+@dataclass
+class CurlResponse:
+    """Parsed cURL response."""
+
+    headers_dump: bytes  # status line + headers
+    stdout_raw: bytes  # stdout bytes
+    stderr_raw: bytes  # stderr bytes
+    status: int = None  # parsed HTTP status code
+    proto: str = None  # parsed HTTP potocol version
+    headers: dict = None  # parsed headers with lowercase names
+
+    @property
+    def stdout(self) -> str:
+        """Decoded stdout."""
+        return self.stdout_raw.decode()
+
+    @property
+    def stderr(self) -> str:
+        """Decoded stderr."""
+        return self.stderr_raw.decode()
+
+    @property
+    def multi_headers(self):
+        """Parsed headers with lowercase names and list of values."""
+        return dict(self._multi_headers)
+
+    def __post_init__(self):
+        try:
+            response_line, headers = self.headers_dump.decode().split("\r\n", 1)
+        except ValueError:
+            tf_cfg.dbg(1, f"Unexpected headers dump: {self.headers_dump}")
+        else:
+            message = email.message_from_file(io.StringIO(headers))
+            match = re.match(r"HTTP/([.12]+) (\d+)", response_line)
+            self.proto = match.group(1)
+            self.status = int(match.group(2))
+
+            self._multi_headers = defaultdict(list)
+            for k, v in ((k.lower(), v) for k, v in message.items()):
+                self._multi_headers[k].append(v)
+            self.headers = {k: v[-1] for k, v in self.multi_headers.items()}
+
+
+@dataclass
+class CurlArguments:
+    """cURL client accepted arguments (fields)."""
+
+    server_addr: str
+    uri: str = "/"
+    cmd_args: str = ""
+    data: str = ""
+    headers: dict = None
+    dump_headers: int = True
+    disable_output: bool = False
+    save_cookies: bool = False
+    load_cookies: bool = False
+    ssl: bool = False
+    http2: bool = False
+    insecure: bool = True
+
+
+class CurlClient(CurlArguments, client.Client):
+    """Wrapper to manage cURL."""
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            **{k: v for k, v in kwargs.items() if k in CurlArguments.__match_args__}
+        )
+        client.Client.__init__(
+            self,
+            binary="curl",
+            server_addr=kwargs["server_addr"],
+            uri=self.uri,
+            ssl=self.ssl or self.http2,
+        )
+        self.options = [self.cmd_args] if self.cmd_args else []
+        self.responses = []
+        self.statuses = defaultdict(lambda: 0)
+
+    @property
+    def cookie_jar_path(self):
+        return Path(self.workdir) / "curl-default.jar"
+
+    @property
+    def output_path(self):
+        return Path(self.workdir) / "curl-output"
+
+    @property
+    def headers_dump_path(self):
+        return Path(self.workdir) / "curl-default.hdr"
+
+    @property
+    def last_response(self) -> CurlResponse:
+        return (self.responses or [None])[-1]
+
+    def clear_cookies(self):
+        """Remove the cookies jar of previous runs."""
+        self.cookie_jar_path.unlink(missing_ok=True)
+
+    def form_command(self):
+        options = ["--no-progress-meter", '--write-out "%{json}"']
+
+        if self.dump_headers:
+            options.append(f"--dump-header '{self.headers_dump_path}'")
+
+        if self.disable_output:
+            options.append(f"--silent --show-error --output /dev/null")
+        else:
+            options.append(f"--output '{self.output_path}'")
+
+        if self.save_cookies:
+            options.append(f"--cookie-jar '{self.cookie_jar_path}'")
+        if self.load_cookies:
+            options.append(f"--cookie '{self.cookie_jar_path}'")
+
+        for header, value in (self.headers or {}).items():
+            options.append(f"--header '{header}: {value}'")
+
+        if self.data:
+            options.append(f"--data '{self.data}'")
+
+        if self.http2:
+            options.append("--http2-prior-knowledge")
+        else:
+            options.append("--http1.1")
+
+        if self.ssl and self.insecure:
+            options.append("--insecure")
+
+        cmd = " ".join([self.bin] + options + self.options + [f"'{self.uri}'"])
+        tf_cfg.dbg(3, f"Curl command formatted: {cmd}")
+        return cmd
+
+    def parse_out(self, stdout, stderr):
+        self.requests += 1
+        if self.dump_headers:
+            for dump in filter(None, self._read_headers_dump().split(b"\r\n\r\n")):
+
+                response = CurlResponse(
+                    headers_dump=dump,
+                    stdout_raw=self._read_output(),
+                    stderr_raw=stderr,
+                )
+                if response.proto and response.proto != ("2" if self.http2 else "1.1"):
+                    raise Exception(
+                        f"Unexpected HTTP version response: {response.proto}"
+                    )
+                self.responses.append(response)
+                self.statuses[response.status] += 1
+        return True
+
+    def _read_headers_dump(self) -> bytes:
+        with self.headers_dump_path.open("rb") as f:
+            return f.read()
+
+    def _read_output(self):
+        with self.output_path.open("rb") as f:
+            return f.read()

--- a/framework/curl_client.py
+++ b/framework/curl_client.py
@@ -87,6 +87,7 @@ class CurlArguments:
     ssl: bool = False
     http2: bool = False
     insecure: bool = True
+    parallel: int = None
 
     @classmethod
     def get_kwargs(cls) -> list[str]:
@@ -113,6 +114,7 @@ class CurlClient(CurlArguments, client.Client):
       ssl (bool): use SSL/TLS for the connection
       http2 (bool): use HTTP version 2
       insecure (bool): Ignore SSL certificate errors. Enabled by default.
+      parallel (int): Enable parallel mode, with maximum <int> simultaneous transfers
     """
 
     def __init__(self, **kwargs):
@@ -201,6 +203,11 @@ class CurlClient(CurlArguments, client.Client):
 
         if self.ssl and self.insecure:
             options.append("--insecure")
+
+        if self.parallel:
+            options.append("--parallel")
+            options.append("--parallel-immediate")
+            options.append(f"--parallel-max {self.parallel}")
 
         cmd = " ".join([self.bin] + options + self.options + [f"'{self.uri}'"])
         tf_cfg.dbg(3, f"Curl command formatted: {cmd}")

--- a/framework/curl_client.py
+++ b/framework/curl_client.py
@@ -263,7 +263,9 @@ class CurlClient(CurlArguments, client.Client):
             except json.JSONDecodeError:
                 tf_cfg.dbg(1, "Error: can't decode cURL JSON stats.")
             else:
-                if self.last_stats:
+                if self.last_stats or (
+                    stderr and b"unknown --write-out variable: 'json'" in stderr
+                ):
                     self._check_binary_version()
         return True
 

--- a/framework/curl_client.py
+++ b/framework/curl_client.py
@@ -96,7 +96,7 @@ class CurlArguments:
     parallel: int = None
 
     @classmethod
-    def get_kwargs(cls) -> list[str]:
+    def get_kwargs(cls) -> List[str]:
         """Returns list of `CurlClient` supported argument names."""
         return list(cls.__dataclass_fields__.keys())
 
@@ -138,7 +138,7 @@ class CurlClient(CurlArguments, client.Client):
         self._responses = []
         self._stats = []
         self._statuses = defaultdict(lambda: 0)
-        self._output_delimeter = "\n"
+        self._output_delimeter = "-===curl-transfer===-"
 
     @property
     def responses(self) -> List[CurlResponse]:

--- a/framework/tester.py
+++ b/framework/tester.py
@@ -176,7 +176,7 @@ class TempestaTest(unittest.TestCase):
     def __create_client_curl(self, client):
         # extract arguments that are supported by cURL client
         kwargs = {k: client[k] for k in curl_client.CurlArguments.get_kwargs() if k in client}
-        kwargs['server_addr'] = fill_template(
+        kwargs['addr'] = fill_template(
             client.get('addr', '${tempesta_ip}'),  # Address is Tempesta IP by default
             client
         )

--- a/framework/tester.py
+++ b/framework/tester.py
@@ -174,9 +174,10 @@ class TempestaTest(unittest.TestCase):
         return ext_client
 
     def __create_client_curl(self, client):
-        kwargs = {k: client[k] for k in curl_client.CurlClient.__match_args__ if k in client}
+        # extract arguments that are supported by cURL client
+        kwargs = {k: client[k] for k in curl_client.CurlArguments.get_kwargs() if k in client}
         kwargs['server_addr'] = fill_template(
-            client.get('addr', '${tempesta_ip}'),  # Tempesta IP by default
+            client.get('addr', '${tempesta_ip}'),  # Address is Tempesta IP by default
             client
         )
         kwargs['cmd_args'] = fill_template(client.get('cmd_args', ''), client)

--- a/framework/tester.py
+++ b/framework/tester.py
@@ -4,10 +4,11 @@ import time
 
 from helpers import control, tf_cfg, dmesg, remote
 
-import framework.wrk_client as wrk_client
+import framework.curl_client as curl_client
 import framework.deproxy_client as deproxy_client
 import framework.deproxy_manager as deproxy_manager
 import framework.external_client as external_client
+import framework.wrk_client as wrk_client
 
 from framework.templates import fill_template, populate_properties
 
@@ -172,6 +173,16 @@ class TempestaTest(unittest.TestCase):
                                                     uri=None)
         return ext_client
 
+    def __create_client_curl(self, client):
+        kwargs = {k: client[k] for k in curl_client.CurlClient.__match_args__ if k in client}
+        kwargs['server_addr'] = fill_template(
+            client.get('addr', '${tempesta_ip}'),  # Tempesta IP by default
+            client
+        )
+        kwargs['cmd_args'] = fill_template(client.get('cmd_args', ''), client)
+        curl = curl_client.CurlClient(**kwargs)
+        return curl
+
     def __create_client(self, client):
         populate_properties(client)
         ssl = client.setdefault('ssl', False)
@@ -189,6 +200,8 @@ class TempestaTest(unittest.TestCase):
             self.__clients[cid].set_rps(client.get('rps', 0))
         elif client['type'] == 'wrk':
             self.__clients[cid] = self.__create_client_wrk(client, ssl)
+        elif client['type'] == 'curl':
+            self.__clients[cid] = self.__create_client_curl(client)
         elif client['type'] == 'external':
             self.__clients[cid] = self.__create_client_external(client)
 
@@ -348,9 +361,9 @@ class TempestaTest(unittest.TestCase):
 
         for item in items:
             if item.is_running():
-                tf_cfg.dbg(4, f'\tClient "{item.options[0]}" wait for finish ')
+                tf_cfg.dbg(4, f'\tClient "{item}" wait for finish ')
                 item.wait_for_finish()
-                tf_cfg.dbg(4, f'\tWaiting for client "{item.options[0]}" is completed')
+                tf_cfg.dbg(4, f'\tWaiting for client "{item}" is completed')
 
     # Should replace all duplicated instances of wait_all_connections
     def wait_all_connections(self, tmt=1):

--- a/selftests/test_curl_client.py
+++ b/selftests/test_curl_client.py
@@ -125,6 +125,12 @@ class TestCurlClient(tester.TempestaTest):
             "ssl": True,
             "insecure": False,
         },
+        {
+            "id": "parallel",
+            "type": "curl",
+            "uri": "/[1-10]",
+            "parallel": 2,
+        },
     ]
 
     tempesta = {
@@ -264,3 +270,10 @@ class TestCurlClient(tester.TempestaTest):
         request = self.get_server("deproxy").last_request
         self.assertEqual(request.method, "POST")
         self.assertEqual(request.body, "param1=1&param2=2")
+
+    def test_parallel_mod_enabled(self):
+        client = self.get_client("parallel")
+        server = self.get_server("deproxy")
+        response = self.get_response(client)
+        self.assertIn("--parallel-max 2", client.form_command())
+        self.assertEqual(len(server.requests), 10)

--- a/selftests/test_curl_client.py
+++ b/selftests/test_curl_client.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 import unittest
 
 from framework import tester
-from framework.curl_client import CurlClient, CurlResponse
+from framework.curl_client import CurlArguments, CurlClient, CurlResponse
 
 __author__ = "Tempesta Technologies, Inc."
 __copyright__ = "Copyright (C) 2022 Tempesta Technologies, Inc."
@@ -23,6 +23,13 @@ server: Tempesta FW/pre-0.7.0\r
 \r
 """
 
+
+class TestCurlArguments(unittest.TestCase):
+
+    def test_kwargs_returned(self):
+        kwargs = CurlArguments.get_kwargs()
+        self.assertIn('server_addr', kwargs)
+        self.assertFalse([arg for arg in kwargs if arg.startswith('_')])
 
 class TestCurlClientParsing(unittest.TestCase):
     def test_initialized(self):

--- a/selftests/test_curl_client.py
+++ b/selftests/test_curl_client.py
@@ -3,6 +3,7 @@ import unittest
 
 from framework import tester
 from framework.curl_client import CurlArguments, CurlClient, CurlResponse
+from helpers import tf_cfg
 
 __author__ = "Tempesta Technologies, Inc."
 __copyright__ = "Copyright (C) 2022 Tempesta Technologies, Inc."
@@ -160,6 +161,11 @@ class TestCurlClient(tester.TempestaTest):
         self.wait_while_busy(client)
         client.stop()
         return client.last_response
+
+    def test_check_curl_binary_version(self):
+        client = self.get_client("default")
+        self.get_response(client)
+        client._check_binary_version()
 
     def test_default_request_completed(self):
         client = self.get_client("default")

--- a/selftests/test_curl_client.py
+++ b/selftests/test_curl_client.py
@@ -169,6 +169,10 @@ class TestCurlClient(tester.TempestaTest):
         self.assertFalse(response.stderr)
         self.assertEqual(response.stdout, "test")
         self.assertEqual(response.proto, "1.1")
+        with self.subTest("stats parsed"):
+            self.assertEqual(len(client.stats), 1)
+            self.assertFalse(client.last_stats["errormsg"])
+            self.assertGreaterEqual(client.last_stats["time_total"], 0)
 
     def test_ssl_request_completed(self):
         client = self.get_client("ssl")
@@ -261,7 +265,7 @@ class TestCurlClient(tester.TempestaTest):
     def test_certificate_error(self):
         client = self.get_client("check_cert")
         response = self.get_response(client)
-        self.assertFalse(response)
+        self.assertTrue(client.last_stats["errormsg"])
 
     def test_data_posted(self):
         client = self.get_client("post")
@@ -277,3 +281,7 @@ class TestCurlClient(tester.TempestaTest):
         response = self.get_response(client)
         self.assertIn("--parallel-max 2", client.form_command())
         self.assertEqual(len(server.requests), 10)
+
+        with self.subTest("multiple stats parsed"):
+            self.assertEqual(len(client.stats), 10)
+            self.assertGreaterEqual(client.last_stats["time_total"], 0)

--- a/selftests/test_curl_client.py
+++ b/selftests/test_curl_client.py
@@ -1,0 +1,172 @@
+from unittest.mock import patch
+import unittest
+
+from framework import tester
+from framework.curl_client import CurlClient, CurlResponse
+
+__author__ = "Tempesta Technologies, Inc."
+__copyright__ = "Copyright (C) 2022 Tempesta Technologies, Inc."
+__license__ = "GPL2"
+
+
+MULTIPLE_RESPONSES = b"""HTTP/1.1 200\r
+date: test\r
+content-length: 1\r
+via: 2.0 tempesta_fw (Tempesta FW pre-0.7.0)\r
+server: Tempesta FW/pre-0.7.0\r
+\r
+HTTP/1.1 200\r
+date: test\r
+content-length: 2\r
+via: 2.0 tempesta_fw (Tempesta FW pre-0.7.0)\r
+server: Tempesta FW/pre-0.7.0\r
+\r
+"""
+
+
+class TestCurlClientParsing(unittest.TestCase):
+    def test_initialized(self):
+        client = CurlClient(server_addr="127.0.0.1")
+        self.assertFalse(client.ssl)
+        self.assertFalse(client.last_response)
+        self.assertEqual(client.uri, "http://127.0.0.1/")
+
+    def test_multiple_responses_parsed(self):
+        client = CurlClient(server_addr="127.0.0.1")
+        with patch(
+            "framework.curl_client.CurlClient._read_headers_dump",
+            return_value=MULTIPLE_RESPONSES,
+        ):
+            client.dump_headers = True
+            client.parse_out(b"", b"")
+            self.assertEqual(len(client.responses), 2)
+            self.assertEqual(client.responses[0].headers["content-length"], "1")
+            self.assertEqual(client.responses[1].headers["content-length"], "2")
+
+
+class TestCurlClient(tester.TempestaTest):
+
+    backends = [
+        {
+            "id": "deproxy",
+            "type": "deproxy",
+            "port": "8000",
+            "response": "static",
+            "response_content": (
+                "HTTP/1.1 200 OK\r\n"
+                "Server: test\r\n"
+                "Date: test\r\n"
+                "X-Header: Test-Value\r\n"
+                "Set-Cookie: curl=test\r\n"
+                "Content-Length: 4\r\n"
+                "\r\n"
+                "test"
+            ),
+        }
+    ]
+
+    clients = [
+        {
+            "id": "default",
+            "type": "curl",
+        },
+        {
+            "id": "wrong_port",
+            "type": "curl",
+            "addr": "${server_ip}:8001",
+        },
+        {
+            "id": "h2",
+            "type": "curl",
+            "http2": True,
+        },
+        {
+            "id": "cookie",
+            "type": "curl",
+            "save_cookies": True,
+            "load_cookies": True,
+        },
+        {
+            "id": "multi",
+            "type": "curl",
+            "uri": f"/[1-2]",
+        },
+    ]
+
+    tempesta = {
+        "config": """
+            listen 80 proto=http;
+            listen 443 proto=h2;
+            server ${server_ip}:8000;
+            tls_certificate ${general_workdir}/tempesta.crt;
+            tls_certificate_key ${general_workdir}/tempesta.key;
+            tls_match_any_server_name;
+        """
+    }
+
+    def start_all(self):
+        self.start_all_servers()
+        self.start_tempesta()
+        self.deproxy_manager.start()
+        self.assertTrue(self.wait_all_connections(1))
+
+    def get_response(self, client) -> CurlResponse:
+        client.start()
+        self.wait_while_busy(client)
+        client.stop()
+        return client.last_response
+
+    def test_default_request_completed(self):
+        self.start_all()
+        client = self.get_client("default")
+        response = self.get_response(client)
+        self.assertEqual(len(client.responses), 1)
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.stdout, "test")
+
+    def test_http2_request_completed(self):
+        self.start_all()
+        client = self.get_client("h2")
+        response = self.get_response(client)
+        self.assertEqual(response.proto, "2")
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.stdout, "test")
+        self.assertTrue(response.headers["via"].startswith("2.0"))
+
+    def test_error_on_wrong_port(self):
+        self.start_all()
+        client = self.get_client("wrong_port")
+        response = self.get_response(client)
+        self.assertFalse(response)
+
+    def test_headers_parsed(self):
+        self.start_all()
+        client = self.get_client("default")
+        headers = self.get_response(client).headers
+        self.assertEqual(headers["content-length"], "4")
+        self.assertEqual(headers["x-header"], "Test-Value")
+        self.assertTrue(headers["via"].startswith("1.1"))
+
+    def test_cookies(self):
+        self.start_all()
+        client = self.get_client("cookie")
+        client.clear_cookies()
+        self.assertFalse(client.cookie_jar_path.exists())
+
+        with self.subTest("Cookie saved"):
+            response = self.get_response(client)
+            request = self.get_server("deproxy").last_request
+            self.assertFalse(request.headers["Cookie"])
+            self.assertTrue(client.cookie_jar_path.exists())
+
+        with self.subTest("Cookie loaded"):
+            response = self.get_response(client)
+            request = self.get_server("deproxy").last_request
+            self.assertEqual(request.headers["Cookie"], "curl=test")
+
+    def test_multiple_requests_completed(self):
+        self.start_all()
+        client = self.get_client("multi")
+        response = self.get_response(client)
+        self.assertEqual(response.status, 200)
+        self.assertEqual([r.status for r in client.responses], [200, 200])

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-apt install python3-pip nginx libnginx-mod-http-echo net-tools libssl-dev unzip -y
+apt install python3-pip nginx libnginx-mod-http-echo net-tools libssl-dev libnghttp2-dev autoconf unzip -y
 
 python3 -m pip install -r requirements.txt
 
@@ -27,3 +27,12 @@ git clone https://github.com/tempesta-tech/h2spec.git /tmp/h2spec
 cd /tmp/h2spec
 make build
 cp ./h2spec /usr/bin/h2spec
+
+# curl
+git clone --depth=1 --branch curl-7_85_0 https://github.com/curl/curl.git /tmp/curl
+cd /tmp/curl
+autoreconf -fi
+./configure --with-openssl --with-nghttp2 --prefix /usr/local
+make
+make install
+ldconfig

--- a/tests_config.ini.sample
+++ b/tests_config.ini.sample
@@ -80,6 +80,17 @@ workdir = /tmp/client
 #
 ab = ab
 
+# cURL binary.
+#
+# ex.: curl = /usr/bin/curl (default curl)
+#
+curl = curl
+
+# cURL version. Set to override runtime version check.
+#
+# curl_version = 7.85.0
+#
+
 # wrk benchmark utility.
 #
 # ex.: wrk = /home/user/wrk/wrk (default wrk)


### PR DESCRIPTION
Add new `framework.client.Client` for convenient work with the `curl` utility.
Client was used in #290, and now pulled into separate PR.

Client implementation includes:
  - Setting the binary to be used, with the `Client.curl` config option
  - Installed binary version check
  - Log output for easier debugging
  - Nice representation for client and response objects
  - Response status and headers parsing
  - Transfer information parsing (list of available variables: https://curl.se/docs/manpage.html#-w )
  - URI and options addition during the tests
  - Cookies support
  - HTTP, HTTPS, HTTP/2 switch
  - Parallel transfer mode switch

## Client declaration examples

```python
 clients = [
        # GET http://{tempesta.ip}
        {
            "id": "default",
            "type": "curl",
        },

        # HEAD https://{tempesta.ip}:8000/page , with verbose output
        {
            "id": "ssl-head",
            "type": "curl",
            "ssl": True,
            "addr": "${tempesta_ip}:8000",
            "uri": "/page"
            # additional cURL binary arguments
            "cmd_args": (
                " --head"
                " --verbose"
            ),
        },

        # HTTP/2 POST data with cookies enabled
        {
            "id": "h2-post",
            "type": "curl",
            "http2": True,
            "data": "param1=1&param2=2",
            "save_cookies": True,
            "load_cookies": True,
        },

        # Make requests to /1, /2 ... /100 , using 10 simultaneous transfers,
        # with disabled output and "Connection: close" header set
        {
            "id": "parallel",
            "type": "curl",
            "uri": "/[1-100]",
            "parallel": 10,
            "disable_output": True,
            "headers": {
                "Connection": "close",
            },
        },
]
```

## Log output example

Output contains full cURL command line, for easy manual reproduction,
and information about performed transfers.

`Running client`
`Curl command formatted: curl --no-progress-meter --create-dirs --dump-header '/tmp/client/curl-default.hdr' --write-out '%{json}' --output '/tmp/client/curl-output' --cookie-jar '/tmp/client/curl-default.jar' --cookie '/tmp/client/curl-default.jar' --http1.1 'http://192.168.122.76/'`
`        Client exit`
`Stopping client`
`        client stdout:`
`{"content_type":null,"errormsg":null,"exitcode":0,"filename_effective":"/tmp/client/curl-output","ftp_entry_path":null,"http_code":200,"http_connect":0,"http_version":"1.1","local_ip":"192.168.122.1","local_port":52846,"method":"GET","num_connects":1,"num_headers":7,"num_redirects":0,"proxy_ssl_verify_result":0,"redirect_url":null,"referer":null,"remote_ip":"192.168.122.76","remote_port":80,"response_code":200,"scheme":"HTTP","size_download":4,"size_header":198,"size_request":78,"size_upload":0,"speed_download":492,"speed_upload":0,"ssl_verify_result":0,"time_appconnect":0.000000,"time_connect":0.000249,"time_namelookup":0.000017,"time_pretransfer":0.000279,"time_redirect":0.000000,"time_starttransfer":0.008015,"time_total":0.008130,"url":"http://192.168.122.76/","url_effective":"http://192.168.122.76/","urlnum":0,"curl_version":"libcurl/7.85.0 OpenSSL/3.0.2 zlib/1.2.11 nghttp2/1.43.0"}`
`Client is stopped`

## Usage example
From the `tester.TempestaTest` method context:
```python
>>> client = self.get_client("curl")
>>> client.start()
>>> self.wait_while_busy(client)
>>> client.stop()

# Client object representation
>>> client
CurlClient(addr='192.168.122.76', uri='http://192.168.122.76/', cmd_args='', data='',
    headers=None, dump_headers=True, disable_output=False, save_cookies=True,
    load_cookies=True, ssl=False, http2=False, insecure=True, parallel=None)

# Observe the responses list
>>> client.responses
[CurlResponse(status=200, proto='1.1',
    headers={'date': 'test', 'x-header': 'Test-Value-2', 'set-cookie': 'curl=test', 'content-length': '4',
    'via': '1.1 tempesta_fw (Tempesta FW pre-0.7.0)', 'server': 'Tempesta FW/pre-0.7.0'})]

# Observe the last response
>>> client.last_response
CurlResponse(status=200, proto='1.1',
    headers={'date': 'test', 'x-header': 'Test-Value-2', 'set-cookie': 'curl=test', 'content-length': '4',
    'via': '1.1 tempesta_fw (Tempesta FW pre-0.7.0)', 'server': 'Tempesta FW/pre-0.7.0'})
>>> client.last_response.status
200

# Observe received headers
>>> client.last_response.headers
{'date': 'test', 'x-header': 'Test-Value-2', 'set-cookie': 'curl=test', 'content-length': '4',
    'via': '1.1 tempesta_fw (Tempesta FW pre-0.7.0)', 'server': 'Tempesta FW/pre-0.7.0'}

# Observe headers with multiple values, like cookies
>>> client.last_response.multi_headers
{'date': ['test'], 'x-header': ['Test-Value-1', 'Test-Value-2'],
    'set-cookie': ['curl=test'], 'content-length': ['4'], 'via': ['1.1 tempesta_fw (Tempesta FW pre-0.7.0)'],
    'server': ['Tempesta FW/pre-0.7.0']}

# Discover transfers stats
>>> len(client.stats)
1
>>> client.last_stats
{'content_type': None, 'errormsg': None, 'exitcode': 0, 'filename_effective': '/tmp/client/curl-output',
    'ftp_entry_path': None, 'http_code': 200, 'http_connect': 0, 'http_version': '1.1',
    'local_ip': '192.168.122.1', 'local_port': 46732, 'method': 'GET', 'num_connects': 1,
    'num_headers': 7, 'num_redirects': 0, 'proxy_ssl_verify_result': 0, 'redirect_url': None,
    'referer': None, 'remote_ip': '192.168.122.76', 'remote_port': 80, 'response_code': 200,
    'scheme': 'HTTP', 'size_download': 4, 'size_header': 198, 'size_request': 97, 'size_upload': 0,
    'speed_download': 112, 'speed_upload': 0, 'ssl_verify_result': 0, 'time_appconnect': 0.0,
    'time_connect': 0.000245, 'time_namelookup': 1.2e-05, 'time_pretransfer': 0.000266,
    'time_redirect': 0.0, 'time_starttransfer': 0.035547, 'time_total': 0.035635,
    'url': 'http://192.168.122.76/', 'url_effective': 'http://192.168.122.76/', 'urlnum': 0,
    'curl_version': 'libcurl/7.85.0 OpenSSL/3.0.2 zlib/1.2.11 nghttp2/1.43.0'
}

# Change uri for the next request
>>> client.set_uri("/page2")
# Add additional option (set request method to PURGE)
>>> client.options.append("--request PURGE")
>>> client.start()
```

## Version check

сURL binary expected version is set by the `framework.curl_client.CURL_BINARY_VERSION`.
On version mismatch, every request will produce error messages:
```
helpers.error.Error: Expected curl binary version: 7.85.0
Detected curl binary version: 7.68.0
Set 'Client.curl_version' config variable to override expected value.
```
or, for badly outdated versions:
```
helpers.error.Error: Can't detect `curl` version. `curl --version` should be 7.85.0
```