### PR TITLE
Fix flacky test

### DIFF
--- a/ws/test_ws_ping.py
+++ b/ws/test_ws_ping.py
@@ -484,6 +484,7 @@ class WssPipelining(WssPing):
     async def handler(self, websocket, path):
         pass
 
+    @dmesg.unlimited_rate_on_tempesta_node
     def test(self):
         self.p1 = Process(target=self.run_ws, args=(8099,))
         self.p1.start()


### PR DESCRIPTION
It seems that we should use `unlimited_rate_on_tempesta_node` each time when we search some warning message in dmesg for test.

Closes #710