### PR TITLE
Add BackendSetCoookieH2 test

### DIFF
--- a/http2_general/test_h2_headers.py
+++ b/http2_general/test_h2_headers.py
@@ -292,6 +292,7 @@ return 200;
         for line in lines:
             if line.startswith("< set-cookie:"):
                 setcookie_count += 1
+                self.assertTrue(len(line.split(','))==1, "Wrong separator")
         self.assertTrue(setcookie_count == 3, "Set-Cookie headers quantity mismatch")
 
 

--- a/http2_general/test_h2_headers.py
+++ b/http2_general/test_h2_headers.py
@@ -223,6 +223,36 @@ return 200;
         CurlTestBase.run_test(self)
 
 
+class BackendSetCoookieH2(CurlTestBase):
+    """The test checks the correctness of forwarding long headers with
+    duplication in mixed order: put header B between two headers A
+    """
+
+    backends = [
+        {
+            "id": "nginx",
+            "type": "nginx",
+            "port": "8000",
+            "status_uri": "http://${server_ip}:8000/nginx_status",
+            "config": NGINX_CONFIG
+            % """
+add_header Set-Cookie "wordpress_86a9106ae65537651a8e456835b316ab=admin%7C1662810634%7CY5HVGAwBX3g13hZEvGgwSf7fyUY1t5ZaPi2JsH8Fpsa%7C634effa8a901f9b410b6fd18ca0512039ffe2f362a0d70b6d82ff995b7f8be22; path=/wp-content/plugins; HttpOnly";
+add_header Set-Cookie "wordpress_86a9106ae65537651a8e456835b316ab=admin%7C1662810634%7CY5HVGAwBX3g13hZEvGgwSf7fyUY1t5ZaPi2JsH8Fpsa%7C634effa8a901f9b410b6fd18ca0512039ffe2f362a0d70b6d82ff995b7f8be22; path=/wp-admin; HttpOnly";
+add_header Set-Cookie "wordpress_logged_in_86a9106ae65537651a8e456835b316ab=admin%7C1662810634%7CY5HVGAwBX3g13hZEvGgwSf7fyUY1t5ZaPi2JsH8Fpsa%7Cd20c220a6974e7c1bdad6eb90b19b37986bbb06ada7bff996b55d0269c077c90; path=/; HttpOnly";
+
+return 200;
+""",
+        }
+    ]
+
+    tempesta = {
+        "config": TEMPESTA_CONFIG % "",
+    }
+
+    def test(self):
+        CurlTestBase.run_test(self)
+
+
 class AddBackendShortHeadersCache(CurlTestBase):
     """The test checks the correctness of serving short headers with duplicate
     (in mixed order: put header B between two headers A) from the cache

--- a/http2_general/test_h2_headers.py
+++ b/http2_general/test_h2_headers.py
@@ -236,9 +236,9 @@ class BackendSetCoookieH2(CurlTestBase):
             "status_uri": "http://${server_ip}:8000/nginx_status",
             "config": NGINX_CONFIG
             % """
-add_header Set-Cookie "wordpress_86a9106ae65537651a8e456835b316ab=admin%7C1662810634%7CY5HVGAwBX3g13hZEvGgwSf7fyUY1t5ZaPi2JsH8Fpsa%7C634effa8a901f9b410b6fd18ca0512039ffe2f362a0d70b6d82ff995b7f8be22; path=/wp-content/plugins; HttpOnly";
-add_header Set-Cookie "wordpress_86a9106ae65537651a8e456835b316ab=admin%7C1662810634%7CY5HVGAwBX3g13hZEvGgwSf7fyUY1t5ZaPi2JsH8Fpsa%7C634effa8a901f9b410b6fd18ca0512039ffe2f362a0d70b6d82ff995b7f8be22; path=/wp-admin; HttpOnly";
-add_header Set-Cookie "wordpress_logged_in_86a9106ae65537651a8e456835b316ab=admin%7C1662810634%7CY5HVGAwBX3g13hZEvGgwSf7fyUY1t5ZaPi2JsH8Fpsa%7Cd20c220a6974e7c1bdad6eb90b19b37986bbb06ada7bff996b55d0269c077c90; path=/; HttpOnly";
+add_header Set-Cookie "wordpress_86a9106ae65537651a8e456835b316ab=admin%7C1662810634%7CY5HVGAwBX3g13hZEvGgwSf7fyUY1t5ZaPi2JsH8Fpsa%7C634effa8a901f9b410b6fd18ca0512039ffe2f362a0d70b6d82ff995b7f8be22,path=/wp-content/plugins,HttpOnly";
+add_header Set-Cookie "wordpress_86a9106ae65537651a8e456835b316ab=admin%7C1662810634%7CY5HVGAwBX3g13hZEvGgwSf7fyUY1t5ZaPi2JsH8Fpsa%7C634effa8a901f9b410b6fd18ca0512039ffe2f362a0d70b6d82ff995b7f8be22,path=/wp-admin,HttpOnly";
+add_header Set-Cookie "wordpress_logged_in_86a9106ae65537651a8e456835b316ab=admin%7C1662810634%7CY5HVGAwBX3g13hZEvGgwSf7fyUY1t5ZaPi2JsH8Fpsa%7Cd20c220a6974e7c1bdad6eb90b19b37986bbb06ada7bff996b55d0269c077c90,path=/,HttpOnly";
 
 return 200;
 """,

--- a/http2_general/test_h2_headers.py
+++ b/http2_general/test_h2_headers.py
@@ -247,11 +247,11 @@ return 200;
     ]
 
     tempesta = {
-        "config": TEMPESTA_CONFIG % "",
+        "config": TEMPESTA_CONFIG % "cache_fulfill * *;",
     }
 
     def test(self):
-        CurlTestBase.run_test(self)
+        CurlTestBase.run_test(self, True)
 
 
 class AddBackendShortHeadersCache(CurlTestBase):

--- a/http2_general/test_h2_headers.py
+++ b/http2_general/test_h2_headers.py
@@ -7,7 +7,7 @@ analises its return code.
 from framework import tester
 
 __author__ = "Tempesta Technologies, Inc."
-__copyright__ = "Copyright (C) 2022 Tempesta Technologies, Inc."
+__copyright__ = "Copyright (C) 2023 Tempesta Technologies, Inc."
 __license__ = "GPL2"
 
 NGINX_CONFIG = """

--- a/http2_general/test_h2_headers.py
+++ b/http2_general/test_h2_headers.py
@@ -224,8 +224,9 @@ return 200;
 
 
 class BackendSetCoookieH2(CurlTestBase):
-    """The test checks the correctness of forwarding long headers with
-    duplication in mixed order: put header B between two headers A
+    """
+    This is a H2 version of BackendSetCoookie test case
+    Put special headers with same Set-Cookie name
     """
 
     backends = [
@@ -236,9 +237,9 @@ class BackendSetCoookieH2(CurlTestBase):
             "status_uri": "http://${server_ip}:8000/nginx_status",
             "config": NGINX_CONFIG
             % """
-add_header Set-Cookie "wordpress_86a9106ae65537651a8e456835b316ab=admin%7C1662810634%7CY5HVGAwBX3g13hZEvGgwSf7fyUY1t5ZaPi2JsH8Fpsa%7C634effa8a901f9b410b6fd18ca0512039ffe2f362a0d70b6d82ff995b7f8be22,path=/wp-content/plugins,HttpOnly";
-add_header Set-Cookie "wordpress_86a9106ae65537651a8e456835b316ab=admin%7C1662810634%7CY5HVGAwBX3g13hZEvGgwSf7fyUY1t5ZaPi2JsH8Fpsa%7C634effa8a901f9b410b6fd18ca0512039ffe2f362a0d70b6d82ff995b7f8be22,path=/wp-admin,HttpOnly";
-add_header Set-Cookie "wordpress_logged_in_86a9106ae65537651a8e456835b316ab=admin%7C1662810634%7CY5HVGAwBX3g13hZEvGgwSf7fyUY1t5ZaPi2JsH8Fpsa%7Cd20c220a6974e7c1bdad6eb90b19b37986bbb06ada7bff996b55d0269c077c90,path=/,HttpOnly";
+add_header Set-Cookie "wordpress_86a9106ae65537651a8e456835b316ab=admin%7C1662810634%7CY5HVGAwBX3g13hZEvGgwSf7fyUY1t5ZaPi2JsH8Fpsa%7C634effa8a901f9b410b6fd18ca0512039ffe2f362a0d70b6d82ff995b7f8be22; path=/wp-content/plugins; HttpOnly";
+add_header Set-Cookie "wordpress_86a9106ae65537651a8e456835b316ab=admin%7C1662810634%7CY5HVGAwBX3g13hZEvGgwSf7fyUY1t5ZaPi2JsH8Fpsa%7C634effa8a901f9b410b6fd18ca0512039ffe2f362a0d70b6d82ff995b7f8be22; path=/wp-admin; HttpOnly";
+add_header Set-Cookie "wordpress_logged_in_86a9106ae65537651a8e456835b316ab=admin%7C1662810634%7CY5HVGAwBX3g13hZEvGgwSf7fyUY1t5ZaPi2JsH8Fpsa%7Cd20c220a6974e7c1bdad6eb90b19b37986bbb06ada7bff996b55d0269c077c90; path=/; HttpOnly";
 
 return 200;
 """,

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -312,7 +312,11 @@
         {
             "name" : "t_sites.test_wordpress.TestWordpressSite.test_blog_post_not_cached_for_autheticated_user",
             "reason": "Disable by issue #1690"
-        },        
+        },
+        {
+            "name" : "t_sites.test_wordpress.TestWordpressSite.test_blog_post_flow",
+            "reason": "Disable by issue #1690"
+        },
         {
             "name" : "t_sites.test_wordpress.TestWordpressSiteH2.test_auth_not_cached",
             "reason": "Disable by issue #1690"
@@ -440,6 +444,10 @@
         {
             "name": "http2_general.test_h2_frame.TestH2Frame.test_tcp_framing_for_request",
             "reason": "Disabled by issue #1743"
+        },
+        {
+            "name": "http2_general.test_h2_headers",
+            "reason": "Disabled by issue #261"
         },
         {
             "name": "http2_general.test_h2_ping",

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -314,10 +314,6 @@
             "reason": "Disable by issue #1690"
         },        
         {
-            "name" : "t_sites.test_wordpress.TestWordpressSite.test_blog_post_flow",
-            "reason": "Disable by issue #1690"
-        },
-        {
             "name" : "t_sites.test_wordpress.TestWordpressSiteH2.test_auth_not_cached",
             "reason": "Disable by issue #1690"
         },
@@ -444,10 +440,6 @@
         {
             "name": "http2_general.test_h2_frame.TestH2Frame.test_tcp_framing_for_request",
             "reason": "Disabled by issue #1743"
-        },
-        {
-            "name": "http2_general.test_h2_headers",
-            "reason": "Disabled by issue #261"
         },
         {
             "name": "http2_general.test_h2_ping",


### PR DESCRIPTION
As we discussed - add a test, which cover multiple Set-Cookie headers case in HTTP2 version