### PR TITLE
fix config generation 

### DIFF
--- a/helpers/tf_cfg.py
+++ b/helpers/tf_cfg.py
@@ -132,6 +132,8 @@ class TestFrameworkCfg(object):
         self.config["Server"]["website_user"] = website_user
         self.config["Server"]["website_password"] = website_password
 
+        self.config["TFW_Logger"]["clickhouse_host"] = remote_ip
+
     def defaults(self):
         self.config = configparser.ConfigParser()
         self.config.read_dict(

--- a/t_frang/test_http_trailer_split_allowed.py
+++ b/t_frang/test_http_trailer_split_allowed.py
@@ -12,7 +12,7 @@ from test_suite import marks
 WARN = "frang: HTTP field appear in header and trailer"
 
 REQUEST_WITH_TRAILER = (
-    "GET / HTTP/1.1\r\n"
+    "POST / HTTP/1.1\r\n"
     "Host: debian\r\n"
     "HdrTest: testVal\r\n"
     "Transfer-Encoding: gzip, chunked\r\n"
@@ -32,7 +32,7 @@ class FrangHttpTrailerSplitLimitOnTestCase(FrangTestCase):
             requests=[
                 REQUEST_WITH_TRAILER,
                 (
-                    "GET / HTTP/1.1\r\n"
+                    "POST / HTTP/1.1\r\n"
                     "Host: debian\r\n"
                     "HdrTest: testVal\r\n"
                     "Transfer-Encoding: chunked\r\n"


### PR DESCRIPTION
fix tests with trailers - Tempesta doesn't allow trailers for GET\HEAD requests.
fix config generation for clickhouse with remote setup.