### PR TITLE
Fix cache_misses

### DIFF
--- a/cache/test_purge.py
+++ b/cache/test_purge.py
@@ -115,7 +115,6 @@ cache_resp_hdr_del set-cookie;
         client.send_request(self.request_template.format("HEAD"), "200")
         self.assertIn("age", client.last_response.headers)
 
-        # TODO uncomment after fixing issue #1699
         checks.check_tempesta_cache_stats(
             self.get_tempesta(),
             cache_hits=4,
@@ -161,7 +160,6 @@ cache_resp_hdr_del set-cookie;
         client.send_request(self.request_template.format("HEAD"), "200")
         self.assertIn("age", client.last_response.headers)
 
-        # TODO uncomment after fixing issue #1699
         checks.check_tempesta_cache_stats(
             self.get_tempesta(),
             cache_hits=4,
@@ -389,7 +387,6 @@ cache_resp_hdr_del set-cookie;
         client.send_request(self.request_template.format("GET"), "200")
         self.assertIn("age", client.last_response.headers)
 
-        # TODO uncomment after fixing issue #1699
         checks.check_tempesta_cache_stats(
             self.get_tempesta(),
             cache_hits=1,

--- a/cache/test_purge.py
+++ b/cache/test_purge.py
@@ -116,12 +116,12 @@ cache_resp_hdr_del set-cookie;
         self.assertIn("age", client.last_response.headers)
 
         # TODO uncomment after fixing issue #1699
-        # checks.check_tempesta_cache_stats(
-        #     self.get_tempesta(),
-        #     cache_hits=4,
-        #     cache_misses=4,
-        #     cl_msg_served_from_cache=4
-        # )
+        checks.check_tempesta_cache_stats(
+            self.get_tempesta(),
+            cache_hits=4,
+            cache_misses=4,
+            cl_msg_served_from_cache=4
+        )
         self.assertEqual(len(self.get_server("deproxy").requests), 4)
 
     def test_purge_get_basic(self):
@@ -162,12 +162,12 @@ cache_resp_hdr_del set-cookie;
         self.assertIn("age", client.last_response.headers)
 
         # TODO uncomment after fixing issue #1699
-        # checks.check_tempesta_cache_stats(
-        #     self.get_tempesta(),
-        #     cache_hits=4,
-        #     cache_misses=3,
-        #     cl_msg_served_from_cache=4,
-        # )
+        checks.check_tempesta_cache_stats(
+            self.get_tempesta(),
+            cache_hits=4,
+            cache_misses=3,
+            cl_msg_served_from_cache=4,
+        )
         self.assertEqual(len(srv.requests), 4)
 
     def test_purge_get_update(self):
@@ -370,7 +370,7 @@ cache_resp_hdr_del set-cookie;
         checks.check_tempesta_cache_stats(
             self.get_tempesta(),
             cache_hits=3,
-            cache_misses=1,
+            cache_misses=3,
             cl_msg_served_from_cache=3,
         )
         self.assertEqual(len(srv.requests), 3)
@@ -390,12 +390,12 @@ cache_resp_hdr_del set-cookie;
         self.assertIn("age", client.last_response.headers)
 
         # TODO uncomment after fixing issue #1699
-        # checks.check_tempesta_cache_stats(
-        #     self.get_tempesta(),
-        #     cache_hits=1,
-        #     cache_misses=1,
-        #     cl_msg_served_from_cache=1,
-        # )
+        checks.check_tempesta_cache_stats(
+            self.get_tempesta(),
+            cache_hits=1,
+            cache_misses=0,
+            cl_msg_served_from_cache=1,
+        )
         self.assertEqual(len(srv.requests), 1)
 
     def test_purge_get_uncacheable(self):
@@ -442,7 +442,7 @@ cache_resp_hdr_del set-cookie;
         checks.check_tempesta_cache_stats(
             self.get_tempesta(),
             cache_hits=1,
-            cache_misses=1,
+            cache_misses=3,
             cl_msg_served_from_cache=1,
         )
         self.assertEqual(len(srv.requests), 4, "Server has lost requests.")


### PR DESCRIPTION
**test_purge** by request:
	miss, miss, hit, hit, purge, miss, miss, hit, hit

**test_purge_get_basic** by request:
	miss, miss, hit, hit,	cache, hit, miss, hit

**test_purge_get_garbage** by request:
	miss, hit, purge, miss, hit, purge, miss, hit

**test_purge_get_uncached** by request:
	cache, hit

**test_purge_get_uncacheable** by request:
	miss, hit, not cache (Cache-Control: private), miss, miss