### PR TITLE
add the `kernel-dbg` option to `run_tests.py`

### DIFF
--- a/framework/tester.py
+++ b/framework/tester.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, annotations
+from __future__ import annotations, print_function
 
 import datetime
 import os
@@ -25,6 +25,7 @@ __author__ = "Tempesta Technologies, Inc."
 __copyright__ = "Copyright (C) 2018-2024 Tempesta Technologies, Inc."
 __license__ = "GPL2"
 
+from helpers import error
 from helpers.deproxy import dbg
 from helpers.stateful import Stateful
 
@@ -433,7 +434,10 @@ class TempestaTest(unittest.TestCase):
                 f"Delta for memory consumption: {delta_used_memory}."
             )
             tf_cfg.dbg(4, f"\tCleanup: memory consumption:\n{msg}")
-            self.assertLessEqual(delta_used_memory, run_config.MEMORY_LEAK_THRESHOLD, msg)
+            if delta_used_memory >= run_config.MEMORY_LEAK_THRESHOLD:
+                raise error.MemoryConsumptionError(
+                    msg, delta_used_memory, run_config.MEMORY_LEAK_THRESHOLD
+                )
 
     def wait_while_busy(self, *items, timeout=20):
         if items is None:

--- a/helpers/control.py
+++ b/helpers/control.py
@@ -322,6 +322,7 @@ class Tempesta(stateful.Stateful):
         self.host = tf_cfg.cfg.get("Tempesta", "hostname")
         self.err_msg = " ".join(["Can't %s TempestaFW on", self.host])
         self.stop_procedures = [self.stop_tempesta, self.remove_config]
+        self.__check_config = True
 
     def run_start(self):
         tf_cfg.dbg(3, "\tStarting TempestaFW on %s" % self.host)
@@ -338,8 +339,8 @@ class Tempesta(stateful.Stateful):
 
         tf_cfg.dbg(4, f"\tTempesta config content:\n{cfg_content}")
 
-        if not cfg_content:
-            raise AttributeError("Tempesta config is empty.")
+        if self.__check_config:
+            assert cfg_content, "Tempesta config is empty."
 
         self.node.copy_file(self.config_name, cfg_content)
         env = {"TFW_CFG_PATH": self.config_name, "TFW_CFG_TMPL": self.tmp_config_name}
@@ -366,6 +367,9 @@ class Tempesta(stateful.Stateful):
     def get_server_stats(self, path):
         cmd = "cat /proc/tempesta/servers/%s" % (path)
         return self.node.run_cmd(cmd, err_msg=(self.err_msg % "get stats of"))
+
+    def disable_check_config(self):
+        self.__check_config = False
 
 
 class TempestaFI(Tempesta):

--- a/helpers/control.py
+++ b/helpers/control.py
@@ -322,7 +322,7 @@ class Tempesta(stateful.Stateful):
         self.host = tf_cfg.cfg.get("Tempesta", "hostname")
         self.err_msg = " ".join(["Can't %s TempestaFW on", self.host])
         self.stop_procedures = [self.stop_tempesta, self.remove_config]
-        self.__check_config = True
+        self.check_config = True
 
     def run_start(self):
         tf_cfg.dbg(3, "\tStarting TempestaFW on %s" % self.host)
@@ -339,7 +339,7 @@ class Tempesta(stateful.Stateful):
 
         tf_cfg.dbg(4, f"\tTempesta config content:\n{cfg_content}")
 
-        if self.__check_config:
+        if self.check_config:
             assert cfg_content, "Tempesta config is empty."
 
         self.node.copy_file(self.config_name, cfg_content)
@@ -367,9 +367,6 @@ class Tempesta(stateful.Stateful):
     def get_server_stats(self, path):
         cmd = "cat /proc/tempesta/servers/%s" % (path)
         return self.node.run_cmd(cmd, err_msg=(self.err_msg % "get stats of"))
-
-    def disable_check_config(self):
-        self.__check_config = False
 
 
 class TempestaFI(Tempesta):

--- a/helpers/error.py
+++ b/helpers/error.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import sys  # for sys.exc_info
+from dataclasses import dataclass
 
 __author__ = "Tempesta Technologies, Inc."
 __copyright__ = "Copyright (C) 2017 Tempesta Technologies, Inc."
@@ -16,6 +17,28 @@ class Error(Exception):
     """
 
     pass
+
+
+@dataclass
+class MemoryConsumptionError(Error):
+    msg: str
+    delta_used_memory: int
+    memory_leak_threshold: int
+
+    def __str__(self):
+        return (
+            f"\n{self.msg}"
+            f"\nUsed memory >= memory_leak_threshold "
+            f"({self.delta_used_memory} KB >= {self.memory_leak_threshold} KB)"
+        )
+
+
+@dataclass
+class KmemLeakError(Error):
+    stdout: str
+
+    def __str__(self):
+        return f"kmemleak found 'tfw' in /sys/kernel/debug/kmemleak:\n{self.stdout}"
 
 
 def assertFalse(expression, msg=""):

--- a/helpers/shell.py
+++ b/helpers/shell.py
@@ -21,6 +21,7 @@ class DisabledListLoader(object):
         self.has_file = False
         self.disabled = []
         self.disable = False
+        self.try_load()
 
     def try_load(self):
         """Try to load specified state file"""

--- a/run_config.py
+++ b/run_config.py
@@ -47,3 +47,6 @@ AUTO_PARSER = True
 # Enable or disable checks for memory leaks for all tests
 CHECK_MEMORY_LEAKS = False
 MEMORY_LEAK_THRESHOLD = int(tf_cfg.cfg.get("General", "memory_leak_threshold"))  # KB
+
+# run tests for debug kernel (kernel with kmemleak etc.)
+KERNEL_DBG_TESTS = False

--- a/tests_disabled_dbgkernel.json
+++ b/tests_disabled_dbgkernel.json
@@ -1,0 +1,73 @@
+{
+  "disable": true,
+  "disabled": [
+    {
+      "name" : "selftests",
+      "reason" : "These tests should not be run for the debug kernel"
+    },
+    {
+      "name" : "t_leaks.test_leak.LeakTest.test_kmemleak",
+      "reason" : "the tests did not work on the first run"
+    },
+    {
+      "name" : "very_many_backends",
+      "reason" : "the tests did not work on the first run"
+    },
+    {
+      "name" : "http2_general.test_h2_block_action.BlockActionH2ReplyWithCustomErrorPage.test_block_action_attack_reply_not_on_req_rcv_event",
+      "reason" : "the tests did not work on the first run"
+    },
+    {
+      "name" : "selftests.test_lxc_server.TestLxcServer.test_status",
+      "reason" : "the tests did not work on the first run"
+    },
+    {
+      "name" : "t_reconf.test_reconf_base.TestServerOptionsReconf.test_reconf_server_queue_size_enabled",
+      "reason" : "the tests did not work on the first run"
+    },
+    {
+      "name" : "t_reconf.test_stress_health_monitor.TestHealthMonitorLiveReconf.test_reconf_on_the_fly_for_health_monitor",
+      "reason" : "the tests did not work on the first run"
+    },
+    {
+      "name" : "t_stress.test_header_leak.TestH2HeaderLeak",
+      "reason" : "the tests did not work on the first run"
+    },
+    {
+      "name" : "t_stress.test_stress.ContinuationFlood",
+      "reason" : "the tests did not work on the first run"
+    },
+    {
+      "name" : "t_stress.test_wordpress.TestWordpressStressH2.test_get_large_images",
+      "reason" : "the tests did not work on the first run"
+    },
+    {
+      "name" : "http2_general.test_h2_specs.H2Spec",
+      "reason" : "the tests did not work on the first run"
+    },
+    {
+      "name" : "http2_general.test_h2_block_action.BlockActionH2ReplyFramesAfterShutdownWithCustomErrorPageSmallWindow",
+      "reason" : "the tests did not work on the first run"
+    },
+    {
+      "name" : "ws.test_ws_ping.RestartOnUpgrade",
+      "reason" : "the tests did not work on the first run"
+    },
+    {
+      "name" : "http2_general.test_h2_stream_priority.TestStreamPriorityStress.test_stream_priority_stress",
+      "reason" : "the tests did not work on the first run"
+    },
+    {
+      "name" : "http2_general.test_flow_control_window.TestFlowControl.test_not_blocked_goaway_frame",
+      "reason" : "the tests did not work on the first run"
+    },
+    {
+      "name" : "http2_general.test_h2_block_action",
+      "reason" : "the tests did not work on the first run"
+    },
+    {
+      "name" : "http_general.test_block_action",
+      "reason" : "the tests did not work on the first run"
+    }
+  ]
+}


### PR DESCRIPTION
 This option runs `kmemleak` check after all the tests

related to [23](https://github.com/tempesta-tech/tempesta-ci/issues/23) and [29](https://github.com/tempesta-tech/tempesta-ci/pull/29)