### PR TITLE
Fix regression tests

### DIFF
--- a/regression/test_stress_failovering.py
+++ b/regression/test_stress_failovering.py
@@ -33,6 +33,7 @@ class RatioFailovering(stress.StressTest):
         """Create sever with very little connections count."""
         port = tempesta.upstream_port_start_from()
         server = control.Nginx(listen_port=port)
+        server.config.set_return_code(200)
         server.conns_n = 4
         self.servers = [server]
 

--- a/regression/test_stress_pipeline.py
+++ b/regression/test_stress_pipeline.py
@@ -29,13 +29,14 @@ class Pipeline(stress.StressTest):
 
     def create_servers(self):
         self.create_servers_helper(tempesta.servers_in_group())
+        for srv in self.servers:
+            srv.config.set_return_code(200)
 
     def test_pipelined_requests(self):
         self.generic_test_routine("cache 0;\n")
 
 
 class PipelineFaultInjection(stress.StressTest):
-
     pipelined_req = 7
     tfw_msg_errors = True
 


### PR DESCRIPTION
When index page is missed in nginx directory regression tests fell because nginx returned 403 but test expects 200. Now nginx will return 200 for any request and index file doesn't need.