### PR TITLE
h2 tests and deproxy h2 update

### DIFF
--- a/framework/deproxy_client.py
+++ b/framework/deproxy_client.py
@@ -475,9 +475,7 @@ class DeproxyClientH2(DeproxyClient):
             max_header_list_size,
         )
 
-        f = SettingsFrame(0)
-        for setting, value in Settings(initial_values=new_settings).items():
-            f.settings[setting] = value
+        f = SettingsFrame(stream_id=0, settings=new_settings)
 
         self.request_buffers.append(f.serialize())
         self.nrreq += 1

--- a/framework/deproxy_client.py
+++ b/framework/deproxy_client.py
@@ -393,8 +393,6 @@ class DeproxyClientH2(DeproxyClient):
             self.h2_connection = h2.connection.H2Connection()
             self.h2_connection.encoder = self.encoder
             self.h2_connection.initiate_connection()
-        if self.selfproxy_present:
-            self.update_selfproxy()
 
         self.h2_connection.encoder.huffman = huffman
 
@@ -427,7 +425,7 @@ class DeproxyClientH2(DeproxyClient):
             self.stream_id += 2
             self.valid_req_num += 1
 
-    def update_initiate_settings(
+    def update_initial_settings(
         self,
         header_table_size: int = None,
         enable_push: int = None,
@@ -549,7 +547,6 @@ class DeproxyClientH2(DeproxyClient):
                     self.nrresp += 1
                 elif isinstance(event, ConnectionTerminated):
                     self.error_codes.append(event.error_code)
-                    self.handle_close()
                 elif isinstance(event, SettingsAcknowledged):
                     self.ack_settings = True
                     # TODO should be changed by issue #358

--- a/framework/deproxy_client.py
+++ b/framework/deproxy_client.py
@@ -453,6 +453,7 @@ class DeproxyClientH2(DeproxyClient):
             # if settings is empty, we should not change them
             if new_settings:
                 self.h2_connection.local_settings = Settings(initial_values=new_settings)
+                self.h2_connection.local_settings.update(new_settings)
 
             self.h2_connection.initiate_connection()
 

--- a/framework/deproxy_client.py
+++ b/framework/deproxy_client.py
@@ -512,7 +512,6 @@ class DeproxyClientH2(DeproxyClient):
             events = self.h2_connection.receive_data(self.response_buffer)
             for event in events:
                 if isinstance(event, ResponseReceived):
-                    method = self.methods[self.nrresp]
                     headers = self.__binary_headers_to_string(event.headers)
 
                     response = self.active_responses.get(event.stream_id)
@@ -523,7 +522,7 @@ class DeproxyClientH2(DeproxyClient):
                     else:
                         response = deproxy.H2Response(
                             headers + "\r\n",
-                            method=method,
+                            method=self.methods[self.nrresp],
                             body_parsing=False,
                             keep_original_data=self.keep_original_data,
                         )

--- a/helpers/deproxy.py
+++ b/helpers/deproxy.py
@@ -32,7 +32,7 @@ import run_config
 from . import error, stateful, tempesta, tf_cfg
 
 __author__ = "Tempesta Technologies, Inc."
-__copyright__ = "Copyright (C) 2017-2022 Tempesta Technologies, Inc."
+__copyright__ = "Copyright (C) 2017-2023 Tempesta Technologies, Inc."
 __license__ = "GPL2"
 
 # -------------------------------------------------------------------------------
@@ -741,6 +741,7 @@ class Client(TlsClient, stateful.Stateful):
         self.stop_procedures = [self.__stop_client]
         self.conn_is_closed = True
         self.bind_addr = bind_addr
+        self.error_codes = []
 
     def __stop_client(self):
         tf_cfg.dbg(4, "\tStop deproxy client")
@@ -821,7 +822,8 @@ class Client(TlsClient, stateful.Stateful):
         self.request_buffer = self.request_buffer[sent:]
 
     def handle_error(self):
-        _, v, _ = sys.exc_info()
+        type_error, v, _ = sys.exc_info()
+        self.error_codes.append(type_error)
         if type(v) == ParseError or type(v) == AssertionError:
             raise v
         elif type(v) == ssl.SSLWantReadError:

--- a/http2_general/__init__.py
+++ b/http2_general/__init__.py
@@ -1,3 +1,10 @@
-__all__ = ["test_h2_specs", "test_h2_perf", "test_h2_ping", "test_h2_frame", "test_h2_hpack"]
+__all__ = [
+    "test_h2_specs",
+    "test_h2_perf",
+    "test_h2_ping",
+    "test_h2_frame",
+    "test_h2_hpack",
+    "test_flow_control_window",
+]
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/http2_general/__init__.py
+++ b/http2_general/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     "test_h2_streams",
     "test_h2_headers",
     "test_h2_sticky_cookie",
+    "test_h2_max_frame_size",
 ]
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/http2_general/__init__.py
+++ b/http2_general/__init__.py
@@ -5,6 +5,9 @@ __all__ = [
     "test_h2_frame",
     "test_h2_hpack",
     "test_flow_control_window",
+    "test_h2_streams",
+    "test_h2_headers",
+    "test_h2_sticky_cookie",
 ]
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/http2_general/helpers.py
+++ b/http2_general/helpers.py
@@ -1,0 +1,68 @@
+__author__ = "Tempesta Technologies, Inc."
+__copyright__ = "Copyright (C) 2023 Tempesta Technologies, Inc."
+__license__ = "GPL2"
+
+from framework import deproxy_client, tester
+
+
+class H2Base(tester.TempestaTest):
+    backends = [
+        {
+            "id": "deproxy",
+            "type": "deproxy",
+            "port": "8000",
+            "response": "static",
+            "response_content": (
+                "HTTP/1.1 200 OK\r\n"
+                + "Date: test\r\n"
+                + "Server: debian\r\n"
+                + "Content-Length: 0\r\n\r\n"
+            ),
+        }
+    ]
+
+    tempesta = {
+        "config": """
+            listen 443 proto=h2;
+            server ${server_ip}:8000;
+            tls_certificate ${tempesta_workdir}/tempesta.crt;
+            tls_certificate_key ${tempesta_workdir}/tempesta.key;
+            tls_match_any_server_name;
+        """
+    }
+
+    clients = [
+        {
+            "id": "deproxy",
+            "type": "deproxy_h2",
+            "addr": "${tempesta_ip}",
+            "port": "443",
+            "ssl": True,
+        },
+    ]
+
+    post_request = [
+        (":authority", "example.com"),
+        (":path", "/"),
+        (":scheme", "https"),
+        (":method", "POST"),
+    ]
+
+    get_request = [
+        (":authority", "example.com"),
+        (":path", "/"),
+        (":scheme", "https"),
+        (":method", "GET"),
+    ]
+
+    def initiate_h2_connection(self, client: deproxy_client.DeproxyClientH2):
+        # add preamble + settings frame with default variable into data_to_send
+        client.update_initiate_settings()
+        # send preamble + settings frame to Tempesta
+        client.send_bytes(client.h2_connection.data_to_send())
+        client.h2_connection.clear_outbound_data_buffer()
+
+        self.assertTrue(
+            client.wait_for_ack_settings(),
+            "Tempesta foes not returns SETTINGS frame with ACK flag.",
+        )

--- a/http2_general/helpers.py
+++ b/http2_general/helpers.py
@@ -28,6 +28,9 @@ class H2Base(tester.TempestaTest):
             tls_certificate ${tempesta_workdir}/tempesta.crt;
             tls_certificate_key ${tempesta_workdir}/tempesta.key;
             tls_match_any_server_name;
+            
+            block_action attack reply;
+            block_action error reply;
         """
     }
 

--- a/http2_general/helpers.py
+++ b/http2_general/helpers.py
@@ -60,7 +60,7 @@ class H2Base(tester.TempestaTest):
 
     def initiate_h2_connection(self, client: deproxy_client.DeproxyClientH2):
         # add preamble + settings frame with default variable into data_to_send
-        client.update_initiate_settings()
+        client.update_initial_settings()
         # send preamble + settings frame to Tempesta
         client.send_bytes(client.h2_connection.data_to_send())
         client.h2_connection.clear_outbound_data_buffer()

--- a/http2_general/test_flow_control_window.py
+++ b/http2_general/test_flow_control_window.py
@@ -1,0 +1,71 @@
+"""Functional tests for flow control window."""
+
+__author__ = "Tempesta Technologies, Inc."
+__copyright__ = "Copyright (C) 2023 Tempesta Technologies, Inc."
+__license__ = "GPL2"
+
+from framework import tester
+
+
+class TestFlowControl(tester.TempestaTest):
+    backends = [
+        {
+            "id": "deproxy",
+            "type": "deproxy",
+            "port": "8000",
+            "response": "static",
+            "response_content": (
+                "HTTP/1.1 200 OK\r\n"
+                + "Date: test\r\n"
+                + "Server: debian\r\n"
+                + "Content-Length: 2000\r\n\r\n"
+                + ("x" * 2000)
+            ),
+        }
+    ]
+
+    tempesta = {
+        "config": """
+            listen 443 proto=h2;
+            server ${server_ip}:8000;
+            tls_certificate ${tempesta_workdir}/tempesta.crt;
+            tls_certificate_key ${tempesta_workdir}/tempesta.key;
+            tls_match_any_server_name;
+        """
+    }
+
+    clients = [
+        {
+            "id": "deproxy",
+            "type": "deproxy_h2",
+            "addr": "${tempesta_ip}",
+            "port": "443",
+            "ssl": True,
+        },
+    ]
+
+    request_headers = [
+        (":authority", "debian"),
+        (":path", "/"),
+        (":scheme", "https"),
+        (":method", "POST"),
+    ]
+
+    def test_flow_control_window_for_stream(self):
+        """
+        Client sets SETTINGS_INITIAL_WINDOW_SIZE = 1k bytes and backend returns response
+        with 2k bytes body.
+        Tempesta must forward DATA frame with 1k bytes and wait WindowUpdate from client.
+        """
+        self.start_all_services()
+        client = self.get_client("deproxy")
+
+        client.update_initiate_settings(initial_window_size=1000)
+        client.make_request(self.request_headers)
+
+        self.assertTrue(
+            client.wait_for_response(), "Tempesta ignored flow control window for stream."
+        )
+        self.assertEqual(
+            len(client.last_response.body), 2000, "Tempesta did not return full response body."
+        )

--- a/http2_general/test_flow_control_window.py
+++ b/http2_general/test_flow_control_window.py
@@ -27,7 +27,7 @@ class TestFlowControl(H2Base):
             + ("x" * 2000)
         )
 
-        client.update_initiate_settings(initial_window_size=1000)
+        client.update_initial_settings(initial_window_size=1000)
         client.make_request(self.post_request)
         client.wait_for_response(3)
 

--- a/http2_general/test_h2_frame.py
+++ b/http2_general/test_h2_frame.py
@@ -114,7 +114,7 @@ class TestH2Frame(H2Base):
         client: deproxy_client.DeproxyClientH2 = self.get_client("deproxy")
 
         # add preamble + settings frame with SETTING_INITIAL_WINDOW_SIZE = 65535
-        client.update_initiate_settings()
+        client.update_initial_settings()
 
         # send preamble + settings frame
         client.send_bytes(client.h2_connection.data_to_send())
@@ -137,7 +137,7 @@ class TestH2Frame(H2Base):
 
         client: deproxy_client.DeproxyClientH2 = self.get_client("deproxy")
 
-        client.update_initiate_settings()
+        client.update_initial_settings()
         client.send_bytes(client.h2_connection.data_to_send())
         client.h2_connection.clear_outbound_data_buffer()
 

--- a/http2_general/test_h2_frame.py
+++ b/http2_general/test_h2_frame.py
@@ -4,52 +4,12 @@ __author__ = "Tempesta Technologies, Inc."
 __copyright__ = "Copyright (C) 2023 Tempesta Technologies, Inc."
 __license__ = "GPL2"
 
-import h2.connection
-import h2.settings
-
-from framework import deproxy_client, tester
+from framework import deproxy_client
 from helpers import checks_for_tests as checks
+from http2_general.helpers import H2Base
 
 
-class TestH2Frame(tester.TempestaTest):
-
-    backends = [
-        {
-            "id": "deproxy",
-            "type": "deproxy",
-            "port": "8000",
-            "response": "static",
-            "response_content": "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n",
-        }
-    ]
-
-    clients = [
-        {
-            "id": "deproxy",
-            "type": "deproxy_h2",
-            "addr": "${tempesta_ip}",
-            "port": "443",
-            "ssl": True,
-        },
-    ]
-
-    tempesta = {
-        "config": """
-            listen 443 proto=h2;
-            server ${server_ip}:8000;
-            tls_certificate ${tempesta_workdir}/tempesta.crt;
-            tls_certificate_key ${tempesta_workdir}/tempesta.key;
-            tls_match_any_server_name;
-        """
-    }
-
-    request_headers = [
-        (":authority", "debian"),
-        (":path", "/"),
-        (":scheme", "https"),
-        (":method", "POST"),
-    ]
-
+class TestH2Frame(H2Base):
     def test_data_framing(self):
         """Send many 1 byte frames in request."""
         self.start_all_services()
@@ -57,7 +17,7 @@ class TestH2Frame(tester.TempestaTest):
         deproxy_cl.parsing = False
         request_body = "x" * 100
 
-        deproxy_cl.make_request(request=self.request_headers, end_stream=False)
+        deproxy_cl.make_request(request=self.post_request, end_stream=False)
         for byte in request_body[:-1]:
             deproxy_cl.make_request(request=byte, end_stream=False)
         deproxy_cl.make_request(request=request_body[-1], end_stream=True)
@@ -73,7 +33,7 @@ class TestH2Frame(tester.TempestaTest):
         deproxy_cl.parsing = False
         request_body = "123"
 
-        deproxy_cl.make_request(request=self.request_headers, end_stream=False)
+        deproxy_cl.make_request(request=self.post_request, end_stream=False)
         deproxy_cl.make_request(request=request_body, end_stream=False)
         deproxy_cl.make_request(request="", end_stream=True)
 
@@ -88,7 +48,7 @@ class TestH2Frame(tester.TempestaTest):
         deproxy_cl.parsing = False
         request_body = "123"
 
-        deproxy_cl.make_request(request=self.request_headers, end_stream=False)
+        deproxy_cl.make_request(request=self.post_request, end_stream=False)
         deproxy_cl.make_request(request="", end_stream=False)
         deproxy_cl.make_request(request=request_body, end_stream=True)
 
@@ -101,7 +61,7 @@ class TestH2Frame(tester.TempestaTest):
         self.start_all_services()
         client.parsing = False
 
-        client.make_request(self.request_headers)
+        client.make_request(self.post_request)
 
         self.__assert_test(client=client, request_body="", request_number=1)
 
@@ -115,7 +75,7 @@ class TestH2Frame(tester.TempestaTest):
         for chunk_size in chunk_sizes:
             with self.subTest(chunk_size=chunk_size):
                 client.segment_size = chunk_size
-                client.make_request(self.request_headers, False)
+                client.make_request(self.post_request, False)
 
                 request_body = "0123456789"
                 client.make_request(request_body, True)
@@ -136,25 +96,16 @@ class TestH2Frame(tester.TempestaTest):
 
         client: deproxy_client.DeproxyClientH2 = self.get_client("deproxy")
 
-        client.h2_connection = h2.connection.H2Connection()
         # initiate_connection() generates preamble + settings frame with default variables
-        client.h2_connection.initiate_connection()
-
-        # send preamble + settings frame
-        client.request_buffers.append(client.h2_connection.data_to_send())
-        client.nrreq += 1
-        client.h2_connection.clear_outbound_data_buffer()
-
-        self.assertTrue(client.wait_for_ack_settings())
+        self.initiate_h2_connection(client)
 
         # send empty setting frame with ack flag.
-        client.request_buffers.append(client.h2_connection.data_to_send())
-        client.nrreq += 1
+        client.send_bytes(client.h2_connection.data_to_send())
         client.h2_connection.clear_outbound_data_buffer()
 
         # send header frame after exchanging settings and make sure
         # that connection is open.
-        client.send_request(self.request_headers, "200")
+        client.send_request(self.post_request, "200")
 
     def __assert_test(self, client, request_body: str, request_number: int):
         server = self.get_server("deproxy")
@@ -170,7 +121,7 @@ class TestH2Frame(tester.TempestaTest):
             srv_msg_forwarded=request_number,
         )
         error_msg = "Malformed request from Tempesta."
-        self.assertEqual(server.last_request.method, self.request_headers[3][1], error_msg)
-        self.assertEqual(server.last_request.headers["host"], self.request_headers[0][1], error_msg)
-        self.assertEqual(server.last_request.uri, self.request_headers[1][1], error_msg)
+        self.assertEqual(server.last_request.method, self.post_request[3][1], error_msg)
+        self.assertEqual(server.last_request.headers["host"], self.post_request[0][1], error_msg)
+        self.assertEqual(server.last_request.uri, self.post_request[1][1], error_msg)
         self.assertEqual(server.last_request.body, request_body)

--- a/http2_general/test_h2_frame.py
+++ b/http2_general/test_h2_frame.py
@@ -1,25 +1,14 @@
 """Functional tests for h2 frames."""
 
 __author__ = "Tempesta Technologies, Inc."
-__copyright__ = "Copyright (C) 2022 Tempesta Technologies, Inc."
+__copyright__ = "Copyright (C) 2023 Tempesta Technologies, Inc."
 __license__ = "GPL2"
-
-import socket
-import ssl
-import time
 
 import h2.connection
 import h2.settings
-from h2.events import (
-    RemoteSettingsChanged,
-    ResponseReceived,
-    SettingsAcknowledged,
-    StreamEnded,
-)
 
 from framework import deproxy_client, tester
 from helpers import checks_for_tests as checks
-from helpers import tf_cfg
 
 
 class TestH2Frame(tester.TempestaTest):

--- a/http2_general/test_h2_frame.py
+++ b/http2_general/test_h2_frame.py
@@ -141,6 +141,8 @@ class TestH2Frame(H2Base):
         client.send_bytes(client.h2_connection.data_to_send())
         client.h2_connection.clear_outbound_data_buffer()
 
+        # H2Connection separates headers to HEADERS + CONTINUATION frames
+        # if they are larger than 16384 bytes
         client.send_request(
             request=self.get_request + [("qwerty", "x" * 5000) for _ in range(4)],
             expected_status_code="200",

--- a/http2_general/test_h2_headers.py
+++ b/http2_general/test_h2_headers.py
@@ -148,7 +148,7 @@ class TestPseudoHeaders(H2Base):
         ]
         self.__test([("content-length", "0"), (":method", "POST")])
 
-    def __test(self, optional_header: list[tuple]):
+    def __test(self, optional_header: list):
         self.start_all_services()
 
         client = self.get_client("deproxy")

--- a/http2_general/test_h2_hpack.py
+++ b/http2_general/test_h2_hpack.py
@@ -86,7 +86,7 @@ class TestHpack(H2Base):
         server = self.get_server("deproxy")
 
         new_table_size = 512
-        client.update_initiate_settings(header_table_size=new_table_size)
+        client.update_initial_settings(header_table_size=new_table_size)
 
         header = "x" * new_table_size * 2
         server.set_response(
@@ -374,7 +374,7 @@ class TestHpack(H2Base):
         client: deproxy_client.DeproxyClientH2 = self.get_client("deproxy")
         server = self.get_server("deproxy")
 
-        client.update_initiate_settings()
+        client.update_initial_settings()
         client.send_bytes(client.h2_connection.data_to_send())
         client.wait_for_ack_settings()
 
@@ -465,7 +465,7 @@ class TestFramePayloadLength(H2Base):
         self.start_all_services()
         client: deproxy_client.DeproxyClientH2 = self.get_client("deproxy")
 
-        client.update_initiate_settings()
+        client.update_initial_settings()
         client.send_bytes(client.h2_connection.data_to_send())
 
         # send headers frame with stream_id = 1, header count = 3

--- a/http2_general/test_h2_max_frame_size.py
+++ b/http2_general/test_h2_max_frame_size.py
@@ -16,7 +16,7 @@ class TestMaxFrameSize(H2Base):
         client: deproxy_client.DeproxyClientH2 = self.get_client("deproxy")
         server: deproxy_server.StaticDeproxyServer = self.get_server("deproxy")
 
-        client.update_initiate_settings(max_frame_size=16384)
+        client.update_initial_settings(max_frame_size=16384)
 
         response_body = "x" * 20000
         server.set_response(
@@ -40,7 +40,7 @@ class TestMaxFrameSize(H2Base):
         client: deproxy_client.DeproxyClientH2 = self.get_client("deproxy")
         server: deproxy_server.StaticDeproxyServer = self.get_server("deproxy")
 
-        client.update_initiate_settings(max_frame_size=16384)
+        client.update_initial_settings(max_frame_size=16384)
 
         large_header = ("qwerty", "x" * 17000)
         server.set_response(
@@ -69,7 +69,7 @@ class TestMaxFrameSize(H2Base):
 
         client: deproxy_client.DeproxyClientH2 = self.get_client("deproxy")
 
-        client.update_initiate_settings()
+        client.update_initial_settings()
         # We set SETTINGS_MAX_FRAME_SIZE = 20000 that H2Connection does not raise error,
         # but Tempesta has default SETTINGS_MAX_FRAME_SIZE = 16384.
         client.h2_connection.max_outbound_frame_size = 20000
@@ -91,7 +91,7 @@ class TestMaxFrameSize(H2Base):
 
         client: deproxy_client.DeproxyClientH2 = self.get_client("deproxy")
 
-        client.update_initiate_settings()
+        client.update_initial_settings()
         # We set SETTINGS_MAX_FRAME_SIZE = 20000 that H2Connection does not raise error,
         # but Tempesta has default SETTINGS_MAX_FRAME_SIZE = 16384.
         client.h2_connection.max_outbound_frame_size = 20000

--- a/http2_general/test_h2_max_frame_size.py
+++ b/http2_general/test_h2_max_frame_size.py
@@ -1,0 +1,103 @@
+__author__ = "Tempesta Technologies, Inc."
+__copyright__ = "Copyright (C) 2023 Tempesta Technologies, Inc."
+__license__ = "GPL2"
+
+from framework import deproxy_client, deproxy_server
+from http2_general.helpers import H2Base
+
+
+class TestMaxFrameSize(H2Base):
+    def test_large_data_frame_in_response(self):
+        """
+        Tempesta must separate response body because it is larger than SETTINGS_MAX_FRAME_SIZE.
+        Client must receive several DATA frames.
+        """
+        self.start_all_services()
+        client: deproxy_client.DeproxyClientH2 = self.get_client("deproxy")
+        server: deproxy_server.StaticDeproxyServer = self.get_server("deproxy")
+
+        client.update_initiate_settings(max_frame_size=16384)
+
+        response_body = "x" * 20000
+        server.set_response(
+            "HTTP/1.1 200 OK\r\n"
+            "Date: test\r\n"
+            "Server: deproxy\r\n"
+            f"Content-Length: {len(response_body)}\r\n\r\n" + response_body
+        )
+
+        # H2Connection has SETTINGS_MAX_FRAME_SIZE = 16384 in local config therefore,
+        # client does not receive response if Tempesta send DATA frame larger than 16384
+        client.send_request(self.get_request, "200")
+        self.assertEqual(len(client.last_response.body), len(response_body))
+
+    def test_large_headers_frame_in_response(self):
+        """
+        Tempesta must separate response headers to HEADERS and CONTINUATION frames because
+        it is larger than SETTINGS_MAX_FRAME_SIZE.
+        """
+        self.start_all_services()
+        client: deproxy_client.DeproxyClientH2 = self.get_client("deproxy")
+        server: deproxy_server.StaticDeproxyServer = self.get_server("deproxy")
+
+        client.update_initiate_settings(max_frame_size=16384)
+
+        large_header = ("qwerty", "x" * 17000)
+        server.set_response(
+            "HTTP/1.1 200 OK\r\n"
+            "Date: test\r\n"
+            "Server: deproxy\r\n"
+            f"{large_header[0]}: {large_header[1]}\r\n"
+            "Content-Length: 0\r\n\r\n"
+        )
+
+        # H2Connection has SETTINGS_MAX_FRAME_SIZE = 16384 in local config therefore,
+        # client does not receive response if Tempesta send HEADERS frame larger than 16384
+        client.send_request(self.post_request, "200")
+        self.assertIsNotNone(client.last_response.headers.get(large_header[0]))
+        self.assertEqual(
+            len(client.last_response.headers.get(large_header[0])), len(large_header[1])
+        )
+
+    def test_headers_frame_is_large_than_max_frame_size(self):
+        """
+        An endpoint MUST send an error code of FRAME_SIZE_ERROR if
+        a frame exceeds the size defined in SETTINGS_MAX_FRAME_SIZE.
+        RFC 9113 4.2
+        """
+        self.start_all_services()
+
+        client: deproxy_client.DeproxyClientH2 = self.get_client("deproxy")
+
+        client.update_initiate_settings()
+        # We set SETTINGS_MAX_FRAME_SIZE = 20000 that H2Connection does not raise error,
+        # but Tempesta has default SETTINGS_MAX_FRAME_SIZE = 16384.
+        client.h2_connection.max_outbound_frame_size = 20000
+
+        request = self.post_request
+        request.append(("qwerty", "x" * 17000))
+
+        client.make_request(request=request, end_stream=True, huffman=False)
+        self.assertFalse(client.wait_for_response(1))
+        self.assertTrue(client.connection_is_closed())
+
+    def test_data_frame_is_large_than_max_frame_size(self):
+        """
+        An endpoint MUST send an error code of FRAME_SIZE_ERROR if
+        a frame exceeds the size defined in SETTINGS_MAX_FRAME_SIZE.
+        RFC 9113 4.2
+        """
+        self.start_all_services()
+
+        client: deproxy_client.DeproxyClientH2 = self.get_client("deproxy")
+
+        client.update_initiate_settings()
+        # We set SETTINGS_MAX_FRAME_SIZE = 20000 that H2Connection does not raise error,
+        # but Tempesta has default SETTINGS_MAX_FRAME_SIZE = 16384.
+        client.h2_connection.max_outbound_frame_size = 20000
+
+        client.make_request(
+            request=(self.post_request, "x" * 18000), end_stream=True, huffman=False
+        )
+        self.assertFalse(client.wait_for_response(1))
+        self.assertTrue(client.connection_is_closed())

--- a/http2_general/test_h2_streams.py
+++ b/http2_general/test_h2_streams.py
@@ -4,7 +4,11 @@ __author__ = "Tempesta Technologies, Inc."
 __copyright__ = "Copyright (C) 2023 Tempesta Technologies, Inc."
 __license__ = "GPL2"
 
-from framework import tester
+from h2.connection import AllowedStreamIDs
+from h2.errors import ErrorCodes
+from h2.stream import StreamInputs
+
+from framework import deproxy_client, tester
 
 
 class TestH2Stream(tester.TempestaTest):
@@ -39,30 +43,136 @@ class TestH2Stream(tester.TempestaTest):
         """
     }
 
+    request_headers = [
+        (":authority", "debian"),
+        (":path", "/"),
+        (":scheme", "https"),
+        (":method", "POST"),
+    ]
+
     def test_max_concurrent_stream(self):
         """
-        Tempesta must not concurrently process streams when their count exceeds set value.
+        An endpoint that receives a HEADERS frame that causes its advertised concurrent
+        stream limit to be exceeded MUST treat this as a stream error
+        of type PROTOCOL_ERROR or REFUSED_STREAM.
+        RFC 9113 5.1.2
         """
         self.start_all_services()
         client = self.get_client("deproxy")
 
-        request_headers = [
-            (":authority", "debian"),
-            (":path", "/"),
-            (":scheme", "https"),
-            (":method", "POST"),
-        ]
         # TODO need change after fix issue #1394
         max_streams = 128
 
         for _ in range(max_streams):
-            client.make_request(request=request_headers, end_stream=False)
+            client.make_request(request=self.request_headers, end_stream=False)
             client.stream_id += 2
 
-        client.make_request(request=request_headers, end_stream=True)
-        client.wait_for_response()
+        client.make_request(request=self.request_headers, end_stream=True)
+        client.wait_for_response(1)
 
-        self.assertTrue(
-            client.connection_is_closed(),
-            "Tempesta did not close connection when number of concurrent streams was exceeded.",
+        self.assertIn(ErrorCodes.PROTOCOL_ERROR or ErrorCodes.REFUSED_STREAM, client.error_codes)
+
+    def test_reuse_stream_id(self):
+        """
+        Stream identifiers cannot be reused.
+
+        An endpoint that receives an unexpected stream identifier MUST
+        respond with a connection error of type PROTOCOL_ERROR.
+        RFC 9113 5.1.1
+        """
+        self.start_all_services()
+        client: deproxy_client.DeproxyClientH2 = self.get_client("deproxy")
+        self.__initiate_h2_connection(client)
+
+        # send headers frame with stream_id = 1
+        client.send_request(self.request_headers, "200")
+        # send headers frame with stream_id = 1 again.
+        client.send_bytes(
+            data=b"\x00\x00\n\x01\x05\x00\x00\x00\x01A\x85\x90\xb1\x98u\x7f\x84\x87\x83",
+            expect_response=True,
         )
+        client.wait_for_response(1)
+
+        client.send_request(self.request_headers, "200")
+
+        self.assertIn(ErrorCodes.PROTOCOL_ERROR, client.error_codes)
+
+    def test_headers_frame_with_zero_stream_id(self):
+        """
+        The identifier of a newly established stream MUST be numerically greater
+        than all streams that the initiating endpoint has opened or reserved.
+
+        An endpoint that receives an unexpected stream identifier MUST
+        respond with a connection error of type PROTOCOL_ERROR.
+        RFC 9113 5.1.1
+        """
+        self.start_all_services()
+        client: deproxy_client.DeproxyClientH2 = self.get_client("deproxy")
+        # add preamble + settings frame with default variable into data_to_send
+        self.__initiate_h2_connection(client)
+        # send headers frame with stream_id = 0.
+        client.send_bytes(
+            b"\x00\x00\n\x01\x05\x00\x00\x00\x00A\x85\x90\xb1\x98u\x7f\x84\x87\x83",
+            expect_response=True,
+        )
+        client.wait_for_response(1)
+
+        self.assertIn(ErrorCodes.PROTOCOL_ERROR, client.error_codes)
+
+    def test_request_with_even_numbered_stream_id(self):
+        """
+        Streams initiated by a client MUST use odd-numbered stream identifiers.
+
+        An endpoint that receives an unexpected stream identifier MUST
+        respond with a connection error of type PROTOCOL_ERROR.
+        RFC 9113 5.1.1
+        """
+        self.start_all_services()
+        client: deproxy_client.DeproxyClientH2 = self.get_client("deproxy")
+        self.__initiate_h2_connection(client)
+        # send headers frame with stream_id = 2.
+        client.send_bytes(
+            b"\x00\x00\n\x01\x05\x00\x00\x00\x02A\x85\x90\xb1\x98u\x7f\x84\x87\x83",
+            expect_response=True,
+        )
+        client.wait_for_response(1)
+
+        self.assertIn(ErrorCodes.PROTOCOL_ERROR, client.error_codes)
+
+    def test_request_with_large_stream_id(self):
+        """
+        stream id >= 0x7fffffff (2**31-1).
+
+        A reserved 1-bit field. The semantics of this bit are undefined,
+        and the bit MUST remain unset (0x00) when sending and MUST be ignored when receiving.
+        RFC 9113 4.2
+        """
+        self.start_all_services()
+        client: deproxy_client.DeproxyClientH2 = self.get_client("deproxy")
+        self.__initiate_h2_connection(client)
+
+        # Create stream that H2Connection object does not raise error.
+        # We are creating stream with id = 2 ** 31 - 1 because Tempesta must return response
+        # in stream with id = 2 ** 31 - 1, but request will be made in stream with id = 2 ** 32 - 1
+        stream = client.h2_connection._begin_new_stream(
+            (2**31 - 1), AllowedStreamIDs(client.h2_connection.config.client_side)
+        )
+        stream.state_machine.process_input(StreamInputs.SEND_HEADERS)
+        # add request method that avoid error in handle_read
+        client.methods.append("POST")
+        # send headers frame with stream_id = 0xffffffff (2**32-1).
+        client.send_bytes(
+            b"\x00\x00\n\x01\x05\xff\xff\xff\xffA\x85\x90\xb1\x98u\x7f\x84\x87\x83",
+            expect_response=True,
+        )
+
+        self.assertTrue(client.wait_for_response())
+        self.assertEqual(client.last_response.status, "200")
+
+    @staticmethod
+    def __initiate_h2_connection(client: deproxy_client.DeproxyClientH2):
+        # add preamble + settings frame with default variable into data_to_send
+        client.update_initiate_settings()
+        # send preamble + settings frame to Tempesta
+        client.send_bytes(client.h2_connection.data_to_send())
+        client.h2_connection.clear_outbound_data_buffer()

--- a/http2_general/test_h2_streams.py
+++ b/http2_general/test_h2_streams.py
@@ -1,0 +1,68 @@
+"""Functional tests for h2 streams."""
+
+__author__ = "Tempesta Technologies, Inc."
+__copyright__ = "Copyright (C) 2023 Tempesta Technologies, Inc."
+__license__ = "GPL2"
+
+from framework import tester
+
+
+class TestH2Stream(tester.TempestaTest):
+
+    backends = [
+        {
+            "id": "deproxy",
+            "type": "deproxy",
+            "port": "8000",
+            "response": "static",
+            "response_content": "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n",
+        }
+    ]
+
+    clients = [
+        {
+            "id": "deproxy",
+            "type": "deproxy_h2",
+            "addr": "${tempesta_ip}",
+            "port": "443",
+            "ssl": True,
+        },
+    ]
+
+    tempesta = {
+        "config": """
+            listen 443 proto=h2;
+            server ${server_ip}:8000;
+            tls_certificate ${tempesta_workdir}/tempesta.crt;
+            tls_certificate_key ${tempesta_workdir}/tempesta.key;
+            tls_match_any_server_name;
+        """
+    }
+
+    def test_max_concurrent_stream(self):
+        """
+        Tempesta must not concurrently process streams when their count exceeds set value.
+        """
+        self.start_all_services()
+        client = self.get_client("deproxy")
+
+        request_headers = [
+            (":authority", "debian"),
+            (":path", "/"),
+            (":scheme", "https"),
+            (":method", "POST"),
+        ]
+        # TODO need change after fix issue #1394
+        max_streams = 128
+
+        for _ in range(max_streams):
+            client.make_request(request=request_headers, end_stream=False)
+            client.stream_id += 2
+
+        client.make_request(request=request_headers, end_stream=True)
+        client.wait_for_response()
+
+        self.assertTrue(
+            client.connection_is_closed(),
+            "Tempesta did not close connection when number of concurrent streams was exceeded.",
+        )

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -476,6 +476,26 @@
         {
             "name": "http2_general.test_h2_headers.TestConnectionHeaders.test_upgrade_header_in_response",
             "reason": "Disabled by issue #1805"
+        },
+        {
+            "name": "http2_general.test_h2_hpack.TestHpack.test_rewrite_dynamic_table_for_response",
+            "reason": "Disabled by issue #1792"
+        },
+        {
+            "name": "http2_general.test_h2_hpack.TestHpack.test_settings_header_table_size",
+            "reason": "Disabled by PR #1798"
+        },
+        {
+            "name": "http2_general.test_h2_hpack.TestHpack.test_settings_header_table_stress",
+            "reason": "Disabled by issue #1792"
+        },
+        {
+            "name": "http2_general.test_h2_hpack.TestFramePayloadLength.test_large_frame_payload_length",
+            "reason": "Disabled by PR #1798"
+        },
+        {
+            "name": "http2_general.test_h2_max_frame_size.TestMaxFrameSize.test_large_headers_frame_in_response",
+            "reason": "Disabled by issue #1103"
         }
     ]
 }

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -460,6 +460,22 @@
         {
             "name": "http2_general.test_h2_streams.TestH2Stream.test_reuse_stream_id",
             "reason": "Disabled by issue #1800"
+        },
+        {
+            "name": "http2_general.test_h2_headers.TestConnectionHeaders.test_proxy_connection_header_in_request",
+            "reason": "Disabled by issue #1805"
+        },
+        {
+            "name": "http2_general.test_h2_headers.TestConnectionHeaders.test_upgrade_header_in_request",
+            "reason": "Disabled by issue #1805"
+        },
+        {
+            "name": "http2_general.test_h2_headers.TestConnectionHeaders.test_proxy_connection_header_in_response",
+            "reason": "Disabled by issue #1805"
+        },
+        {
+            "name": "http2_general.test_h2_headers.TestConnectionHeaders.test_upgrade_header_in_response",
+            "reason": "Disabled by issue #1805"
         }
     ]
 }

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -451,7 +451,11 @@
         },
         {
             "name": "http2_general.test_h2_streams.TestH2Stream.test_max_concurrent_stream",
-            "reason": "Disabled by issue #1394"
+            "reason": "Disabled by issue #1346"
+        },
+        {
+            "name": "http2_general.test_h2_hpack.TestHpack.test_clearing_dynamic_table_with_settings_frame",
+            "reason": "Disabled by issue #1793"
         }
     ]
 }

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -448,6 +448,10 @@
         {
             "name": "http2_general.test_flow_control_window",
             "reason": "Disabled by issue #1394"
+        },
+        {
+            "name": "http2_general.test_h2_streams.TestH2Stream.test_max_concurrent_stream",
+            "reason": "Disabled by issue #1394"
         }
     ]
 }

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -444,6 +444,10 @@
         {
             "name": "access_log.test_access_log_h2.FrangTest",
             "reason": "Disabled by issue #1781"
+        },
+        {
+            "name": "http2_general.test_flow_control_window",
+            "reason": "Disabled by issue #1394"
         }
     ]
 }

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -456,6 +456,10 @@
         {
             "name": "http2_general.test_h2_hpack.TestHpack.test_clearing_dynamic_table_with_settings_frame",
             "reason": "Disabled by issue #1793"
+        },
+        {
+            "name": "http2_general.test_h2_streams.TestH2Stream.test_reuse_stream_id",
+            "reason": "Disabled by issue #1800"
         }
     ]
 }


### PR DESCRIPTION
Now deproxy h2 client can:
- send settings frame;
- update default settings before create connection;
- accept settings frame with ack flag;
- wait settings frame with ack flag;
- saves error codes;
- send bytes;

`handle_read` method for deproxy h2 client - now `method` variable is created when client receives `ResponseReceived` event. This fixes error of receiving frames other than headers.

Added tests for issue #88:
> Verification of correct frames exchange during establishing of h2 connection: get correct SETTINGS frame (with SETTINGS_INITIAL_WINDOW_SIZE parameter), correct WINDOW_UPDATE frame and correct SETTINGS ACK frame.

> [HPACK entries eviction](https://tools.ietf.org/html/rfc7541#section-4): we must correctly process the maximum dynamic table and evict old entries - the test must define the table limit and send too many different headers

> Use small SETTINGS_MAX_FRAME_SIZE on a client and test that HTTP response headers and body are normally fragmented

> Stream IDs: (1) check that even IDs and ID > 0x7fffffff aren't accepted and (2) you cannot reuse old ID (see [Victim 1–HTTP/2 Stream Multiplexing (CVE-2016-0150)](https://www.imperva.com/docs/Imperva_HII_HTTP2.pdf))

For all cases from issue #344 

For issue [#1394](https://github.com/tempesta-tech/tempesta/issues/1394):

> Doesn't send more than allowed by per-stream flow control

Added some tests for RFC 7541 and 9113. 
