### PR TITLE
deproxy_h2: fixed receiving multiple DATA frames

### DIFF
--- a/framework/deproxy_client.py
+++ b/framework/deproxy_client.py
@@ -407,7 +407,7 @@ class DeproxyClientH2(DeproxyClient):
                 elif isinstance(event, DataReceived):
                     body = event.data.decode()
                     response = self.active_responses.get(event.stream_id)
-                    response.parse_text(str(response.headers) + "\r\n" + body)
+                    response.body += body
                 elif isinstance(event, TrailersReceived):
                     trailers = self.__headers_to_string(event.headers)
                     response = self.active_responses.get(event.stream_id)

--- a/framework/deproxy_client.py
+++ b/framework/deproxy_client.py
@@ -408,6 +408,10 @@ class DeproxyClientH2(DeproxyClient):
                     body = event.data.decode()
                     response = self.active_responses.get(event.stream_id)
                     response.body += body
+                    self.h2_connection.acknowledge_received_data(
+                        acknowledged_size=event.flow_controlled_length,
+                        stream_id=event.stream_id
+                    )
                 elif isinstance(event, TrailersReceived):
                     trailers = self.__headers_to_string(event.headers)
                     response = self.active_responses.get(event.stream_id)


### PR DESCRIPTION
Just concatenate received body to local response body. Parsing of body will have no effect for HTTP2 frames. Content-Length also not required in HTTP2, therefore our standard logic can't be applied. Handling of TrailersReceived also incorrect, but it's not critical, now we don't have HTTP2 trailers in tempesta.