### PR TITLE
Enabled and fix tests blocked by #1762

### DIFF
--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -210,10 +210,6 @@
             "reason": "Disabled by issue #1740"
         },
         {
-            "name": "t_frang.test_client_body_and_header_timeout",
-            "reason": "Disabled by issue #1762"
-        },
-        {
             "name": "http2_general.test_h2_frame.TestH2Frame.test_empty_last_data_frame",
             "reason": "Disabled by issue #1775"
         },

--- a/tests_disabled_tcpseg.json
+++ b/tests_disabled_tcpseg.json
@@ -122,6 +122,10 @@
             "reason": "These tests should not be run with TCP segmentation."
         },
         {
+            "name": "t_frang.test_client_body_and_header_timeout",
+            "reason": "These tests should not be run with TCP segmentation."
+        },
+        {
             "name": "encoding.test_encoding.TestH1ChunkedNonCacheable",
             "reason": "Disabled by issue #1884"
         },


### PR DESCRIPTION
`client_header_timeout` and `client_body_timeout`
configuration options work in the following way:
When we receive the first block of the request
header or body, we remember the time when it was
received. When the next block arrives, we check
the time of its arrival and if the waiting timeout exceeds the specified one, we drop the request.
Fix tests according this description.