### PR TITLE
parameterization via decorators

### DIFF
--- a/framework/parameterize.py
+++ b/framework/parameterize.py
@@ -3,14 +3,12 @@ __copyright__ = "Copyright (C) 2023 Tempesta Technologies, Inc."
 __license__ = "GPL2"
 
 
-import parameterized as p
-from parameterized import param
+from parameterized import parameterized, parameterized_class
 
 
 def get_func_name(func, param_num, params):
-    suffix = params.kwargs.get("name", None)
-
-    if suffix is None:
+    suffix = params.kwargs.get("name")
+    if not suffix:
         if params.args:
             suffix = params.args[0]
         else:
@@ -19,26 +17,26 @@ def get_func_name(func, param_num, params):
                 "or add the 'name' argument."
             )
 
-    return f"{func.__name__}_{p.parameterized.to_safe_name(f'{suffix}')}"
+    return f"{func.__name__}_{parameterized.to_safe_name(f'{suffix}')}"
 
 
 def get_class_name(cls, num, params_dict: dict):
-    if params_dict.get("name", None) is not None:
-        suffix = p.parameterized.to_safe_name(params_dict["name"])
+    if params_dict.get("name"):
+        suffix = parameterized.to_safe_name(params_dict["name"])
     else:
         raise AttributeError("Please add the 'name' variable to the class parameters.")
 
-    return f"{cls.__name__}{p.parameterized.to_safe_name(suffix)}"
+    return f"{cls.__name__}{parameterized.to_safe_name(suffix)}"
 
 
 def parameterize_class(
     attrs, input_values=None, class_name_func=get_class_name, classname_func=None
 ):
     """Default wrapper for parametrizing a class from `parameterized` library."""
-    return p.parameterized_class(attrs, input_values, class_name_func, classname_func)
+    return parameterized_class(attrs, input_values, class_name_func, classname_func)
 
 
-class parameterize(p.parameterized):
+class parameterize(parameterized):
     @classmethod
     def expand(
         cls,

--- a/framework/parameterize.py
+++ b/framework/parameterize.py
@@ -1,0 +1,53 @@
+__author__ = "Tempesta Technologies, Inc."
+__copyright__ = "Copyright (C) 2023 Tempesta Technologies, Inc."
+__license__ = "GPL2"
+
+
+import parameterized as p
+from parameterized import param
+
+
+def get_func_name(func, param_num, params):
+    suffix = params.kwargs.get("name", None)
+
+    if suffix is None:
+        if params.args:
+            suffix = params.args[0]
+        else:
+            raise AttributeError(
+                "Please use string or integer type as first function parameter "
+                "or add the 'name' argument."
+            )
+
+    return f"{func.__name__}_{p.parameterized.to_safe_name(f'{suffix}')}"
+
+
+def get_class_name(cls, num, params_dict: dict):
+    if params_dict.get("name", None) is not None:
+        suffix = p.parameterized.to_safe_name(params_dict["name"])
+    else:
+        raise AttributeError("Please add the 'name' variable to the class parameters.")
+
+    return f"{cls.__name__}{p.parameterized.to_safe_name(suffix)}"
+
+
+def parameterize_class(
+    attrs, input_values=None, class_name_func=get_class_name, classname_func=None
+):
+    """Default wrapper for parametrizing a class from `parameterized` library."""
+    return p.parameterized_class(attrs, input_values, class_name_func, classname_func)
+
+
+class parameterize(p.parameterized):
+    @classmethod
+    def expand(
+        cls,
+        input_,
+        name_func=get_func_name,
+        doc_func=None,
+        skip_on_empty=False,
+        namespace=None,
+        **legacy,
+    ):
+        """Default wrapper for parametrizing a function from `parameterized` library."""
+        return super().expand(input_, name_func, doc_func, skip_on_empty, namespace, **legacy)

--- a/framework/parameterize.py
+++ b/framework/parameterize.py
@@ -3,7 +3,7 @@ __copyright__ = "Copyright (C) 2023 Tempesta Technologies, Inc."
 __license__ = "GPL2"
 
 
-from parameterized import parameterized, parameterized_class
+from parameterized import param, parameterized, parameterized_class
 
 
 def get_func_name(func, param_num, params):

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ pre-commit==2.20.0
 isort==5.12.0
 black==23.1.0
 inquirer
-
+parameterized

--- a/t_frang/test_tls_incomplete.py
+++ b/t_frang/test_tls_incomplete.py
@@ -1,6 +1,7 @@
 """Tests for Frang directive tls-related."""
 import time
 
+from framework.parameterize import param, parameterize
 from t_frang.frang_test_case import FrangTestCase
 
 __author__ = "Tempesta Technologies, Inc."
@@ -47,7 +48,14 @@ class FrangTlsIncompleteTestCase(FrangTestCase):
         """,
     }
 
-    def _base_scenario(self, steps):
+    @parameterize.expand(
+        [
+            param(name="rate", steps=5),
+            param(name="without_reaching_the_limit", steps=3),
+            param(name="rate_on_the_limit", steps=4),
+        ]
+    )
+    def test_tls_incomplete_connection(self, name, steps):
         """
         Create several client connections with fail.
         If number of connections is more than 4 they will be blocked.
@@ -71,12 +79,3 @@ class FrangTlsIncompleteTestCase(FrangTestCase):
         else:
             # rate limit is reached
             self.assertFrangWarning(warning=ERROR_INCOMP_CONN, expected=1)
-
-    def test_tls_incomplete_connection_rate(self):
-        self._base_scenario(steps=5)
-
-    def test_tls_incomplete_connection_rate_without_reaching_the_limit(self):
-        self._base_scenario(steps=3)
-
-    def test_tls_incomplete_connection_rate_on_the_limit(self):
-        self._base_scenario(steps=4)


### PR DESCRIPTION
Function example:
```
from framework.parametrize import param, parameterize

@parameterize.expand([
    param(name="first", param1=1, param2=2),
    param("second", param1=2, param2=1),
    param("third", 1, 1),
    param("fourth", 1, param2=3),
])
def test(self, name, param1, param2)
   ...
```

Class example:
```
from framework.parametrize import parameterize_class

@parameterize_class([
    {"name": "Http", "clients": [DEPROXY_CLIENT]},
    {"name": "H2", "clients": [DEPROXY_CLIENT_H2]},
])
class TestResponse(tester.TempestaTest):
   ...
```