### PR TITLE
Fix framework tearDown

### DIFF
--- a/framework/tester.py
+++ b/framework/tester.py
@@ -317,6 +317,7 @@ class TempestaTest(unittest.TestCase):
 
     def tearDown(self):
         tf_cfg.dbg(3, "\tTeardown")
+        self.deproxy_manager.stop()
         for cid in self.__clients:
             client = self.__clients[cid]
             client.stop()
@@ -324,7 +325,6 @@ class TempestaTest(unittest.TestCase):
         for sid in self.__servers:
             server = self.__servers[sid]
             server.stop()
-        self.deproxy_manager.stop()
         try:
             deproxy_manager.finish_all_deproxy()
         except:


### PR DESCRIPTION
Stop deproxy manager and release lock first, before stopping clients. Stopping clients during polling and under lock looks wrong and leads to hanging on tearDown phase.