### PR TITLE
Replace 'access_log on' by 'access_log dmesg'

### DIFF
--- a/access_log/test_access_log.py
+++ b/access_log/test_access_log.py
@@ -31,7 +31,7 @@ class CheckedResponses(tester.TempestaTest):
         "config": """
             cache 0;
             listen 80;
-            access_log on;
+            access_log dmesg;
 
             srv_group localhost {
                 server ${server_ip}:8000;
@@ -193,7 +193,7 @@ class AccessLogFrang(CheckedResponses):
         "config": """
             cache 0;
             listen 80;
-            access_log on;
+            access_log dmesg;
 
             frang_limits {
                 ip_block off;

--- a/access_log/test_access_log_h2.py
+++ b/access_log/test_access_log_h2.py
@@ -68,7 +68,7 @@ def tempesta(extra=""):
     return {
         "config": """
            listen 443 proto=h2;
-           access_log on;
+           access_log dmesg;
            %s
 
             server ${server_ip}:8000;

--- a/t_sites/test_tempesta_tech.py
+++ b/t_sites/test_tempesta_tech.py
@@ -107,7 +107,7 @@ class TestTempestaTechSite(NetfilterMarkMixin, tester.TempestaTest):
             # Allow purging from the containers (upstream), localhost (VM) and the host.
             cache_purge_acl ${client_ip};
 
-            access_log on;
+            access_log dmesg;
 
             frang_limits {
                 request_rate 200;

--- a/ws/test_ws_ping.py
+++ b/ws/test_ws_ping.py
@@ -153,7 +153,7 @@ vhost default {
     proxy_pass default;
 }
 
-access_log on;
+access_log dmesg;
 
 cache 1;
 cache_fulfill * *;


### PR DESCRIPTION
In #537 access_log fields were changed. Instead of on|off fields there are dmesg|mmap|off. Change test configs accordingly.