### PR TITLE
fix unstable tests

### DIFF
--- a/framework/deproxy_client.py
+++ b/framework/deproxy_client.py
@@ -237,7 +237,7 @@ class BaseDeproxyClient(deproxy.Client, abc.ABC):
         timeout_not_exceeded = util.wait_until(
             lambda: not self.connection_is_closed(),
             timeout,
-            abort_cond=lambda: self.state != stateful.STATE_STARTED,
+            abort_cond=lambda: self.state == stateful.STATE_ERROR,
         )
         if strict:
             assert (

--- a/framework/lxc_server.py
+++ b/framework/lxc_server.py
@@ -145,7 +145,7 @@ class LXCServer(LXCServerArguments, stateful.Stateful, port_checks.FreePortsChec
 
     def _stop_container(self):
         tf_cfg.dbg(3, f"\tlxc server: stop {self.id}")
-        self.node.run_cmd(self._construct_cmd(["stop", self.container_name]))
+        self.node.run_cmd(self._construct_cmd(["stop", self.container_name]), timeout=30)
         if self.make_snapshot:
             self._restore_pretest_snapshot()
 


### PR DESCRIPTION
- deproxy_client.py - we must not use `STATE_STARTED` as `abort_cond` for `wait_for_connection_close` because `handle_close`, etc. can change the state (for example `handle_close` method change status: `STATE_STARTED` -> `STATE_STOPPED`). Then `wait_for_connection_close` will return None, but it is unexpected. So the `STATE_ERROR` state can be used as `abort_cond`;
- lxc_server.py sometimes needs more time to close on CI;
- rework `test_wait_for_headers_frame` test using a new option in DeproxyClientH2 - `auto_flow_control`.