### PR TITLE
fix: deproxy-h2 does not receive 4xx response

### DIFF
--- a/framework/deproxy_client.py
+++ b/framework/deproxy_client.py
@@ -418,6 +418,7 @@ class DeproxyClientH2(DeproxyClient):
                         return
                     self.receive_response(response)
                     self.nrresp += 1
+                # TODO should be changed by issue #358
                 else:
                     self.handle_read()
 

--- a/framework/deproxy_client.py
+++ b/framework/deproxy_client.py
@@ -406,8 +406,7 @@ class DeproxyClientH2(DeproxyClient):
                     response = self.active_responses.get(event.stream_id)
                     response.body += body
                     self.h2_connection.acknowledge_received_data(
-                        acknowledged_size=event.flow_controlled_length,
-                        stream_id=event.stream_id
+                        acknowledged_size=event.flow_controlled_length, stream_id=event.stream_id
                     )
                 elif isinstance(event, TrailersReceived):
                     trailers = self.__headers_to_string(event.headers)
@@ -419,6 +418,8 @@ class DeproxyClientH2(DeproxyClient):
                         return
                     self.receive_response(response)
                     self.nrresp += 1
+                else:
+                    self.handle_read()
 
         except deproxy.IncompleteMessage:
             tf_cfg.dbg(

--- a/selftests/test_deproxy.py
+++ b/selftests/test_deproxy.py
@@ -236,6 +236,23 @@ class DeproxyTestH2(tester.TempestaTest):
         resp = deproxy_cl.wait_for_response(timeout=5)
         self.assertEqual(deproxy_cl.last_response.status, "200")
 
+    def test_get_4xx_response(self):
+        self.start_all()
+
+        head = [
+            (":authority", ""),
+            (":path", "/"),
+            (":scheme", "https"),
+            (":method", "GET"),
+        ]
+        deproxy_cl = self.get_client("deproxy")
+        deproxy_cl.parsing = False
+        deproxy_cl.make_request(head)
+
+        self.assertTrue(deproxy_cl.wait_for_response(timeout=2))
+        self.assertIsNotNone(deproxy_cl.last_response)
+        self.assertEqual(deproxy_cl.last_response.status, "400")
+
 
 class DeproxyClientTest(tester.TempestaTest):
 


### PR DESCRIPTION
This was used in #265, and now pulled into separate PR.

`handle_read()` method is call 3-4 (or more) times for 2xx responses, but only 1 times for 4xx responses.