### PR TITLE
Take into account NUMA nodes count in `TestCacheClean`

### DIFF
--- a/cache/test_cache.py
+++ b/cache/test_cache.py
@@ -10,7 +10,7 @@ from http import HTTPStatus
 from framework.curl_client import CurlResponse
 from framework.deproxy_client import DeproxyClientH2
 from framework.deproxy_server import StaticDeproxyServer
-from helpers import deproxy, error
+from helpers import deproxy, error, remote
 from helpers.control import Tempesta
 from helpers.deproxy import HttpMessage
 from test_suite import checks_for_tests as checks
@@ -1970,6 +1970,8 @@ class TestCacheClean(tester.TempestaTest):
 
     def test(self):
         """
+        Only for cache REPLICA mode, SHARD mode is not expected.
+
         Send request, Tempesta cache it, wait for max-age time then send second request.
         At this stage we expected that first request evicted from cache and only new version
         is presented in the cache. Send third request with different uri to verify we don't clean
@@ -1979,6 +1981,7 @@ class TestCacheClean(tester.TempestaTest):
         server = self.get_server("deproxy")
         client = self.get_client("deproxy")
         tempesta = self.get_tempesta()
+        nodes_num = remote.tempesta.get_numa_nodes_count()
 
         server.set_response(
             f"HTTP/1.1 200 OK\r\n"
@@ -1997,16 +2000,19 @@ class TestCacheClean(tester.TempestaTest):
         time.sleep(3)
         client.send_request(request, expected_status_code="200")
 
+        # We testing cache REPLICA mode, thus we expect response will be copied to each numa node
+        expected_objects_num = nodes_num
         tempesta.get_stats()
-        self.assertEqual(tempesta.stats.cache_objects, 1)
+        self.assertEqual(tempesta.stats.cache_objects, expected_objects_num)
 
         request = client.create_request(
             uri="/2", authority="tempesta-tech.com", method="GET", headers=[]
         )
         client.send_request(request, expected_status_code="200")
 
+        expected_objects_num = nodes_num * 2
         tempesta.get_stats()
-        self.assertEqual(tempesta.stats.cache_objects, 2)
+        self.assertEqual(tempesta.stats.cache_objects, expected_objects_num)
 
 
 class TestCacheUseStaleCfg(tester.TempestaTest):

--- a/framework/deproxy_server.py
+++ b/framework/deproxy_server.py
@@ -181,7 +181,7 @@ class StaticDeproxyServer(asyncore.dispatcher, stateful.Stateful):
         self.segment_gap = segment_gap
 
         self.stop_procedures: list[callable] = [self.__stop_server]
-        self.node: remote.INode = remote.host
+        self.node: remote.ANode = remote.host
         self._polling_lock: threading.Lock | None = None
 
     def _reinit_variables(self):

--- a/framework/docker_server.py
+++ b/framework/docker_server.py
@@ -73,7 +73,7 @@ class DockerServer(DockerServerArguments, stateful.Stateful):
         # with only supported arguments
         super().__init__(**{k: kwargs[k] for k in self.get_arg_names() if k in kwargs})
         stateful.Stateful.__init__(self)
-        self.node: remote.INode = remote.server
+        self.node: remote.ANode = remote.server
         self.container_id = None
         self.stop_procedures = [self.stop_server, self.cleanup]
         self.port_checker = port_checks.FreePortsChecker()
@@ -107,9 +107,7 @@ class DockerServer(DockerServerArguments, stateful.Stateful):
     @property
     def health_status(self):
         """Status of the container: 'starting', 'healthy', 'unhealthy'."""
-        stdout, stderr = self.node.run_cmd(
-            self._form_inspect_health_command()
-        )
+        stdout, stderr = self.node.run_cmd(self._form_inspect_health_command())
         if stderr or not stdout:
             error.bug(self._form_error(action="inspect_health"))
         try:
@@ -145,7 +143,8 @@ class DockerServer(DockerServerArguments, stateful.Stateful):
         t = time.time()
         while t - t0 <= timeout and self.health_status != "unhealthy":
             if self.health_status == "healthy" and self.port_checker.check_ports_established(
-                ip=self.server_ip, ports=self.ports.keys(),
+                ip=self.server_ip,
+                ports=self.ports.keys(),
             ):
                 return True
             time.sleep(0.001)  # to prevent redundant CPU usage

--- a/helpers/analyzer.py
+++ b/helpers/analyzer.py
@@ -1,12 +1,12 @@
 """
 Instruments for network traffic analysis.
 """
+
 from __future__ import print_function
 
 import abc
 
 from scapy.all import *
-
 
 from helpers import error, remote, tf_cfg, util
 
@@ -27,7 +27,7 @@ CWR = 0x80
 
 class Sniffer(object, metaclass=abc.ABCMeta):
 
-    def __init__(self, node: remote.INode, host, count=0, timeout=30, ports=(80,), node_close=True):
+    def __init__(self, node: remote.ANode, host, count=0, timeout=30, ports=(80,), node_close=True):
         self.node = node
         self.ports = ports
         self.thread = None

--- a/helpers/port_checks.py
+++ b/helpers/port_checks.py
@@ -6,7 +6,7 @@ import ipaddress
 from typing import List
 
 from helpers import remote, tf_cfg
-from helpers.remote import INode
+from helpers.remote import ANode
 
 
 class FreePortsChecker(object):
@@ -16,11 +16,11 @@ class FreePortsChecker(object):
         super().__init__()
 
     @property
-    def node(self) -> INode:
+    def node(self) -> ANode:
         return self.__node
 
     @node.setter
-    def node(self, node: INode) -> None:
+    def node(self, node: ANode) -> None:
         self.__node = node
 
     def add_port_to_checks(self, ip: str, port: int) -> None:

--- a/helpers/tf_cfg.py
+++ b/helpers/tf_cfg.py
@@ -18,7 +18,7 @@ from rich import pretty
 from rich.logging import Console, RichHandler
 
 if TYPE_CHECKING:
-    from helpers.remote import INode
+    from helpers.remote import ANode
 
 
 LOGGER = logging.getLogger(__name__)
@@ -263,7 +263,7 @@ def dbg(level: int, msg: str, *args, **kwargs) -> None:
     )
 
 
-def log_dmesg(node: 'INode', msg: str) -> None:
+def log_dmesg(node: "ANode", msg: str) -> None:
     """Forward a message to kernel log at given node."""
     try:
         node.run_cmd(f"echo '{msg}' > /dev/kmsg")

--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,7 @@ CURRENT_DIR=$(pwd)
 
 apt install python3-pip nginx libnginx-mod-http-echo libtool net-tools libssl-dev \
     apache2-utils nghttp2-client libnghttp2-dev autoconf unzip libtemplate-perl \
-    tcpdump lxc -y
+    tcpdump lxc util-linux -y
 
 # stop and disable installed nginx
 systemctl stop nginx


### PR DESCRIPTION
Currently in test `TestCacheClean` we testing cache in REPLICA mode, therefore on numa machine cached
response will be copied to each node and in statistics we got total count of objects around all NUMA nodes.

`lscpu` added to setup.sh