### PR TITLE
Implement tests to check Tempesta 'cache' directive

### DIFF
--- a/tests_disabled_remote.json
+++ b/tests_disabled_remote.json
@@ -82,6 +82,10 @@
             "reason": "These tests should not be run with remote setup."
         },
         {
+            "name": "cache.test_purge.TestPurgeInvalidConfig",
+            "reason": "These tests should not be run with remote setup."
+        },
+        {
             "name": "t_modify_http_headers.test_logic.TestManyRequestHeaders.test_many_headers",
             "reason": "Disabled by issue #1103"
         },

--- a/tests_disabled_tcpseg.json
+++ b/tests_disabled_tcpseg.json
@@ -138,6 +138,10 @@
             "reason": "These tests should not be run with TCP segmentation."
         },
         {
+            "name": "cache.test_purge.TestPurgeInvalidConfig",
+            "reason": "These tests should not be run with TCP segmentation."
+        },
+        {
             "name": "tls.test_tls_integrity.ProxyH2",
             "reason": "Disabled by issue #1714"
         },


### PR DESCRIPTION
Now Tempesta FW fails to start if cache directive is empty or equal to zero, but purge directive is set. Also Tempesta FW fails to start if purge directive is set but purge acl is not set and vice versa.