### PR TITLE
fixed lxc container 9000 port conflicting with clickhouse

### DIFF
--- a/selftests/test_lxc_server.py
+++ b/selftests/test_lxc_server.py
@@ -41,7 +41,7 @@ class TestLxcServer(tester.TempestaTest):
         if Tempesta and server has different connection ports.
         """
         server = self.get_server("lxc")
-        server.external_port = "9000"
+        server.external_port = "19000"
 
         server.start()
         self.start_tempesta()


### PR DESCRIPTION
```
test_wait_for_connections_negative (selftests.test_lxc_server.TestLxcServer) ... 25-01-26 13:34:12.208633 CRITICAL  | Exception in stopping process:                                                                                                    tf_cfg.py:258
                                  process: <Popen: returncode: 1 args: 'lxc config device remove tempesta-site-stage te...>;                                                        
                                  stderr: b"Error: Device doesn't exist\n", type: <class 'helpers.error.ProcessBadExitStatusException'>, traceback:                                 
                                  Traceback (most recent call last):                                                                                                                
                                    File "/home/jenkins/workspace/Manual_run/tempesta-test/framework/stateful.py", line 69, in force_stop                                           
                                      stop_proc()                                                                                                                                   
                                    File "/home/jenkins/workspace/Manual_run/tempesta-test/framework/lxc_server.py", line 112, in _proxy_teardown                                   
                                      self.node.run_cmd(                                                                                                                            
                                    File "/home/jenkins/workspace/Manual_run/tempesta-test/helpers/remote.py", line 253, in run_cmd                                                 
                                      raise error.ProcessBadExitStatusException(                                                                                                    
                                  helpers.error.ProcessBadExitStatusException:                                                                                                      
                                  process: <Popen: returncode: 1 args: 'lxc config device remove tempesta-site-stage te...>;                                                        
                                  stderr: b"Error: Device doesn't exist\n"                                                                                                          
                                                                                                                                                                                    
ERROR
ERROR
test_wait_for_connections_positive (selftests.test_lxc_server.TestLxcServer) ... ok

======================================================================
ERROR: test_wait_for_connections_negative (selftests.test_lxc_server.TestLxcServer)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/workspace/Manual_run/tempesta-test/selftests/test_lxc_server.py", line 46, in test_wait_for_connections_negative
    server.start()
  File "/home/jenkins/workspace/Manual_run/tempesta-test/framework/stateful.py", line 62, in start
    self.run_start()
  File "/home/jenkins/workspace/Manual_run/tempesta-test/framework/lxc_server.py", line 69, in run_start
    self._proxy_setup()
  File "/home/jenkins/workspace/Manual_run/tempesta-test/framework/lxc_server.py", line 96, in _proxy_setup
    self.node.run_cmd(
  File "/home/jenkins/workspace/Manual_run/tempesta-test/helpers/remote.py", line 253, in run_cmd
    raise error.ProcessBadExitStatusException(
helpers.error.ProcessBadExitStatusException: 
process: <Popen: returncode: 1 args: 'lxc config device add tempesta-site-stage tempe...>;
stderr: b'Error: Failed to start device "tempesta-test-8000-80": Error occurred when starting proxy device: Error: Failed to listen on 192.168.122.4:9000: listen tcp 192.168.122.4:9000: bind: address already in use\n'

======================================================================
ERROR: test_wait_for_connections_negative (selftests.test_lxc_server.TestLxcServer)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/workspace/Manual_run/tempesta-test/test_suite/tester.py", line 381, in cleanup_services
    raise error.ServiceStoppingException(self.__exceptions)
helpers.error.ServiceStoppingException: 
---------------------------------------------------------
Exception in stopping process for LXCServer: Traceback (most recent call last):
  File "/home/jenkins/workspace/Manual_run/tempesta-test/framework/stateful.py", line 69, in force_stop
    stop_proc()
  File "/home/jenkins/workspace/Manual_run/tempesta-test/framework/lxc_server.py", line 112, in _proxy_teardown
    self.node.run_cmd(
  File "/home/jenkins/workspace/Manual_run/tempesta-test/helpers/remote.py", line 253, in run_cmd
    raise error.ProcessBadExitStatusException(
helpers.error.ProcessBadExitStatusException: 
process: <Popen: returncode: 1 args: 'lxc config device remove tempesta-site-stage te...>;
stderr: b"Error: Device doesn't exist\n"

```