### PR TITLE
Add test for simultaneous HTTP/1.1 and HTTP/2 availability over HTTPS on a single port

### DIFF
--- a/multiple_listeners/test_mixed.py
+++ b/multiple_listeners/test_mixed.py
@@ -220,7 +220,7 @@ class TestMixedListeners(tester.TempestaTest):
         self.check_curl_response(self.make_curl_request("curl-https-false"), fail=True)
 
 
-class single_port_config(TestMixedListeners):
+class TestSinglePortConfig(TestMixedListeners):
     tempesta = {
         "config": f"""
 


### PR DESCRIPTION
Fix #631