### PR TITLE
h2 tests for RST_STREAM and GOAWAY frames

### DIFF
--- a/http2_general/test_h2_frame.py
+++ b/http2_general/test_h2_frame.py
@@ -171,8 +171,6 @@ class TestH2Frame(H2Base):
         # Tempesta closes it for itself.
         client.h2_connection.reset_stream(stream_id=1, error_code=0)
         client.send_bytes(client.h2_connection.data_to_send())
-        client.h2_connection.clear_outbound_data_buffer()
-        self.assertTrue(client.wait_for_ack_settings())
 
         # Client send DATA frame in stream 3 and it MUST receive response
         client.send_request("qwe", "200")

--- a/http2_general/test_h2_hpack.py
+++ b/http2_general/test_h2_hpack.py
@@ -385,12 +385,14 @@ class TestHpack(H2Base):
         client.update_initial_settings(header_table_size=1024)
         client.send_request(request=self.post_request, expected_status_code="200")
         self.assertIn(b"\x3f\xe1\x07", client.response_buffer, error_msg.format(1024))
+        self.assertEqual(client.h2_connection.decoder.header_table_size, 1024)
 
         # Client set HEADER_TABLE_SIZE = 12288 bytes, but Tempesta works with table 4096 bytes
         # and we expect \x3f\xe1\x07 bytes in first header frame
         client.send_settings_frame(header_table_size=12288)
         client.send_request(request=self.post_request, expected_status_code="200")
         self.assertIn(b"\x3f\xe1\x1f", client.response_buffer, error_msg.format(4096))
+        self.assertEqual(client.h2_connection.decoder.header_table_size, 4096)
 
     def test_bytes_of_table_size_in_header_frame_2(self):
         """
@@ -412,6 +414,7 @@ class TestHpack(H2Base):
             client.response_buffer,
             "Tempesta added dynamic table size (4096) before first header block.",
         )
+        self.assertEqual(client.h2_connection.decoder.header_table_size, 4096)
 
     def __setup_settings_header_table_tests(self):
         self.start_all_services()

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -496,6 +496,14 @@
         {
             "name": "http2_general.test_h2_max_frame_size.TestMaxFrameSize.test_large_headers_frame_in_response",
             "reason": "Disabled by issue #1103"
+        },
+        {
+            "name": "http2_general.test_h2_frame.TestH2Frame.test_rst_frame_in_response",
+            "reason": "Disabled by issue #1819"
+        },
+        {
+            "name": "http2_general.test_h2_hpack.TestHpack.test_bytes_of_table_size_in_header_frame_1",
+            "reason": "Disabled by PR #1804"
         }
     ]
 }


### PR DESCRIPTION
#88 

> Verification of correct handling for connection and stream error cases: a) get valid GOAWAY frame in response on connection error case; b) get valid RST_STREAM frame in response on stream error situation (the whole connection must remain alive).

I also added some tests for `header table size update` bytes in headers frame.