### PR TITLE
update deproxy client and tests for stream states

### DIFF
--- a/framework/deproxy_client.py
+++ b/framework/deproxy_client.py
@@ -504,6 +504,19 @@ class DeproxyClientH2(DeproxyClient):
             time.sleep(0.01)
         return True
 
+    def wait_for_reset_stream(self, stream_id: int, timeout=5):
+        """Wait RST_STREAM frame for stream."""
+        if self.state != stateful.STATE_STARTED:
+            return False
+
+        t0 = time.time()
+        while not self.h2_connection._stream_is_closed_by_reset(stream_id=stream_id):
+            t = time.time()
+            if t - t0 > timeout:
+                return False
+            time.sleep(0.01)
+        return True
+
     def send_bytes(self, data: bytes, expect_response=False):
         self.request_buffers.append(data)
         self.nrreq += 1

--- a/framework/tester.py
+++ b/framework/tester.py
@@ -159,12 +159,20 @@ class TempestaTest(unittest.TestCase):
     def __create_client_deproxy(self, client, ssl, bind_addr):
         addr = fill_template(client["addr"], client)
         port = int(fill_template(client["port"], client))
+        socket_family = client.get("socket_family", "ipv4")
         if client["type"] == "deproxy_h2":
             clt = deproxy_client.DeproxyClientH2(
-                addr=addr, port=port, ssl=ssl, bind_addr=bind_addr, proto="h2"
+                addr=addr,
+                port=port,
+                ssl=ssl,
+                bind_addr=bind_addr,
+                proto="h2",
+                socket_family=socket_family,
             )
         else:
-            clt = deproxy_client.DeproxyClient(addr=addr, port=port, ssl=ssl, bind_addr=bind_addr)
+            clt = deproxy_client.DeproxyClient(
+                addr=addr, port=port, ssl=ssl, bind_addr=bind_addr, socket_family=socket_family
+            )
         if ssl and "ssl_hostname" in client:
             # Don't set SNI by default, do this only if it was specified in
             # the client configuration.

--- a/helpers/tf_cfg.py
+++ b/helpers/tf_cfg.py
@@ -46,6 +46,7 @@ class TestFrameworkCfg(object):
             {
                 "General": {
                     "ip": "127.0.0.1",
+                    "ipv6": "::1",
                     "verbose": "0",
                     "workdir": "/tmp/host",
                     "duration": "10",
@@ -59,6 +60,7 @@ class TestFrameworkCfg(object):
                 },
                 "Client": {
                     "ip": "127.0.0.1",
+                    "ipv6": "::1",
                     "hostname": "localhost",
                     "ab": "ab",
                     "wrk": "wrk",
@@ -69,6 +71,7 @@ class TestFrameworkCfg(object):
                 },
                 "Tempesta": {
                     "ip": "127.0.0.1",
+                    "ipv6": "::1",
                     "hostname": "localhost",
                     "user": "root",
                     "port": "22",
@@ -80,6 +83,7 @@ class TestFrameworkCfg(object):
                 },
                 "Server": {
                     "ip": "127.0.0.1",
+                    "ipv6": "::1",
                     "hostname": "localhost",
                     "user": "root",
                     "port": "22",

--- a/http2_general/test_h2_stream_states.py
+++ b/http2_general/test_h2_stream_states.py
@@ -1,0 +1,57 @@
+"""Functional tests for stream states."""
+
+__author__ = "Tempesta Technologies, Inc."
+__copyright__ = "Copyright (C) 2023 Tempesta Technologies, Inc."
+__license__ = "GPL2"
+
+from hyperframe.frame import PriorityFrame, RstStreamFrame, WindowUpdateFrame
+
+from http2_general.helpers import H2Base
+
+
+class TestClosedStreamState(H2Base):
+    def test_rst_stream_frame_in_closed_state(self):
+        """
+        An endpoint that sends a frame with the END_STREAM flag set or a RST_STREAM frame might
+        receive a WINDOW_UPDATE or RST_STREAM frame from its peer in the time before the peer
+        receives and processes the frame that closes the stream.
+        RFC 9113 5.1
+
+        Tempesta MUST not close connection.
+        """
+        self.start_all_services()
+
+        client = self.get_client("deproxy")
+        client.send_request(request=self.post_request, expected_status_code="200")
+        client.send_bytes(RstStreamFrame(stream_id=1).serialize())
+        client.send_request(request=self.post_request, expected_status_code="200")
+
+    def test_window_update_frame_in_closed_state(self):
+        """
+        An endpoint that sends a frame with the END_STREAM flag set or a RST_STREAM frame might
+        receive a WINDOW_UPDATE or RST_STREAM frame from its peer in the time before the peer
+        receives and processes the frame that closes the stream.
+        RFC 9113 5.1
+
+        Tempesta MUST not close connection.
+        """
+        self.start_all_services()
+
+        client = self.get_client("deproxy")
+        client.send_request(request=self.post_request, expected_status_code="200")
+        client.send_bytes(WindowUpdateFrame(stream_id=1).serialize())
+        client.send_request(request=self.post_request, expected_status_code="200")
+
+    def test_priority_frame_in_closed_state(self):
+        """
+        An endpoint MUST NOT send frames other than PRIORITY on a closed stream.
+        RFC 9113 5.1
+
+        Tempesta MUST not close connection.
+        """
+        self.start_all_services()
+
+        client = self.get_client("deproxy")
+        client.send_request(request=self.post_request, expected_status_code="200")
+        client.send_bytes(PriorityFrame(stream_id=1).serialize())
+        client.send_request(request=self.post_request, expected_status_code="200")

--- a/http2_general/test_h2_stream_states.py
+++ b/http2_general/test_h2_stream_states.py
@@ -4,13 +4,19 @@ __author__ = "Tempesta Technologies, Inc."
 __copyright__ = "Copyright (C) 2023 Tempesta Technologies, Inc."
 __license__ = "GPL2"
 
-from hyperframe.frame import PriorityFrame, RstStreamFrame, WindowUpdateFrame
+from hyperframe.frame import (
+    DataFrame,
+    Frame,
+    PriorityFrame,
+    RstStreamFrame,
+    WindowUpdateFrame,
+)
 
 from http2_general.helpers import H2Base
 
 
 class TestClosedStreamState(H2Base):
-    def test_rst_stream_frame_in_closed_state(self):
+    def __base_scenario(self, frame: Frame):
         """
         An endpoint that sends a frame with the END_STREAM flag set or a RST_STREAM frame might
         receive a WINDOW_UPDATE or RST_STREAM frame from its peer in the time before the peer
@@ -23,24 +29,14 @@ class TestClosedStreamState(H2Base):
 
         client = self.get_client("deproxy")
         client.send_request(request=self.post_request, expected_status_code="200")
-        client.send_bytes(RstStreamFrame(stream_id=1).serialize())
+        client.send_bytes(frame.serialize())
         client.send_request(request=self.post_request, expected_status_code="200")
+
+    def test_rst_stream_frame_in_closed_state(self):
+        self.__base_scenario(RstStreamFrame(stream_id=1))
 
     def test_window_update_frame_in_closed_state(self):
-        """
-        An endpoint that sends a frame with the END_STREAM flag set or a RST_STREAM frame might
-        receive a WINDOW_UPDATE or RST_STREAM frame from its peer in the time before the peer
-        receives and processes the frame that closes the stream.
-        RFC 9113 5.1
-
-        Tempesta MUST not close connection.
-        """
-        self.start_all_services()
-
-        client = self.get_client("deproxy")
-        client.send_request(request=self.post_request, expected_status_code="200")
-        client.send_bytes(WindowUpdateFrame(stream_id=1).serialize())
-        client.send_request(request=self.post_request, expected_status_code="200")
+        self.__base_scenario(WindowUpdateFrame(stream_id=1))
 
     def test_priority_frame_in_closed_state(self):
         """
@@ -49,9 +45,48 @@ class TestClosedStreamState(H2Base):
 
         Tempesta MUST not close connection.
         """
-        self.start_all_services()
+        self.__base_scenario(PriorityFrame(stream_id=1))
 
+
+class TestHalfClosedStreamState(H2Base):
+    def __base_scenario(self, frame: Frame):
+        """
+        If an endpoint receives additional frames, other than WINDOW_UPDATE, PRIORITY,
+        or RST_STREAM, for a stream that is in this state, it MUST respond with a stream
+        error (Section 5.4.2) of type STREAM_CLOSED.
+        RFC 9113 5.1
+
+        Tempesta MUST not close connection.
+        """
         client = self.get_client("deproxy")
-        client.send_request(request=self.post_request, expected_status_code="200")
-        client.send_bytes(PriorityFrame(stream_id=1).serialize())
-        client.send_request(request=self.post_request, expected_status_code="200")
+        client.encoder.huffman = True
+
+        self.start_all_services()
+        self.initiate_h2_connection(client)
+
+        client.h2_connection.send_headers(stream_id=1, headers=self.get_request, end_stream=True)
+        client.send_bytes(
+            data=(
+                client.h2_connection.data_to_send()
+                + DataFrame(stream_id=1, data=b"request body").serialize()
+                + frame.serialize()
+            ),
+            expect_response=True,
+        )
+
+        # TODO Uncomment by issue #1819
+        # self.assertTrue(client.wait_for_response(3))
+        # self.assertEqual(client.last_response.status, '400')
+        self.assertTrue(client.wait_for_reset_stream(stream_id=1))
+
+        client.stream_id += 2
+        client.send_request(self.get_request, "200")
+
+    def test_priority_frame_in_half_closed_state(self):
+        self.__base_scenario(frame=PriorityFrame(stream_id=1))
+
+    def test_reset_frame_in_half_closed_state(self):
+        self.__base_scenario(frame=RstStreamFrame(stream_id=1))
+
+    def test_window_update_frame_in_half_closed_state(self):
+        self.__base_scenario(frame=WindowUpdateFrame(stream_id=1))

--- a/tests_config.ini.sample
+++ b/tests_config.ini.sample
@@ -1,13 +1,14 @@
 [General]
 # This section refer to testing framework itself.
 
-# IPv4/IPv6 address of the host that runs the testing framework.
+# IPv4 and IPv6 addresses of the host that runs the testing framework.
 # This is the address deproxy's server will be listening at.
 # This value will be used internally, in command lines and configuration files.
 #
 # ex.: ip = 192.168.11.6 (default 127.0.0.1)
 #
 ip = 127.0.0.1
+ipv6 = ::1
 
 # Verbose level:
 # 0 - quiet mode, result of each test is shown by symbols:
@@ -86,13 +87,14 @@ long_body_size = 500
 # Note: in some tests, HTTP servers are also ran locally using this configuration
 # (disregarding [Server] section).
 
-# IPv4/IPv6 address of this host in the test network, as reachable from the host
+# IPv4 and IPv6 addresses of this host in the test network, as reachable from the host
 # running TempestaFW.
 # This value will be used internally, in command lines and configuration files.
 #
 # ex.: ip = 192.168.11.6 (default 127.0.0.1)
 #
 ip = 127.0.0.1
+ipv6 = ::1
 
 # Absolute path to the working (temporary) directory on this host.
 #
@@ -149,13 +151,14 @@ tls-perf = tls-perf
 # Configuration for the host running TempestaFW. It may be configured to run
 # locally or remotely (using SSH). Refer to README.md for more information.
 
-# IPv4/IPv6 address of the host running TempestaFW in the test network,
+# IPv4 and IPv6 addresses of the host running TempestaFW in the test network,
 # as reachable from this host.
 # This value will be used internally, in command lines and configuration files.
 #
 # ex.: ip = 192.168.11.6 (default 127.0.0.1)
 #
 ip = 127.0.0.1
+ipv6 = ::1
 
 # Target host description. These values will be used to SSH into the remote host.
 # If hostname is 'localhost', TempestaFW will be ran locally.
@@ -204,12 +207,13 @@ unavaliable_timeout = 300
 # Configuration for the host running HTTP servers. They may be configured to run
 # locally or remotely (using SSH). Refer to README.md for more information.
 
-# IPv4/IPv6 address of the host running HTTP servers in the test network,
+# IPv4 and IPv6 addresses of the host running HTTP servers in the test network,
 # as reachable from the host running TempestaFW.
 #
 # ex.: ip = 192.168.11.7 (default 127.0.0.1)
 #
 ip = 127.0.0.1
+ipv6 = ::1
 
 # Target host description. These values will be used to SSH into the remote host.
 # If hostname is 'localhost', HTTP servers will be ran locally.


### PR DESCRIPTION
Deproxy client can create IPv6 socket connection.
DeproxyClientH2 can wait to receive RST_STREAM.