### PR TITLE
Quick fix flaky test

### DIFF
--- a/sessions/test_h2_sticky_scheduler.py
+++ b/sessions/test_h2_sticky_scheduler.py
@@ -1,7 +1,13 @@
 """Test module for http2 and Sticky Cookie Scheduler."""
+
+__author__ = "Tempesta Technologies, Inc."
+__copyright__ = "Copyright (C) 2017-2024 Tempesta Technologies, Inc."
+__license__ = "GPL2"
+
 import http
 
 from framework import tester
+from helpers import dmesg
 
 
 class H2StickySchedulerTestCase(tester.TempestaTest):
@@ -84,6 +90,7 @@ class H2StickySchedulerTestCase(tester.TempestaTest):
         },
     ]
 
+    @dmesg.unlimited_rate_on_tempesta_node
     def test_h2_cookie_scheduler(self):
         """
         Test for sticky cookie scheduler by issue.
@@ -135,10 +142,9 @@ class H2StickySchedulerTestCase(tester.TempestaTest):
         self.assertEqual(response.status, http.HTTPStatus.FORBIDDEN)
 
         # check request is filtering out
-        # TODO uncomment by test issue 525
-        # self.assertTrue(
-        #     self.oops.find(
-        #         "request has been filtered out via http table",
-        #     ),
-        #     "Filtered request warning is not shown",
-        # )
+        self.assertTrue(
+            self.oops.find(
+                "request has been filtered out via http table",
+            ),
+            "Filtered request warning is not shown",
+        )


### PR DESCRIPTION
Fixed unstable test `sessions.test_h2_sticky_scheduler.H2StickySchedulerTestCase.test_h2_cookie_scheduler`.

<img width="651" alt="Screenshot 2024-02-26 at 21 59 52" src="https://github.com/tempesta-tech/tempesta-test/assets/152840171/0df9df4a-8172-4d92-9aa9-9cd286863c48">
<img width="650" alt="Screenshot 2024-02-26 at 22 00 21" src="https://github.com/tempesta-tech/tempesta-test/assets/152840171/0858dd9b-8d73-4abb-a4c0-89376954d7bf">

Used the decorator `@dmesg.unlimited_rate_on_tempesta_node` that turns off dmesg messages rate limiting to ensure important messages are caught.