### PR TITLE
Add tests to check frang reconfiguration

### DIFF
--- a/tests_disabled_dbgkernel.json
+++ b/tests_disabled_dbgkernel.json
@@ -68,18 +68,6 @@
     {
       "name" : "http_general.test_block_action",
       "reason" : "the tests did not work on the first run"
-    },
-    {
-      "name" : "t_frang.test_http_ct_vals",
-      "reason" : "Disabled by tempesta issue #2256"
-    },
-    {
-      "name" : "t_frang.test_http_resp_code_block",
-      "reason" : "Disabled by tempesta issue #2256"
-    },
-    {
-      "name" : "t_http_rules",
-      "reason" : "Disabled by tempesta issue #2256"
     }
   ]
 }


### PR DESCRIPTION
Add tests to check reconiguration for `http_ct_vals` directive. This tests is very useful with kmemleak, because Tempesta FW had leak which was fixed and checked by this tests.