### PR TITLE
fixed blinking tests

### DIFF
--- a/helpers/tf_cfg.py
+++ b/helpers/tf_cfg.py
@@ -108,8 +108,11 @@ class TestFrameworkCfg(object):
         self.config["General"]["Duration"] = val
         return True
 
-    def get(self, section, opt):
+    def get(self, section, opt) -> str:
         return self.config[section][opt]
+
+    def set_option(self, section: str, opt: str, value: str) -> None:
+        self.config[section][opt] = value
 
     def get_binary(self, section, binary):
         if self.config.has_option(section, binary):

--- a/http_rules/test_http.py
+++ b/http_rules/test_http.py
@@ -228,6 +228,7 @@ class HttpRulesBackupServers(HttpRules):
         # Check tempesta for no errors
         self.tempesta.get_stats()
         self.assert_tempesta()
+        self.main_server.stop()
 
     def response_received(self):
         self.responses_received += 1

--- a/t_long_body/test_long_request.py
+++ b/t_long_body/test_long_request.py
@@ -105,6 +105,11 @@ class LongBodyInRequest(TempestaTest, CustomMtuMixin):
     ]
 
     def setUp(self):
+        self.verbose = tf_cfg.cfg.get("General", "verbose")
+        if int(self.verbose) < 2:
+            print(f"\n{self.id()}")
+            tf_cfg.cfg.set_option("General", "verbose", "2")
+
         location = tf_cfg.cfg.get("Client", "workdir")
         self.abs_path = os.path.join(location, "long_body.bin")
         remote.client.copy_file(self.abs_path, "x" * BODY_SIZE)
@@ -112,6 +117,9 @@ class LongBodyInRequest(TempestaTest, CustomMtuMixin):
 
     def tearDown(self):
         super().tearDown()
+
+        tf_cfg.cfg.set_option("General", "verbose", self.verbose)
+
         if not remote.DEBUG_FILES:
             remote.client.run_cmd(f"rm {self.abs_path}")
 

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -134,10 +134,6 @@
             "reason" : "Disabled by issue #1669"
         },
         {
-            "name" : "tls.test_tls_kernel.TCrypt.test_tcrypt",
-            "reason" : "Disabled by issue #328"
-        },
-        {
             "name" : "tls.test_tls_limits.TLSLimits.test_with_deproxy",
             "reason" : "Disabled by issue #363"
         },
@@ -234,10 +230,6 @@
             "reason": "Need to investigate"
         },
         {
-            "name" : "http_rules.test_http.HttpRulesBackupServers.test_scheduler",
-            "reason": "Disable by issue #328"
-        },
-        {
             "name": "tls.test_tls_cert.TlsCertSelectBySan",
             "reason": "Disable by issue #1688"
         },
@@ -264,46 +256,6 @@
         {
             "name": "tls.test_tls_cert.TlsSniWithHttpTableMultiH2Frang",
             "reason": "Disable by issue #1688"
-        },
-        {
-            "name" : "very_many_backends.test_deadtime_1M.ChangingSG.test",
-            "reason": "Disable by issue #328"
-        },
-        {
-            "name" : "very_many_backends.test_deadtime_1M.AddingBackendNewSG.test",
-            "reason": "Disable by issue #328"
-        },
-        {
-            "name" : "very_many_backends.test_deadtime_1M.DontModifyBackend.test",
-            "reason": "Disable by issue #328"
-        },
-        {
-            "name" : "very_many_backends.test_deadtime_1M.RemovingBackendSG.test",
-            "reason": "Disable by issue #328"
-        },
-        {
-            "name" : "cache.test_cache_control.ResponseMustRevalidateCached.test",
-            "reason": "Disable by issue #328"
-        },
-        {
-            "name" : "cache.test_cache_control.StoringResponsesWithSetCookieHeaderProxyRevalidateCache.test",
-            "reason": "Disable by issue #328"
-        },
-        {
-            "name" : "cache.test_cache_control.RequestOnlyIfCachedCached.test",
-            "reason": "Disable by issue #328"
-        },
-        {
-            "name" : "cache.test_cache_control.StoringResponsesToAuthenticatedRequestsMustRevalidateCache2.test",
-            "reason": "Disable by issue #328"
-        },
-        {
-            "name" : "t_long_body.test_long_request",
-            "reason": "Disable by issue #328"
-        },
-        {
-            "name" : "cache.test_cache_control.StoringResponsesWithSetCookieHeaderMustRevalidateCache",
-            "reason": "Disable by issue #328"
         },
         {
             "name" : "http2_general.test_h2_sticky_cookie.H2StickyCookieTestCase",
@@ -488,6 +440,10 @@
         {
             "name": "t_frang.test_client_body_and_header_timeout",
             "reason": "Disabled by issue #1762"
+        },
+        {
+            "name": "cache.test_cache_control",
+            "reason": "Disabled by PR #1765"
         }
     ]
 }

--- a/tls/test_tls_kernel.py
+++ b/tls/test_tls_kernel.py
@@ -29,8 +29,8 @@ class TCrypt(tester.TempestaTest):
         except Exception as e:
             # modprobe tcrypt always returns non-zero status code.
             # -EAGAIN return code is the successful return code of the module.
-            m = re.findall("Resource temporarily unavailable\n", str(e))
-            self.assertTrue(len(m) == 5)
+            m = re.findall("Resource temporarily unavailable", e.stderr.decode())
+            self.assertEqual(len(m), 5)
 
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
I didn't fix `t_long_body.test_long_request` and `very_many_backends.test_deadtime_1M` because they are working on CI now. But I added curl error output for `test_long_request`.

The main problem of blinking `test_cache_control` is situation when `max-age` == `age`. I fixed timeouts for these tests.

`test_cache_control` are disabled  by https://github.com/tempesta-tech/tempesta/pull/1765. 

