### PR TITLE
Truncated cached responses tests

### DIFF
--- a/cache/test_cache.py
+++ b/cache/test_cache.py
@@ -466,7 +466,7 @@ class TestChunkedResponse(tester.TempestaTest):
             response = self.get_response(client)
             self.assertEqual(response.status, 200, response)
             self.assertNotIn("age", response.headers)
-            original_data = response.stdout
+            self.assertEqual(response.stdout, "9\r\ntest-data\r\n0\r\n\r\n")
 
         with self.subTest("Get cached response"):
             response = self.get_response(client)
@@ -475,8 +475,8 @@ class TestChunkedResponse(tester.TempestaTest):
             # check that response is from the cache
             self.assertEqual(len(srv.requests), 1)
             self.assertIn("age", response.headers)
-
-        self.assertEqual(cached_data, original_data)
+            # Cached response is dechunked after the #1418
+            self.assertEqual(response.stdout, "test-data")
 
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/cache/test_cache.py
+++ b/cache/test_cache.py
@@ -4,7 +4,6 @@ __author__ = "Tempesta Technologies, Inc."
 __copyright__ = "Copyright (C) 2022 Tempesta Technologies, Inc."
 __license__ = "GPL2"
 
-
 from framework import tester
 from framework.curl_client import CurlResponse
 from framework.deproxy_client import DeproxyClient

--- a/cache/test_purge.py
+++ b/cache/test_purge.py
@@ -446,3 +446,118 @@ cache_resp_hdr_del set-cookie;
             cl_msg_served_from_cache=1,
         )
         self.assertEqual(len(srv.requests), 4, "Server has lost requests.")
+
+
+class TestPurgeGetWithTransferEncoding(tester.TempestaTest):
+
+    backends = [
+        # /server-1: default transfer encoding
+        {
+            "id": "default",
+            "type": "deproxy",
+            "port": "8000",
+            "response": "static",
+            "response_content": (
+                "HTTP/1.1 200 OK\r\n"
+                "From: /server1\r\n"
+                "Content-length: 9\r\n"
+                "\r\n"
+                "test-data"
+            ),
+        },
+        # /server-2: chunked transfer encoding
+        {
+            "id": "chunked",
+            "type": "deproxy",
+            "port": "8001",
+            "response": "static",
+            "response_content": (
+                "HTTP/1.1 200 OK\r\n"
+                "From: /server2\r\n"
+                "Transfer-Encoding: chunked\r\n"
+                "\r\n"
+                "9\r\n"
+                "test-data\r\n"
+                "0\r\n"
+                "\r\n"
+            ),
+        },
+        # /server-3: keepalive with chunked transfer encoding
+        {
+            "id": "chunked_keepalive",
+            "type": "deproxy",
+            "port": "8002",
+            "response": "static",
+            "response_content": (
+                "HTTP/1.1 200 OK\r\n"
+                "From: /server3\r\n"
+                "Transfer-Encoding: chunked\r\n"
+                "Connection: Keep-Alive\r\n"
+                "\r\n"
+                "9\r\n"
+                "test-data\r\n"
+                "0\r\n"
+                "\r\n"
+            ),
+        },
+    ]
+
+    tempesta = {
+        "config": """
+        listen 80;
+        cache_purge;
+        cache_purge_acl ${client_ip};
+
+        srv_group sg1 { server ${server_ip}:8000; }
+        srv_group sg2 { server ${server_ip}:8001; }
+        srv_group sg3 { server ${server_ip}:8002; }
+
+        vhost server1 { proxy_pass sg1; }
+        vhost server2 { proxy_pass sg2; }
+        vhost server3 { proxy_pass sg3; }
+
+        http_chain {
+          uri == "/server1" -> server1;
+          uri == "/server2" -> server2;
+          uri == "/server3" -> server3;
+        }
+        """
+    }
+    clients = [
+        {
+            "id": "purge",
+            "type": "curl",
+            "cmd_args": (" --request PURGE" ' --header "X-Tempesta-Cache: get"' " --max-time 2"),
+        },
+    ]
+
+    def start_all(self):
+        self.start_all_servers()
+        self.start_tempesta()
+        self.deproxy_manager.start()
+        self.assertTrue(self.wait_all_connections(1))
+
+    def test_purge_get_success(self):
+        """Test that PURGE+GET request completed with no errors.
+        (see Tempesta issue #1692)
+        """
+        self.start_all()
+        client = self.get_client("purge")
+
+        for uri in "/server1", "/server2", "/server3":
+            with self.subTest("PURGE+GET", uri=uri):
+                client.set_uri(uri)
+
+                client.start()
+                self.wait_while_busy(client)
+                client.stop()
+                response = client.last_response
+
+                self.assertEqual(response.status, 200, response)
+                # Response is from expected backend
+                self.assertEqual(response.headers["from"], uri)
+                # Body is truncated
+                self.assertFalse(response.stdout)
+                self.assertEqual(response.headers["content-length"], "0")
+                # Purge is completed with no errors
+                self.assertFalse(response.stderr)

--- a/cache/test_purge.py
+++ b/cache/test_purge.py
@@ -561,3 +561,22 @@ class TestPurgeGetWithTransferEncoding(tester.TempestaTest):
                 self.assertEqual(response.headers["content-length"], "0")
                 # Purge is completed with no errors
                 self.assertFalse(response.stderr)
+
+    def test_purge_connection_close_header(self):
+        """Test that `Connection` header is passed to backend."""
+        self.start_all()
+        client = self.get_client('purge')
+        client.options.append(f"--header 'Test: close'")
+        client.options.append(f"--header 'Connection: close'")
+        client.set_uri("/server1")
+
+        client.start()
+        self.wait_while_busy(client)
+        client.stop()
+        response = client.last_response
+
+        self.assertEqual(response.status, 200, response)
+
+        server_request = self.get_server('default').last_request
+        self.assertEqual(server_request.headers['Test'], 'close')
+        self.assertEqual(server_request.headers['Connection'], 'close')

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -338,6 +338,14 @@
             "reason": "Disabled by issue #1669"
         },
         {
+            "name": "cache.test_cache.TestChunkedResponse",
+            "reason": "Disabled by issue #1698"
+        },
+        {
+            "name": "cache.test_purge.TestPurgeGet",
+            "reason": "Disabled by issue #1692"
+        },
+        {
             "name" : "tls.test_tls_handshake.TlsVhostHandshakeTest.test_bad_host",
             "reason": "Disabled by issue #286"
         },


### PR DESCRIPTION
*  `cache.test_cache.TestChunkedResponse` — https://github.com/tempesta-tech/tempesta/issues/1698
* `cache.test_purge.TestPurgeGet` — https://github.com/tempesta-tech/tempesta/issues/1692

Tests was used in https://github.com/tempesta-tech/tempesta-test/issues/290, and now pulled into separate PR.
Currently failing tests are disabled.