### PR TITLE
h2 tests and update for h2spec

### DIFF
--- a/framework/tester.py
+++ b/framework/tester.py
@@ -273,6 +273,9 @@ class TempestaTest(unittest.TestCase):
             return None
         return self.__clients[cid]
 
+    def get_clients(self) -> list:
+        return list(self.__clients.values())
+
     def get_clients_id(self):
         """Return list of registered clients id"""
         return self.__clients.keys()

--- a/helpers/remote.py
+++ b/helpers/remote.py
@@ -18,6 +18,8 @@ from typing import Union  # TODO: use | instead when we move to python3.10
 
 import paramiko
 
+import run_config
+
 from . import error, tf_cfg
 
 __author__ = "Tempesta Technologies, Inc."
@@ -85,7 +87,9 @@ class LocalNode(Node):
         env_full = {}
         env_full.update(os.environ)
         env_full.update(env)
-        env_full["SSLKEYLOGFILE"] = "./secrets.txt"
+        if run_config.SAVE_SECRETS and "curl" in cmd:
+            env_full["SSLKEYLOGFILE"] = "./secrets.txt"
+
         with subprocess.Popen(
             cmd, shell=True, stdout=subprocess.PIPE, stderr=stderr_pipe, env=env_full
         ) as p:

--- a/helpers/remote.py
+++ b/helpers/remote.py
@@ -85,6 +85,7 @@ class LocalNode(Node):
         env_full = {}
         env_full.update(os.environ)
         env_full.update(env)
+        env_full["SSLKEYLOGFILE"] = "./secrets.txt"
         with subprocess.Popen(
             cmd, shell=True, stdout=subprocess.PIPE, stderr=stderr_pipe, env=env_full
         ) as p:

--- a/http2_general/test_h2_headers.py
+++ b/http2_general/test_h2_headers.py
@@ -112,7 +112,11 @@ class HeadersParsing(H2Base):
         )
 
     def test_transfer_encoding_header_in_request(self):
-        """The request must be treated as malformed. RFC 7540 8.1.2"""
+        """
+        The only exception to this is the TE header field, which MAY be present in an HTTP/2
+        request; when it is, it MUST NOT contain any value other than "trailers".
+        RFC 9113 8.2.2
+        """
         self.start_all_services()
 
         client = self.get_client("deproxy")

--- a/http2_general/test_h2_headers.py
+++ b/http2_general/test_h2_headers.py
@@ -111,6 +111,20 @@ class HeadersParsing(H2Base):
             "400",
         )
 
+    def test_transfer_encoding_header_in_request(self):
+        """The request must be treated as malformed. RFC 7540 8.1.2"""
+        self.start_all_services()
+
+        client = self.get_client("deproxy")
+        client.parsing = False
+        client.send_request(
+            (
+                self.post_request + [("transfer-encoding", "chunked")],
+                "123",
+            ),
+            "400",
+        )
+
 
 class TestPseudoHeaders(H2Base):
     def test_invalid_pseudo_header(self):

--- a/http2_general/test_h2_specs.py
+++ b/http2_general/test_h2_specs.py
@@ -1,5 +1,4 @@
 from framework import tester
-from helpers import tf_cfg
 
 __author__ = "Tempesta Technologies, Inc."
 __copyright__ = "Copyright (C) 2022 Tempesta Technologies, Inc."
@@ -59,6 +58,8 @@ vhost default {
     proxy_pass default;
 }
 
+block_action attack reply;
+block_action error reply;
 cache 0;
 
 """
@@ -104,31 +105,25 @@ class H2Spec(tester.TempestaTest):
         # amount of runs in a row.
         h2spec.options.extend(
             [
-                "-x generic/2/2",
-                "-x generic/2/3",
-                "-x generic/3.10/2",
-                "-x http2/4.3/3",
-                "-x http2/5.1/5",
-                "-x http2/5.1/6",
-                "-x http2/5.1/11",
-                "-x http2/5.1/12",
-                "-x http2/5.1.1/4",
-                "-x http2/5.3.1/1",  # causes dmesg warning
-                "-x http2/5.3.1/2",
-                "-x http2/5.5/2",
-                "-x http2/6.1/2",
-                "-x http2/6.2/2",
-                "-x http2/6.9.1/2",
-                "-x http2/6.9.1/3",
-                "-x http2/8.1/1",
-                "-x http2/8.1.2/1",
-                "-x http2/8.1.2.1/3",  # causes dmesg warning
-                "-x http2/8.1.2.2/2",
-                "-x http2/8.1.2.3/5",  # causes dmesg warning
-                "-x http2/8.1.2.3/6",  # causes dmesg warning
-                "-x http2/8.1.2.3/7",  # causes dmesg warning
-                "-x hpack/4.2/1",
-                "-x hpack/5.2/3",  # causes dmesg warning
+                "-x generic/2/2",  # disabled by issue 1394
+                "-x generic/2/3",  # disabled by issue 1196
+                "-x http2/4.3/3",  # disabled by issue 1823
+                "-x http2/5.1/5",  # disabled by issue 1828
+                "-x http2/5.1/6",  # disabled by issue 1828
+                "-x http2/5.1/11",  # disabled by issue 1828
+                "-x http2/5.1/12",  # disabled by issue 1828
+                "-x http2/5.1.1/3",  # disabled by issue 1800
+                "-x http2/5.3.1/1",  # disabled by issue 1196
+                "-x http2/5.3.1/2",  # disabled by issue 1196
+                "-x http2/5.5/2",  # disabled by issue 1824
+                "-x http2/6.1/2",  # disabled by issue 1828
+                "-x http2/6.2/2",  # disabled by issue 1823
+                "-x http2/6.9.1/2",  # disabled by issue 1394
+                "-x http2/6.9.1/3",  # disabled by issue 1394
+                "-x http2/8.1.2/1",  # disabled by issue 1729
+                "-x http2/8.1.2.2/2",  # disabled by issue #1819
+                "-x hpack/4.2/1",  # disabled by issue #1825
+                "-x hpack/5.2/3",  # disabled by issue #1827
             ]
         )
 
@@ -136,4 +131,6 @@ class H2Spec(tester.TempestaTest):
         self.start_tempesta()
         self.start_all_clients()
         self.wait_while_busy(h2spec)
+        h2spec.stop()
         self.assertEqual(0, h2spec.returncode)
+        assert "0 failed" in h2spec.response_msg, h2spec.response_msg

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -496,6 +496,10 @@
         {
             "name": "http2_general.test_h2_hpack.TestHpack.test_bytes_of_table_size_in_header_frame_1",
             "reason": "Disabled by PR #1804"
+        },
+        {
+            "name": "http2_general.test_h2_streams.TestMultiplexing",
+            "reason": "Disabled by PR #1820"
         }
     ]
 }


### PR DESCRIPTION
New tests:

- TE header in h2 request.
- issue #88

> Basic test for streams multiplexing: 1. Different HTTP/2 requests (i.e. HEADERS/CONTINUATION/DATA frames in each request) are sent in several streams - one by one, without waiting the responses; 2. And correct HTTP/2 responses must be received for each request/stream (regardless of the sending/receiving order). Do this in one and several TCP connections in parallel.

Added env variable for curl secrets.
