### PR TITLE
Fix h2spec test config

### DIFF
--- a/http2_general/test_h2_specs.py
+++ b/http2_general/test_h2_specs.py
@@ -59,8 +59,8 @@ vhost default {
     proxy_pass default;
 }
 
-block_action attack reply;
-block_action error reply;
+block_action attack drop;
+block_action error drop;
 cache 0;
 
 """


### PR DESCRIPTION
We should set block_action to drop for h2spec
tests, because otherwise we send response in case
of error, but some h2spec tests doesn't expect it.