### PR TITLE
fixed unstable the ja5 stress test on seg

### DIFF
--- a/t_ja5/test_ja5t.py
+++ b/t_ja5/test_ja5t.py
@@ -4,6 +4,8 @@ __author__ = "Tempesta Technologies, Inc."
 __copyright__ = "Copyright (C) 2024 Tempesta Technologies, Inc."
 __license__ = "GPL2"
 
+import time
+
 from helpers import dmesg, tf_cfg
 from helpers.control import Tempesta
 from test_suite import marks, tester
@@ -86,7 +88,7 @@ class TestJa5t(tester.TempestaTest):
                 name="hash_for_client_not_block",
                 tempesta_ja5_config="""
 					ja5t {
-						hash 66cb9fd8d4250000 1 10;
+						hash 66cb9fd8d4250000 1 100;
 					}
 				""",
                 expected_block=False,
@@ -175,7 +177,7 @@ class TestJa5tStress(tester.TempestaTest):
     tempesta_ja5_config_2 = """
         ja5t {
             hash deadbeef 10 1000;
-            hash 1f5a9a29ef170000 1 2;
+            hash 1f5a9a29ef170000 1 100;
         }
     """
     tempesta_ja5_config_empty = ""
@@ -184,14 +186,17 @@ class TestJa5tStress(tester.TempestaTest):
         tempesta: Tempesta = self.get_tempesta()
         config = tempesta.config.defconfig
         ja5_configs = [
+            self.tempesta_ja5_config_empty,
             self.tempesta_ja5_config_1,
             self.tempesta_ja5_config_2,
-            self.tempesta_ja5_config_empty,
         ] * 4
 
         for ja5_config in ja5_configs:
             tempesta.config.defconfig = config + ja5_config
             self.get_tempesta().reload()
+
+            # sleep sometime to receive 200 responses
+            time.sleep(0.5)
 
     @marks.Parameterize.expand(
         [

--- a/t_ja5/test_ja5t.py
+++ b/t_ja5/test_ja5t.py
@@ -195,9 +195,6 @@ class TestJa5tStress(tester.TempestaTest):
             tempesta.config.defconfig = config + ja5_config
             self.get_tempesta().reload()
 
-            # sleep sometime to receive 200 responses
-            time.sleep(0.5)
-
     @marks.Parameterize.expand(
         [
             marks.Param(name="Http", client_id="wrk"),

--- a/t_ja5/test_ja5t.py
+++ b/t_ja5/test_ja5t.py
@@ -4,8 +4,6 @@ __author__ = "Tempesta Technologies, Inc."
 __copyright__ = "Copyright (C) 2024 Tempesta Technologies, Inc."
 __license__ = "GPL2"
 
-import time
-
 from helpers import dmesg, tf_cfg
 from helpers.control import Tempesta
 from test_suite import marks, tester

--- a/tests_disabled_tcpseg.json
+++ b/tests_disabled_tcpseg.json
@@ -288,6 +288,10 @@
         {
             "name": "http2_general.test_h2_headers.TestIPv6.test_request_with_some_data",
             "reason": "Disabled by test issue #525"
+        },
+        {
+            "name": "t_ja5.test_ja5t.TestJa5tStress",
+            "reason": "This test should not be run with TCP segmentation. It use h2load and wrk clients and ja5 only works for requests."
         }
     ]
 }


### PR DESCRIPTION
```
======================================================================
FAIL: test_hash_for_client_not_block (t_ja5.test_ja5t.TestJa5tHttp)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/parameterized/parameterized.py", line 620, in standalone_func
    return func(*(a + p.args), **p.kwargs, **kw)
  File "/home/symstu/projects/tempesta/tempesta-test/t_ja5/test_ja5t.py", line 130, in test
    self.assertTrue(client.wait_for_response())
AssertionError: None is not true

======================================================================
ERROR: test_Http (t_ja5.test_ja5t.TestJa5tStress)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jenkins/workspace/Manual_run/tempesta-test/venv/lib/python3.10/site-packages/parameterized/parameterized.py", line 620, in standalone_func
    return func(*(a + p.args), **p.kwargs, **kw)
  File "/home/jenkins/workspace/Manual_run/tempesta-test/helpers/dmesg.py", line 166, in func_wrapper
    return __change_dmesg_limit_on_tempesta_node(func, 5, *args, **kwargs)
  File "/home/jenkins/workspace/Manual_run/tempesta-test/helpers/dmesg.py", line 143, in __change_dmesg_limit_on_tempesta_node
    return func(*args, **kwargs)
  File "/home/jenkins/workspace/Manual_run/tempesta-test/t_ja5/test_ja5t.py", line 212, in test
    self.assertGreater(client.statuses[200], 0)
KeyError: 200
```