### PR TITLE
HTTP headers tests set

### DIFF
--- a/http2_general/test_h2_headers.py
+++ b/http2_general/test_h2_headers.py
@@ -531,3 +531,28 @@ class MissingDateServerWithBodyTest(tester.TempestaTest):
         resp = deproxy_cl.wait_for_response(timeout=5)
         self.assertTrue(resp)
         self.assertEqual(deproxy_cl.last_response.status, "200")
+
+
+LARGE_CONTENT_LENGTH = 1024 * 8
+
+
+class MissingDateServerWithLargeBodyTest(MissingDateServerWithBodyTest):
+    """
+    Same as `MissingDateServerWithBodyTest`, but with a larger body.
+    Can cause panic, see Tempesta issue #1704
+    """
+
+    backends = [
+        {
+            "id": "deproxy",
+            "type": "deproxy",
+            "port": "8000",
+            "response": "static",
+            "response_content": (
+                "HTTP/1.1 200 OK\r\n"
+                f"Content-Length: {LARGE_CONTENT_LENGTH}\r\n"
+                "\r\n"
+                f"{'1' * LARGE_CONTENT_LENGTH}"
+            ),
+        },
+    ]

--- a/http_general/__init__.py
+++ b/http_general/__init__.py
@@ -1,0 +1,3 @@
+__all__ = ['test_headers']
+
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/http_general/__init__.py
+++ b/http_general/__init__.py
@@ -1,3 +1,3 @@
-__all__ = ['test_headers']
+__all__ = ["test_headers"]
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/http_general/test_headers.py
+++ b/http_general/test_headers.py
@@ -91,16 +91,9 @@ class BackendSetCoookie(tester.TempestaTest):
         }
     ]
 
-    def start_all(self):
-        self.start_all_servers()
-        self.start_tempesta()
-        self.deproxy_manager.start()
-        self.start_all_clients()
-        self.assertTrue(self.wait_all_connections(1))
-
     def test_request_success(self):
         """Test that Tempesta proxies responses with Set-Cookie headers successfully."""
-        self.start_all()
+        self.start_all_services()
         client = self.get_client("deproxy")
         for path in (
             "cookie1",  # single Set-Cookie header
@@ -149,13 +142,6 @@ class RepeatedHeaderCache(tester.TempestaTest):
         }
     ]
 
-    def start_all(self):
-        self.start_all_servers()
-        self.start_tempesta()
-        self.deproxy_manager.start()
-        self.start_all_clients()
-        self.assertTrue(self.wait_all_connections(1))
-
     def test_request_cache_del_dup_success(self):
         """
         Test that no kernel panic occur when:
@@ -164,7 +150,7 @@ class RepeatedHeaderCache(tester.TempestaTest):
           - `cache_resp_hdr_del` is used.
         (see Tempesta issue #1691)
         """
-        self.start_all()
+        self.start_all_services()
         client = self.get_client("deproxy")
 
         client.make_request("GET / HTTP/1.1\r\n\r\n")
@@ -201,15 +187,9 @@ class TestSmallHeader(tester.TempestaTest):
         }
     ]
 
-    def start_all(self):
-        self.start_all_servers()
-        self.start_tempesta()
-        self.deproxy_manager.start()
-        self.assertTrue(self.wait_all_connections(1))
-
     def test_small_header_name_accepted(self):
         """Request with small header name length completes successfully."""
-        self.start_all()
+        self.start_all_services()
         client = self.get_client("deproxy")
 
         for length in range(1, 5):

--- a/http_general/test_headers.py
+++ b/http_general/test_headers.py
@@ -1,0 +1,86 @@
+"""
+Tests for correct handling of HTTP/1.1 headers.
+"""
+
+from framework import tester
+
+__author__ = 'Tempesta Technologies, Inc.'
+__copyright__ = 'Copyright (C) 2022 Tempesta Technologies, Inc.'
+__license__ = 'GPL2'
+
+
+class BackendSetCoookie(tester.TempestaTest):
+
+    backends = [
+        {
+            'id': 'set-cookie-1',
+            'type': 'deproxy',
+            'port': '8000',
+            'response': 'static',
+            'response_content': (
+                'HTTP/1.1 200 OK\r\n'
+                'Set-Cookie: c1=test1\r\n'
+                'Content-Length: 0\r\n\r\n'
+            ),
+        },
+        {
+            'id': 'set-cookie-2',
+            'type': 'deproxy',
+            'port': '8001',
+            'response': 'static',
+            'response_content': (
+                'HTTP/1.1 200 OK\r\n'
+                'Set-Cookie: c1=test1\r\n'
+                'Set-Cookie: c2=test2\r\n'
+                'Content-Length: 0\r\n\r\n'
+            ),
+        },
+    ]
+
+    tempesta = {
+        'config':
+        """
+        listen 80;
+        srv_group sg1 { server ${server_ip}:8000; }
+        srv_group sg2 { server ${server_ip}:8001; }
+
+        vhost cookie1 { proxy_pass sg1; }  # single cookie
+        vhost cookie2 { proxy_pass sg2; }  # two cookie headers
+
+        http_chain {
+          uri == "/cookie1" -> cookie1;
+          uri == "/cookie2" -> cookie2;
+        }
+        """
+    }
+
+    clients = [
+        {
+            'id': 'deproxy',
+            'type': 'deproxy',
+            'addr': "${tempesta_ip}",
+            'port': '80',
+        }
+    ]
+
+    def start_all(self):
+        self.start_all_servers()
+        self.start_tempesta()
+        self.deproxy_manager.start()
+        self.start_all_clients()
+        self.assertTrue(self.wait_all_connections(1))
+
+    def test_request_success(self):
+        """Test that Tempesta proxies responses with Set-Cookie headers successfully."""
+        self.start_all()
+        client = self.get_client('deproxy')
+        for path in (
+                "cookie1",  # single Set-Cookie header
+                "cookie2"  # two Set-Cookie headers
+        ):
+            with self.subTest("GET cookies", path=path):
+                client.make_request(f"GET /{path} HTTP/1.1\r\n\r\n")
+                self.assertTrue(
+                    client.wait_for_response(timeout=1)
+                )
+                self.assertEqual(client.last_response.status, '200')

--- a/http_general/test_headers.py
+++ b/http_general/test_headers.py
@@ -9,6 +9,27 @@ __copyright__ = 'Copyright (C) 2022 Tempesta Technologies, Inc.'
 __license__ = 'GPL2'
 
 
+# Response from the WordPress POST /wp-login.php
+wordpress_login_response = """HTTP/1.1 200 OK
+Date: Thu, 08 Sep 2022 11:50:34 GMT
+Server: Apache/2.4.54 (Debian)
+X-Powered-By: PHP/7.4.30
+Expires: Wed, 11 Jan 1984 05:00:00 GMT
+Cache-Control: no-cache, must-revalidate, max-age=0
+Set-Cookie: wordpress_test_cookie=WP%20Cookie%20check; path=/
+X-Frame-Options: SAMEORIGIN
+Set-Cookie: wordpress_86a9106ae65537651a8e456835b316ab=admin%7C1662810634%7CY5HVGAwBX3g13hZEvGgwSf7fyUY1t5ZaPi2JsH8Fpsa%7C634effa8a901f9b410b6fd18ca0512039ffe2f362a0d70b6d82ff995b7f8be22; path=/wp-content/plugins; HttpOnly
+Set-Cookie: wordpress_86a9106ae65537651a8e456835b316ab=admin%7C1662810634%7CY5HVGAwBX3g13hZEvGgwSf7fyUY1t5ZaPi2JsH8Fpsa%7C634effa8a901f9b410b6fd18ca0512039ffe2f362a0d70b6d82ff995b7f8be22; path=/wp-admin; HttpOnly
+Set-Cookie: wordpress_logged_in_86a9106ae65537651a8e456835b316ab=admin%7C1662810634%7CY5HVGAwBX3g13hZEvGgwSf7fyUY1t5ZaPi2JsH8Fpsa%7Cd20c220a6974e7c1bdad6eb90b19b37986bbb06ada7bff996b55d0269c077c90; path=/; HttpOnly
+Vary: Accept-Encoding
+Content-Length: 15
+Keep-Alive: timeout=5, max=100
+Connection: Keep-Alive
+Content-Type: text/html; charset=UTF-8
+
+<!DOCTYPE html>"""
+
+
 class BackendSetCoookie(tester.TempestaTest):
 
     backends = [
@@ -35,6 +56,13 @@ class BackendSetCoookie(tester.TempestaTest):
                 'Content-Length: 0\r\n\r\n'
             ),
         },
+        {
+            'id': 'wordpress-login',
+            'type': 'deproxy',
+            'port': '8002',
+            'response': 'static',
+            'response_content': wordpress_login_response,
+        },
     ]
 
     tempesta = {
@@ -43,13 +71,16 @@ class BackendSetCoookie(tester.TempestaTest):
         listen 80;
         srv_group sg1 { server ${server_ip}:8000; }
         srv_group sg2 { server ${server_ip}:8001; }
+        srv_group sg3 { server ${server_ip}:8002; }
 
         vhost cookie1 { proxy_pass sg1; }  # single cookie
         vhost cookie2 { proxy_pass sg2; }  # two cookie headers
+        vhost wordpress-login { proxy_pass sg3; }  # WordPress login response
 
         http_chain {
           uri == "/cookie1" -> cookie1;
           uri == "/cookie2" -> cookie2;
+          uri == "/wordpress-login" -> wordpress-login;
         }
         """
     }
@@ -76,7 +107,8 @@ class BackendSetCoookie(tester.TempestaTest):
         client = self.get_client('deproxy')
         for path in (
                 "cookie1",  # single Set-Cookie header
-                "cookie2"  # two Set-Cookie headers
+                "cookie2",  # two Set-Cookie headers
+                "wordpress-login",  # WordPress response with multiple Set-Cookie headers
         ):
             with self.subTest("GET cookies", path=path):
                 client.make_request(f"GET /{path} HTTP/1.1\r\n\r\n")

--- a/http_general/test_headers.py
+++ b/http_general/test_headers.py
@@ -4,9 +4,9 @@ Tests for correct handling of HTTP/1.1 headers.
 
 from framework import tester
 
-__author__ = 'Tempesta Technologies, Inc.'
-__copyright__ = 'Copyright (C) 2022 Tempesta Technologies, Inc.'
-__license__ = 'GPL2'
+__author__ = "Tempesta Technologies, Inc."
+__copyright__ = "Copyright (C) 2022 Tempesta Technologies, Inc."
+__license__ = "GPL2"
 
 
 # Response from the WordPress POST /wp-login.php
@@ -34,40 +34,37 @@ class BackendSetCoookie(tester.TempestaTest):
 
     backends = [
         {
-            'id': 'set-cookie-1',
-            'type': 'deproxy',
-            'port': '8000',
-            'response': 'static',
-            'response_content': (
-                'HTTP/1.1 200 OK\r\n'
-                'Set-Cookie: c1=test1\r\n'
-                'Content-Length: 0\r\n\r\n'
+            "id": "set-cookie-1",
+            "type": "deproxy",
+            "port": "8000",
+            "response": "static",
+            "response_content": (
+                "HTTP/1.1 200 OK\r\n" "Set-Cookie: c1=test1\r\n" "Content-Length: 0\r\n\r\n"
             ),
         },
         {
-            'id': 'set-cookie-2',
-            'type': 'deproxy',
-            'port': '8001',
-            'response': 'static',
-            'response_content': (
-                'HTTP/1.1 200 OK\r\n'
-                'Set-Cookie: c1=test1\r\n'
-                'Set-Cookie: c2=test2\r\n'
-                'Content-Length: 0\r\n\r\n'
+            "id": "set-cookie-2",
+            "type": "deproxy",
+            "port": "8001",
+            "response": "static",
+            "response_content": (
+                "HTTP/1.1 200 OK\r\n"
+                "Set-Cookie: c1=test1\r\n"
+                "Set-Cookie: c2=test2\r\n"
+                "Content-Length: 0\r\n\r\n"
             ),
         },
         {
-            'id': 'wordpress-login',
-            'type': 'deproxy',
-            'port': '8002',
-            'response': 'static',
-            'response_content': wordpress_login_response,
+            "id": "wordpress-login",
+            "type": "deproxy",
+            "port": "8002",
+            "response": "static",
+            "response_content": wordpress_login_response,
         },
     ]
 
     tempesta = {
-        'config':
-        """
+        "config": """
         listen 80;
         srv_group sg1 { server ${server_ip}:8000; }
         srv_group sg2 { server ${server_ip}:8001; }
@@ -87,10 +84,10 @@ class BackendSetCoookie(tester.TempestaTest):
 
     clients = [
         {
-            'id': 'deproxy',
-            'type': 'deproxy',
-            'addr': "${tempesta_ip}",
-            'port': '80',
+            "id": "deproxy",
+            "type": "deproxy",
+            "addr": "${tempesta_ip}",
+            "port": "80",
         }
     ]
 
@@ -104,40 +101,37 @@ class BackendSetCoookie(tester.TempestaTest):
     def test_request_success(self):
         """Test that Tempesta proxies responses with Set-Cookie headers successfully."""
         self.start_all()
-        client = self.get_client('deproxy')
+        client = self.get_client("deproxy")
         for path in (
-                "cookie1",  # single Set-Cookie header
-                "cookie2",  # two Set-Cookie headers
-                "wordpress-login",  # WordPress response with multiple Set-Cookie headers
+            "cookie1",  # single Set-Cookie header
+            "cookie2",  # two Set-Cookie headers
+            "wordpress-login",  # WordPress response with multiple Set-Cookie headers
         ):
             with self.subTest("GET cookies", path=path):
                 client.make_request(f"GET /{path} HTTP/1.1\r\n\r\n")
-                self.assertTrue(
-                    client.wait_for_response(timeout=1)
-                )
-                self.assertEqual(client.last_response.status, '200')
+                self.assertTrue(client.wait_for_response(timeout=1))
+                self.assertEqual(client.last_response.status, "200")
 
 
 class RepeatedHeaderCache(tester.TempestaTest):
 
     backends = [
         {
-            'id': 'headers',
-            'type': 'deproxy',
-            'port': '8000',
-            'response': 'static',
-            'response_content': (
-                'HTTP/1.1 200 OK\r\n'
-                'Dup: 1\r\n'  # Header is
-                'Dup: 2\r\n'  # repeated
-                'Content-Length: 0\r\n\r\n'
+            "id": "headers",
+            "type": "deproxy",
+            "port": "8000",
+            "response": "static",
+            "response_content": (
+                "HTTP/1.1 200 OK\r\n"
+                "Dup: 1\r\n"  # Header is
+                "Dup: 2\r\n"  # repeated
+                "Content-Length: 0\r\n\r\n"
             ),
         },
     ]
 
     tempesta = {
-        'config':
-        """
+        "config": """
         listen 80;
         cache 1;
         cache_fulfill * *;
@@ -148,10 +142,10 @@ class RepeatedHeaderCache(tester.TempestaTest):
 
     clients = [
         {
-            'id': 'deproxy',
-            'type': 'deproxy',
-            'addr': "${tempesta_ip}",
-            'port': '80',
+            "id": "deproxy",
+            "type": "deproxy",
+            "addr": "${tempesta_ip}",
+            "port": "80",
         }
     ]
 
@@ -171,31 +165,27 @@ class RepeatedHeaderCache(tester.TempestaTest):
         (see Tempesta issue #1691)
         """
         self.start_all()
-        client = self.get_client('deproxy')
+        client = self.get_client("deproxy")
 
-        client.make_request('GET / HTTP/1.1\r\n\r\n')
+        client.make_request("GET / HTTP/1.1\r\n\r\n")
 
         self.assertTrue(client.wait_for_response(timeout=1))
-        self.assertEqual(client.last_response.status, '200')
+        self.assertEqual(client.last_response.status, "200")
 
 
 class TestSmallHeader(tester.TempestaTest):
     backends = [
         {
-            'id': 'deproxy',
-            'type': 'deproxy',
-            'port': '8000',
-            'response': 'static',
-            'response_content': (
-                'HTTP/1.1 200 OK\r\n'
-                'Content-Length: 0\r\n\r\n'
-            ),
+            "id": "deproxy",
+            "type": "deproxy",
+            "port": "8000",
+            "response": "static",
+            "response_content": ("HTTP/1.1 200 OK\r\n" "Content-Length: 0\r\n\r\n"),
         },
     ]
 
     tempesta = {
-        'config':
-        """
+        "config": """
         listen 80;
         server ${server_ip}:8000;
         cache 0;
@@ -204,10 +194,10 @@ class TestSmallHeader(tester.TempestaTest):
 
     clients = [
         {
-            'id': 'deproxy',
-            'type': 'deproxy',
-            'addr': "${tempesta_ip}",
-            'port': '80',
+            "id": "deproxy",
+            "type": "deproxy",
+            "addr": "${tempesta_ip}",
+            "port": "80",
         }
     ]
 
@@ -220,17 +210,13 @@ class TestSmallHeader(tester.TempestaTest):
     def test_small_header_name_accepted(self):
         """Request with small header name length completes successfully."""
         self.start_all()
-        client = self.get_client('deproxy')
+        client = self.get_client("deproxy")
 
         for length in range(1, 5):
-            header = 'X' * length
+            header = "X" * length
             client.start()
             with self.subTest(header=header):
-                client.make_request(
-                    'GET / HTTP/1.1\r\n'
-                    f"{header}: test\r\n"
-                    '\r\n'
-                )
+                client.make_request("GET / HTTP/1.1\r\n" f"{header}: test\r\n" "\r\n")
                 self.assertTrue(client.wait_for_response(timeout=1))
-                self.assertEqual(client.last_response.status, '200')
+                self.assertEqual(client.last_response.status, "200")
             client.stop()

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -146,19 +146,7 @@
             "reason" : "Disabled by issue #73"
         },
         {
-            "name" : "http2_general.test_h2_perf",
-            "reason" : "Disabled by issue #261"
-        },
-        {
-            "name" : "http2_general.test_h2_ping",
-            "reason" : "Disabled by issue #261"
-        },
-        {
-            "name" : "http2_general.test_h2_specs",
-            "reason" : "Disabled by issue #261"
-        },
-        {
-            "name" : "http2_general.test_h2_sticky_cookie",
+            "name" : "http2_general",
             "reason" : "Disabled by issue #261"
         },
         {

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -146,7 +146,19 @@
             "reason" : "Disabled by issue #73"
         },
         {
-            "name" : "http2_general",
+            "name" : "http2_general.test_h2_perf",
+            "reason" : "Disabled by issue #261"
+        },
+        {
+            "name" : "http2_general.test_h2_ping",
+            "reason" : "Disabled by issue #261"
+        },
+        {
+            "name" : "http2_general.test_h2_specs",
+            "reason" : "Disabled by issue #261"
+        },
+        {
+            "name" : "http2_general.test_h2_sticky_cookie",
             "reason" : "Disabled by issue #261"
         },
         {
@@ -440,6 +452,23 @@
         {
             "name" : "selftests.test_framework.ExampleTest.test_curl",
             "reason": "Disable by issue #308"
+        },
+        {
+            "name" : "http2_general.test_h2_headers.MissingDateServerWithBodyTest",
+            "reason" : "Disabled by issue #1669"
+        },
+        {
+            "name" : "http2_general.test_h2_headers.MissingDateServerWithLargeBodyTest",
+            "reason" : "Disabled by issue #1704"
+        },
+        {
+            "name" : "http_general.test_headers.BackendSetCoookie",
+            "reason" : "Disabled by issue #1690"
+        },
+        {
+            "name" : "http_general.test_headers.TestSmallHeader",
+            "reason" : "Disabled by issue #1697"
         }
+
     ]
 }

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -452,10 +452,6 @@
         {
             "name" : "http_general.test_headers.BackendSetCoookie",
             "reason" : "Disabled by issue #1690"
-        },
-        {
-            "name" : "http_general.test_headers.TestSmallHeader",
-            "reason" : "Disabled by issue #1697"
         }
 
     ]


### PR DESCRIPTION
HTTP and HTTP2 headers tests:
* `http_general.test_headers.BackendSetCoookie` — https://github.com/tempesta-tech/tempesta/issues/1690
* `http_general.test_headers.RepeatedHeaderCache` — https://github.com/tempesta-tech/tempesta/issues/1691
* `http2_general.test_h2_headers.MissingDateServerWithLargeBodyTest` — https://github.com/tempesta-tech/tempesta/issues/1704

Tests was used in https://github.com/tempesta-tech/tempesta-test/issues/290, and now pulled into separate PR.  
Currently failing tests are disabled.
