### PR TITLE
Enable tests which was blocked by #1690 tempesta issue

### DIFF
--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -270,10 +270,6 @@
             "reason" : "Disabled by issue #1704"
         },
         {
-            "name" : "http_general.test_headers.BackendSetCoookie",
-            "reason" : "Disabled by issue #1690"
-        },
-        {
             "name" : "sessions.test_cookies",
             "reason" : "Disabled by issue #923"
         },
@@ -302,28 +298,12 @@
             "reason": "Disabled by issues #1748 #261"
         },
         {
-            "name" : "t_sites.test_wordpress.TestWordpressSite.test_auth_not_cached",
-            "reason": "Disable by issue #1690"
-        },
-        {
-            "name" : "t_sites.test_wordpress.TestWordpressSite.test_blog_post_not_cached_for_autheticated_user",
-            "reason": "Disable by issue #1690"
-        },
-        {
             "name" : "t_sites.test_wordpress.TestWordpressSite.test_blog_post_flow",
-            "reason": "Disable by issue #1690"
-        },
-        {
-            "name" : "t_sites.test_wordpress.TestWordpressSiteH2.test_auth_not_cached",
-            "reason": "Disable by issue #1690"
-        },
-        {
-            "name" : "t_sites.test_wordpress.TestWordpressSiteH2.test_blog_post_flow",
-            "reason": "Disable by issue #1690"
+            "reason": "Disabled by issue #384"
         },
         {
             "name" : "t_sites.test_wordpress.TestWordpressSiteH2",
-            "reason": "Disable by issue #1669"
+            "reason": "Disabled by issue #384 #1669"
         },
         {
             "name" : "t_stress.test_wordpress.H2WordpressStress",


### PR DESCRIPTION
After fixed of #1690 issue in tempesta we enable all tests which was blocked by this issue. Note that
t_sites.test_wordpress.TestWordpressSiteH2 tests
are also blocked by 1669, so they are not enabled.