### PR TITLE
Enable and fix tests blocked by #1949

### DIFF
--- a/selftests/test_curl_client.py
+++ b/selftests/test_curl_client.py
@@ -329,7 +329,7 @@ class TestCurlClient(tester.TempestaTest):
         self.assertIn("--parallel-max 2", client.form_command())
         self.assertEqual(len(server.requests), 10)
         self.assertEqual(client.requests, 10)
-        self.assertEqual(client.results(), (10, 0, ANY, {}))
+        self.assertEqual(client.results(), (10, 0, ANY, {200: 10}))
 
         with self.subTest("multiple stats parsed"):
             self.assertEqual(len(client.stats), 10)

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -382,10 +382,6 @@
             "reason": "Disabled by issue #1961"
         },
         {
-            "name": "t_frang.test_whitelist_mark.FrangWhitelistMarkTestCase",
-            "reason": "Disabled by issue #1949"
-        },
-        {
             "name": "ws.test_ws_ping.WsPipelining",
             "reason": "Disabled by test issue #1968"
         },


### PR DESCRIPTION
- Initialize netfilter rules before starting client (it is necessary for successful passing mark to tempesta).
- Increase timeout for parallel curl connections.