### PR TITLE
Refix of empty Tempesta config problem

### DIFF
--- a/framework/tester.py
+++ b/framework/tester.py
@@ -272,8 +272,6 @@ class TempestaTest(unittest.TestCase):
         config = ""
         if "config" in desc:
             config = desc["config"]
-        else:
-            raise AttributeError("Tempesta config is empty.")
         if "type" in desc:
             factory = tempesta_defs[desc["type"]]
             self.__tempesta = factory(desc)

--- a/helpers/control.py
+++ b/helpers/control.py
@@ -336,14 +336,10 @@ class Tempesta(stateful.Stateful):
     def _do_run(self, cmd):
         cfg_content = self.config.get_config()
 
-        if cfg_content:
-            tf_cfg.dbg(4, f"\tTempesta config content:\n{cfg_content}")
-        else:
-            tf_cfg.dbg(
-                1,
-                "\tTempesta config is empty. Maybe it's ok, but usually that means "
-                "you missed out 'tempesta' attribute in the testcase.",
-            )
+        tf_cfg.dbg(4, f"\tTempesta config content:\n{cfg_content}")
+
+        if not cfg_content:
+            raise AttributeError("Tempesta config is empty.")
 
         self.node.copy_file(self.config_name, cfg_content)
         env = {"TFW_CFG_PATH": self.config_name, "TFW_CFG_TMPL": self.tmp_config_name}

--- a/helpers/control.py
+++ b/helpers/control.py
@@ -326,14 +326,27 @@ class Tempesta(stateful.Stateful):
     def run_start(self):
         tf_cfg.dbg(3, "\tStarting TempestaFW on %s" % self.host)
         self.stats.clear()
-        self.node.copy_file(self.config_name, self.config.get_config())
-        cmd = "%s/scripts/tempesta.sh --start" % self.srcdir
+        self._do_run(f"{self.srcdir}/scripts/tempesta.sh --start")
+
+    def reload(self):
+        """Live reconfiguration"""
+        tf_cfg.dbg(3, "\tReconfiguring TempestaFW on %s" % self.host)
+        self._do_run(f"{self.srcdir}/scripts/tempesta.sh --reload")
+
+    def _do_run(self, cmd):
+        cfg_content = self.config.get_config()
+
+        if cfg_content:
+            tf_cfg.dbg(4, f"\tTempesta config content:\n{cfg_content}")
+        else:
+            tf_cfg.dbg(
+                1,
+                "\tTempesta config is empty. Maybe it's ok, but usually that means "
+                "you missed out 'tempesta' attribute in the testcase.",
+            )
+
+        self.node.copy_file(self.config_name, cfg_content)
         env = {"TFW_CFG_PATH": self.config_name, "TFW_CFG_TMPL": self.tmp_config_name}
-
-        if tf_cfg.v_level() >= 5:
-            out, _ = remote.tempesta.run_cmd(f"cat {self.config_name}")
-            tf_cfg.dbg(5, f"\tTempesta config contents:\n{out.decode('utf-8')}")
-
         self.node.run_cmd(cmd, timeout=30, env=env, err_msg=(self.err_msg % "start"))
 
     def stop_tempesta(self):
@@ -344,14 +357,6 @@ class Tempesta(stateful.Stateful):
     def remove_config(self):
         self.node.remove_file(self.config_name)
         self.node.remove_file(self.tmp_config_name)
-
-    def reload(self):
-        """Live reconfiguration"""
-        tf_cfg.dbg(3, "\tReconfiguring TempestaFW on %s" % self.host)
-        self.node.copy_file(self.config_name, self.config.get_config())
-        cmd = "%s/scripts/tempesta.sh --reload" % self.srcdir
-        env = {"TFW_CFG_PATH": self.config_name, "TFW_CFG_TMPL": self.tmp_config_name}
-        self.node.run_cmd(cmd, timeout=30, env=env, err_msg=(self.err_msg % "reload"))
 
     def get_stats(self):
         cmd = "cat /proc/tempesta/perfstat"

--- a/tls/test_tls_cert.py
+++ b/tls/test_tls_cert.py
@@ -855,12 +855,10 @@ http {
         for step in range(n):
             if step % 2 == 1:
                 self.set_first_config()
+                self.get_tempesta().reload()
             else:
                 self.set_second_config()
-
-    def start_all(self):
-        self.start_all_servers()
-        self.start_tempesta()
+                self.get_tempesta().reload()
 
     def test_wrk(self):
         generate_certificate(
@@ -869,8 +867,8 @@ http {
         generate_certificate(
             cert_name="private", cn="private", san=["example.com", "private.example.com"]
         )
-        self.start_all()
         self.set_first_config()
+        self.start_all_services(client=False)
         wrk = self.get_client("wrk")
         wrk.duration = 10
         wrk.start()
@@ -915,7 +913,6 @@ http {
             custom_cert=True,
         )
         self.get_tempesta().config = config
-        self.get_tempesta().reload()
 
     def set_second_config(self):
         config = tempesta.Config()
@@ -950,7 +947,6 @@ http {
             custom_cert=True,
         )
         self.get_tempesta().config = config
-        self.get_tempesta().reload()
 
 
 class BaseTlsSniWithHttpTable(tester.TempestaTest, base=True):


### PR DESCRIPTION
We can't raise exceptions, because some tests intentionally leave Tempesta config empty. So just write warning.