### PR TITLE
Remove some tests

### DIFF
--- a/t_frang/test_http_strict_host_checking.py
+++ b/t_frang/test_http_strict_host_checking.py
@@ -9,7 +9,6 @@ __license__ = "GPL2"
 WARN_UNKNOWN = "frang: Request authority is unknown"
 WARN_DIFFER = "frang: Request host from absolute URI differs from Host header for"
 WARN_IP_ADDR = "frang: Host header field contains IP address"
-WARN_HEADER_FORWARDED = "frang: Request authority differs from forwarded for"
 WARN_HEADER_HOST = "frang: Request :authority differs from Host for"
 WARN_INVALID_AUTHORITY = "Invalid authority"
 
@@ -92,35 +91,6 @@ class FrangHostRequiredTestCase(FrangTestCase):
             requests=["GET http://user@tempesta-tech.com/ HTTP/1.1\r\nHost: \r\n\r\n"],
         )
         self.check_response(client, status_code="403", warning_msg=WARN_DIFFER)
-
-    def test_host_header_forwarded(self):
-        """Test with invalid host in `Forwarded` header."""
-        client = self.base_scenario(
-            frang_config="http_strict_host_checking true;",
-            requests=[
-                (
-                    "GET / HTTP/1.1\r\n"
-                    "Host: tempesta-tech.com\r\n"
-                    "Forwarded: host=qwerty.com\r\n\r\n"
-                )
-            ],
-        )
-        self.check_response(client, status_code="403", warning_msg=WARN_HEADER_FORWARDED)
-
-    def test_host_header_forwarded_double(self):
-        """Test with double `Forwarded` header (invalid/valid)."""
-        client = self.base_scenario(
-            frang_config="http_strict_host_checking true;",
-            requests=[
-                (
-                    "GET http://user@tempesta-tech.com/ HTTP/1.1\r\n"
-                    "Host: tempesta-tech.com\r\n"
-                    "Forwarded: host=tempesta1-tech.com\r\n"
-                    "Forwarded: host=tempesta-tech.com\r\n\r\n"
-                )
-            ],
-        )
-        self.check_response(client, status_code="403", warning_msg=WARN_HEADER_FORWARDED)
 
     def test_host_header_no_port_in_uri(self):
         """Test with default port in uri."""
@@ -340,25 +310,6 @@ block_action error reply;
                 (":authority", "[20:11:abb::1]:443"),
             ],
             expected_warning=WARN_IP_ADDR,
-        )
-
-    def test_h2_missmatch_forwarded_header(self):
-        """Test with missmath header `forwarded`."""
-        self._test(
-            headers=[(":path", "/"), (":authority", "localhost"), ("forwarded", "host=qwerty")],
-            expected_warning=WARN_HEADER_FORWARDED,
-        )
-
-    def test_h2_double_different_forwarded_headers(self):
-        """Test with double header `forwarded`."""
-        self._test(
-            [
-                (":path", "/"),
-                (":authority", "tempesta-tech.com"),
-                ("forwarded", "host=tempesta.com"),
-                ("forwarded", "host=tempesta-tech.com"),
-            ],
-            expected_warning=WARN_HEADER_FORWARDED,
         )
 
     def test_h2_different_host_and_authority_header(self):


### PR DESCRIPTION
Since we decide that equality of forwarded host
and header host is not necessary, we should remove appropriate tests.