### PR TITLE
Increment max_concurrent_streams for stress tests

### DIFF
--- a/t_reconf/test_stress_sched_dynamic.py
+++ b/t_reconf/test_stress_sched_dynamic.py
@@ -62,6 +62,7 @@ listen 443 proto=h2;
 tls_certificate ${tempesta_workdir}/tempesta.crt;
 tls_certificate_key ${tempesta_workdir}/tempesta.key;
 tls_match_any_server_name;
+max_concurrent_streams 10000;
 
 cache 0;
 

--- a/t_reconf/test_stress_sched_hash.py
+++ b/t_reconf/test_stress_sched_hash.py
@@ -56,6 +56,7 @@ listen ${tempesta_ip}:443 proto=h2;
 tls_certificate ${tempesta_workdir}/tempesta.crt;
 tls_certificate_key ${tempesta_workdir}/tempesta.key;
 tls_match_any_server_name;
+max_concurrent_streams 10000;
 
 cache 0;
 

--- a/t_reconf/test_stress_sched_ratio.py
+++ b/t_reconf/test_stress_sched_ratio.py
@@ -58,6 +58,7 @@ listen ${tempesta_ip}:443 proto=h2;
 tls_certificate ${tempesta_workdir}/tempesta.crt;
 tls_certificate_key ${tempesta_workdir}/tempesta.key;
 tls_match_any_server_name;
+max_concurrent_streams 10000;
 
 cache 0;
 server ${server_ip}:8000;

--- a/t_regress/test_reboot_under_load.py
+++ b/t_regress/test_reboot_under_load.py
@@ -24,6 +24,7 @@ TEMPESTA_NO_CACHE = {
         tls_certificate ${tempesta_workdir}/tempesta.crt;
         tls_certificate_key ${tempesta_workdir}/tempesta.key;
         tls_match_any_server_name;
+        max_concurrent_streams 10000;
         
         cache 0;
         block_action error reply;
@@ -40,6 +41,7 @@ TEMPESTA_WITH_CACHE = {
         tls_certificate ${tempesta_workdir}/tempesta.crt;
         tls_certificate_key ${tempesta_workdir}/tempesta.key;
         tls_match_any_server_name;
+        max_concurrent_streams 10000;
         
         cache 2;
         cache_fulfill * *;

--- a/t_regress/test_stress_failovering.py
+++ b/t_regress/test_stress_failovering.py
@@ -60,6 +60,7 @@ TFW_CONFIF_WITH_DEFAULT_SCHED = f"""
     tls_certificate {GENERAL_WORKDIR}/tempesta.crt;
     tls_certificate_key {GENERAL_WORKDIR}/tempesta.key;
     tls_match_any_server_name;
+    max_concurrent_streams 10000;
 
     cache 0;
     server {SERVER_IP}:8000;
@@ -73,6 +74,7 @@ TFW_CONFIF_WITH_HASH_SCHED = f"""
     tls_certificate {GENERAL_WORKDIR}/tempesta.crt;
     tls_certificate_key {GENERAL_WORKDIR}/tempesta.key;
     tls_match_any_server_name;
+    max_concurrent_streams 10000;
 
     cache 0;
     server {SERVER_IP}:8000;

--- a/t_sched/test_hash_stress.py
+++ b/t_sched/test_hash_stress.py
@@ -79,6 +79,7 @@ class BindToServer(tester.TempestaTest):
     tls_certificate ${tempesta_workdir}/tempesta.crt;
     tls_certificate_key ${tempesta_workdir}/tempesta.key;
     tls_match_any_server_name;
+    max_concurrent_streams 10000;
 
     sched hash;
     cache 0;

--- a/t_sched/test_ratio_static.py
+++ b/t_sched/test_ratio_static.py
@@ -69,6 +69,7 @@ listen 443 proto=h2;
 tls_certificate ${tempesta_workdir}/tempesta.crt;
 tls_certificate_key ${tempesta_workdir}/tempesta.key;
 tls_match_any_server_name;
+max_concurrent_streams 10000;
 
 cache 0;
 server ${server_ip}:8000;
@@ -92,6 +93,7 @@ listen 443 proto=h2;
 tls_certificate ${tempesta_workdir}/tempesta.crt;
 tls_certificate_key ${tempesta_workdir}/tempesta.key;
 tls_match_any_server_name;
+max_concurrent_streams 10000;
 
 cache 0;
 server ${server_ip}:8000;

--- a/t_sched/test_ratio_weight.py
+++ b/t_sched/test_ratio_weight.py
@@ -78,6 +78,7 @@ listen 443 proto=h2;
 tls_certificate ${tempesta_workdir}/tempesta.crt;
 tls_certificate_key ${tempesta_workdir}/tempesta.key;
 tls_match_any_server_name;
+max_concurrent_streams 10000;
 
 cache 0;
 server ${server_ip}:8000;
@@ -101,6 +102,7 @@ listen 443 proto=h2;
 tls_certificate ${tempesta_workdir}/tempesta.crt;
 tls_certificate_key ${tempesta_workdir}/tempesta.key;
 tls_match_any_server_name;
+max_concurrent_streams 10000;
 
 cache 0;
 server ${server_ip}:8000;

--- a/t_stress/test_stress.py
+++ b/t_stress/test_stress.py
@@ -471,6 +471,7 @@ class H2LoadStress(CustomMtuMixin, LargePageNginxBackendMixin, tester.TempestaTe
             tls_certificate ${tempesta_workdir}/tempesta.crt;
             tls_certificate_key ${tempesta_workdir}/tempesta.key;
             tls_match_any_server_name;
+            max_concurrent_streams 10000;
             cache 0;
         """
     }
@@ -524,6 +525,7 @@ class RequestStress(CustomMtuMixin, tester.TempestaTest):
     tls_certificate ${tempesta_workdir}/tempesta.crt;
     tls_certificate_key ${tempesta_workdir}/tempesta.key;
     tls_match_any_server_name;
+    max_concurrent_streams 10000;
     cache 0;
     """
     }


### PR DESCRIPTION
By default max_concurrent_streams is equal to 100, which is not enough for stress tests.