### PR TITLE
`tcpdump` for tests

### DIFF
--- a/framework/tester.py
+++ b/framework/tester.py
@@ -24,7 +24,7 @@ backend_defs = {}
 tempesta_defs = {}
 save_tcpdump = False
 last_test_id = ""
-build_info = f"{datetime.date.today()}/{datetime.datetime.now().strftime('%H:%M:%S')}"
+build_path = f"/var/tcpdump/{datetime.date.today()}/{datetime.datetime.now().strftime('%H:%M:%S')}"
 
 
 def register_backend(type_name, factory):
@@ -408,11 +408,10 @@ class TempestaTest(unittest.TestCase):
         """
         if save_tcpdump and self.__tcpdump is None:
             tempesta_ip = tf_cfg.cfg.get("Tempesta", "ip")
-            dir_path = f"/var/tcpdump/{build_info}"
             test_name = self.__update_tcpdump_filename()
 
-            if not os.path.isdir(dir_path):
-                os.makedirs(dir_path)
+            if not os.path.isdir(build_path):
+                os.makedirs(build_path)
 
             self.__tcpdump = subprocess.Popen(
                 [
@@ -422,7 +421,7 @@ class TempestaTest(unittest.TestCase):
                     "any",
                     f"ip src {tempesta_ip} and ip dst {tempesta_ip}",
                     "-w",
-                    f"{dir_path}/{test_name}.pcap",
+                    f"{build_path}/{test_name}.pcap",
                 ],
                 shell=False,
                 stdout=subprocess.PIPE,

--- a/run_tests.py
+++ b/run_tests.py
@@ -162,7 +162,7 @@ for opt, arg in options:
     elif opt in ("-I", "--ignore-errors"):
         ignore_errors = True
     elif opt in ("-i", "--identifier"):
-        tester.build_info = arg
+        tester.build_path = arg
     elif opt in ("-s", "--save-tcpdump"):
         tester.save_tcpdump = True
 


### PR DESCRIPTION
added enable/disable `tcpdump` in `setUp` and `teardown` methods.
New options for running tests:
- `-i` or `--identifier` is path to tcpdump results folder.  Workspace path and build tag on CI or other. 
- `-s` or `--save-tcpdump` - enable `tcpdump` for test. Results is saved to file with name of test. Works with `-R` option. Default path - `/var/tcpdump/<date>/<time>/<test_id>.pcap [number]`. For `-i` option - `/<identifier>/<test_id>.pcap [number]`