### PR TITLE
Enable tests according fixes in Tempesta

### DIFF
--- a/http2_general/test_h2_specs.py
+++ b/http2_general/test_h2_specs.py
@@ -108,13 +108,8 @@ class H2Spec(tester.TempestaTest):
             [
                 "-x generic/2/2",  # Our version TestHalfClosedStreamStateWindowUpdate
                 "-x generic/2/3",  # disabled by issue 1196
-                "-x http2/5.1/5",  # disabled by issue 1828
-                "-x http2/5.1/6",  # disabled by issue 1828
-                "-x http2/5.1/11",  # disabled by issue 1828
-                "-x http2/5.1/12",  # disabled by issue 1828
                 "-x http2/5.3.1/1",  # disabled by issue 1196
                 "-x http2/5.3.1/2",  # disabled by issue 1196
-                "-x http2/6.1/2",  # disabled by issue 1828
                 "-x hpack/5.2/3",  # disabled by issue #1827
             ]
         )

--- a/http2_general/test_h2_specs.py
+++ b/http2_general/test_h2_specs.py
@@ -114,7 +114,6 @@ class H2Spec(tester.TempestaTest):
                 "-x http2/5.1/12",  # disabled by issue 1828
                 "-x http2/5.3.1/1",  # disabled by issue 1196
                 "-x http2/5.3.1/2",  # disabled by issue 1196
-                "-x http2/5.5/2",  # disabled by issue 1824
                 "-x http2/6.1/2",  # disabled by issue 1828
                 "-x hpack/5.2/3",  # disabled by issue #1827
             ]

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -250,10 +250,6 @@
             "reason": "Disabled by issue #702"
         },
         {
-            "name": "t_malformed.test_h2_field_validity.TestH2HeaderFieldRequest.test_ascii_uppercase_in_header_name",
-            "reason": "Disabled by issue #1729"
-        },
-        {
             "name": "t_malformed.test_h2_field_validity.TestH2HeaderFieldRequest.test_ascii_0x20_and_0x09_in_header_value",
             "reason": "Disabled by issue #1882"
         },
@@ -308,10 +304,6 @@
         {
             "name": "http2_general.test_h2_stream_states.TestHalfClosedStreamStateUnexpectedFrames",
             "reason": "Disabled by issue #1196"
-        },
-        {
-            "name": "cache.test_cache.TestH2CacheHdrDel.test_cache_bypass",
-            "reason": "Disabled by issue #1900"
         },
         {
             "name": "cache.test_conditional.TestConditionalH2.test_none_match_empty_etag",

--- a/tests_disabled_remote.json
+++ b/tests_disabled_remote.json
@@ -58,18 +58,6 @@
             "reason": "Disabled by issue #1103"
         },
         {
-            "name": "encoding.test_encoding.TestH2BodyDechunking",
-            "reason": "Disabled by issue #1934"
-        },
-        {
-            "name": "encoding.test_encoding.TestH2LargeResponseBodyDechunking",
-            "reason": "Disabled by issue #1934"
-        },
-        {
-            "name": "encoding.test_encoding.TestH2LargeResponseBodyDechunking2",
-            "reason": "Disabled by issue #1934"
-        },
-        {
             "name": "http2_general.test_h2_headers.TestIPv6",
             "reason": "Disabled by test issue #508"
         },

--- a/tests_disabled_tcpseg.json
+++ b/tests_disabled_tcpseg.json
@@ -150,10 +150,6 @@
             "reason": "Disabled by test issue #450"
         },
         {
-            "name": "t_malformed.test_h2_malformed_headers.H2MalformedRequestsTest.test_missing_name",
-            "reason": "Disabled by PR #1926"
-        },
-        {
             "name": "t_sched.test_hash_func.HashScheduler",
             "reason": "Disabled by issue #1103"
         },


### PR DESCRIPTION
Enable test blocked by 1824 and some other
tests which were blocked by fixed issues.