### PR TITLE
Add new directive `tmp_config` to config 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 repos:
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/ambv/black
-    rev: 22.10.0
+    rev: 23.1.0
     hooks:
       - id: black

--- a/helpers/tf_cfg.py
+++ b/helpers/tf_cfg.py
@@ -18,7 +18,6 @@ class ConfigError(Exception):
 
 
 class TestFrameworkCfg(object):
-
     kvs = {}
 
     cfg_file = os.path.relpath(os.path.join(os.path.dirname(__file__), "..", "tests_config.ini"))
@@ -76,6 +75,7 @@ class TestFrameworkCfg(object):
                     "srcdir": "/root/tempesta",
                     "workdir": "/tmp/tempesta",
                     "config": "tempesta.conf",
+                    "tmp_config": "tempesta_tmp.conf",
                     "unavaliable_timeout": "300",
                 },
                 "Server": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ wemake-python-styleguide>=0.16.1
 pycodestyle==2.8.0
 requests
 pre-commit==2.20.0
-isort==5.10.1
-black==22.10.0
+isort==5.12.0
+black==23.1.0
 

--- a/tests_config.ini.sample
+++ b/tests_config.ini.sample
@@ -189,6 +189,13 @@ workdir = /tmp/tempesta
 #
 config = tempesta.conf
 
+# Workdir-relative path to the temporary TempestaFW template config
+# (created during testing).
+#
+# ex.: tmp_config = etc/tempesta_tmp_test.conf (default tempesta_tmp.conf)
+#
+tmp_config = tempesta.conf
+
 # Timeout to wait if node is unavaliable
 # ex.: unavaliable_timeout = 300 (default 300)
 unavaliable_timeout = 300


### PR DESCRIPTION
Added new directive `tmp_config` to config that allows to specify path name of tempesta's template config.

Currently template config generates to framework `workdir`