### PR TITLE
Enable test blocked by #1825

### DIFF
--- a/http2_general/test_h2_block_action.py
+++ b/http2_general/test_h2_block_action.py
@@ -412,7 +412,10 @@ class BlockActionH2ReplyFramesAfterShutdownWithCustomErrorPageSmallWindow(BlockA
             )
         )
 
-        client.send_bytes(frame.serialize() if isinstance(frame, Frame) else frame)
+        client.send_bytes(
+            frame.serialize() if isinstance(frame, Frame) else frame,
+            expect_response=expected_response,
+        )
 
         if expected_response:
             self.assertTrue(client.wait_for_connection_close())

--- a/http2_general/test_h2_hpack.py
+++ b/http2_general/test_h2_hpack.py
@@ -825,7 +825,7 @@ class TestFramePayloadLength(H2Base):
         client.send_request(self.get_request, "400")
 
         self.assertTrue(client.wait_for_connection_close())
-        self.assertIn(ErrorCodes.PROTOCOL_ERROR, client.error_codes)
+        self.assertIn(ErrorCodes.COMPRESSION_ERROR, client.error_codes)
 
     def test_invalid_data(self):
         self.start_all_services()

--- a/http2_general/test_h2_specs.py
+++ b/http2_general/test_h2_specs.py
@@ -116,7 +116,6 @@ class H2Spec(tester.TempestaTest):
                 "-x http2/5.3.1/2",  # disabled by issue 1196
                 "-x http2/5.5/2",  # disabled by issue 1824
                 "-x http2/6.1/2",  # disabled by issue 1828
-                "-x hpack/4.2/1",  # disabled by issue #1825
                 "-x hpack/5.2/3",  # disabled by issue #1827
             ]
         )

--- a/tests_disabled_tcpseg.json
+++ b/tests_disabled_tcpseg.json
@@ -156,6 +156,10 @@
         {
             "name": "t_sched.test_hash_func.HashScheduler",
             "reason": "Disabled by issue #1103"
+        },
+        {
+            "name": "http2_general.test_h2_block_action.BlockActionH2ReplyFramesAfterShutdownWithCustomErrorPageSmallWindow.test_block_action_error_reply_with_conn_close_garbage",
+            "reason": "Disabled by issue #525"
         }
     ]
 }


### PR DESCRIPTION
Also write tests to check that Tempesta send
error response with COMPRESSION_ERROR in case
if hpack table size is encoded in invalid place.