### PR TITLE
DeproxyClient: updated `wait_for_response` method.

### DIFF
--- a/framework/deproxy_client.py
+++ b/framework/deproxy_client.py
@@ -24,10 +24,12 @@ __author__ = "Tempesta Technologies, Inc."
 __copyright__ = "Copyright (C) 2018-2023 Tempesta Technologies, Inc."
 __license__ = "GPL2"
 
+
 def adjust_timeout_for_tcp_segmentation(timeout):
     if run_config.TCP_SEGMENTATION and timeout < 30:
         timeout = 30
     return timeout
+
 
 class BaseDeproxyClient(deproxy.Client, abc.ABC):
     def __init__(self, *args, **kwargs):
@@ -349,13 +351,11 @@ class DeproxyClient(BaseDeproxyClient):
 
     def wait_for_response(self, timeout=5):
         timeout = adjust_timeout_for_tcp_segmentation(timeout)
-        if self.state != stateful.STATE_STARTED:
-            return False
 
         t0 = time.time()
         while len(self.responses) < self.valid_req_num:
             t = time.time()
-            if t - t0 > timeout:
+            if t - t0 > timeout or self.state != stateful.STATE_STARTED:
                 return False
             time.sleep(0.01)
         return True

--- a/helpers/deproxy.py
+++ b/helpers/deproxy.py
@@ -797,6 +797,7 @@ class Client(TlsClient, stateful.Stateful):
     def handle_close(self):
         self.close()
         self.conn_is_closed = True
+        self.state = stateful.STATE_STOPPED
 
     def handle_read(self):
         while True:  # TLS aware - read as many records as we can


### PR DESCRIPTION
Now client does not wait for response if connection is closed. [CI with -T 1](http://tempesta-vm.cloud.cherryservers.net:8080/job/Run%20tests/661/parameters/)