### PR TITLE
Fix flow control in deproxy client

### DIFF
--- a/framework/deproxy_client.py
+++ b/framework/deproxy_client.py
@@ -519,7 +519,10 @@ class DeproxyClientH2(DeproxyClient):
                     self.h2_connection.increment_flow_control_window(
                         increment=event.flow_controlled_length, stream_id=None
                     )
-                    if event.stream_ended is None:
+                    if (
+                        self.h2_connection._get_stream_by_id(event.stream_id).state_machine.state
+                        != h2.stream.StreamState.CLOSED
+                    ):
                         self.h2_connection.increment_flow_control_window(
                             increment=event.flow_controlled_length, stream_id=event.stream_id
                         )


### PR DESCRIPTION
We can receive several data events and one of
it contains end_of_stream flag. We should not
increment flow control window for stream in
this case because stream is already closed.