### PR TITLE
fix returncode 0 for `unexpectedSuccesses` tests.

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -609,10 +609,7 @@ if not tests or (test_resume.state.last_id == tests[-1].id() and test_resume.sta
 __check_memory_consumption(python_memory_before, used_memory_before)
 __check_kmemleak()
 
-if len(result.errors) > 0:
-    sys.exit(-1)
-
-if len(result.failures) > 0:
+if len(result.failures) > 0 or len(result.unexpectedSuccesses) > 0 or len(result.errors) > 0:
     sys.exit(1)
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/t_malformed/test_h2_malformed_headers.py
+++ b/t_malformed/test_h2_malformed_headers.py
@@ -1,5 +1,5 @@
 __author__ = "Tempesta Technologies, Inc."
-__copyright__ = "Copyright (C) 2023 Tempesta Technologies, Inc."
+__copyright__ = "Copyright (C) 2023-2025 Tempesta Technologies, Inc."
 __license__ = "GPL2"
 
 import unittest
@@ -23,6 +23,10 @@ class H2MalformedRequestsTest(test_malformed_headers.MalformedRequestsTest):
 
     def test_te(self):
         self.common_check(headers=("TE", "invalid"))
+
+    def test_expect(self):
+        """TempestaFW blocks h2 requests with Expect header."""
+        self.common_check(headers=("Expect", "100-continue"))
 
     @staticmethod
     def generate_request(headers: tuple, method="GET"):
@@ -64,6 +68,10 @@ class H2MalformedRequestsWithoutStrictParsingTest(
     @unittest.SkipTest
     def test_te(self):
         pass
+
+    @unittest.SkipTest
+    def test_expect(self):
+        """This test move to H2MalformedRequestsTest."""
 
     @staticmethod
     def generate_request(headers: tuple, method="GET"):

--- a/t_malformed/test_malformed_headers.py
+++ b/t_malformed/test_malformed_headers.py
@@ -1,5 +1,5 @@
 __author__ = "Tempesta Technologies, Inc."
-__copyright__ = "Copyright (C) 2018-2024 Tempesta Technologies, Inc."
+__copyright__ = "Copyright (C) 2018-2025 Tempesta Technologies, Inc."
 __license__ = "GPL2"
 
 import unittest
@@ -65,7 +65,7 @@ server ${server_ip}:8000;
 
 class MalformedRequestsTest(MalformedRequestsBase):
 
-    def test_expect(self):
+    def test_expect_invalid(self):
         """
         https://tools.ietf.org/html/rfc7231#section-5.1.1
 

--- a/t_malformed/test_malformed_headers.py
+++ b/t_malformed/test_malformed_headers.py
@@ -64,6 +64,17 @@ server ${server_ip}:8000;
 
 
 class MalformedRequestsTest(MalformedRequestsBase):
+
+    def test_expect(self):
+        """
+        https://tools.ietf.org/html/rfc7231#section-5.1.1
+
+        A server that receives an Expect field-value other than 100-continue
+        MAY respond with a 417 (Expectation Failed) status code to indicate
+        that the unexpected expectation cannot be met.
+        """
+        self.common_check(headers=("Expect", "invalid"))
+
     def test_missing_name(self):
         """
         Header name must contain at least one token character to be valid.
@@ -253,18 +264,7 @@ class MalformedRequestsWithoutStrictParsingTest(MalformedRequestsBase):
         self.disable_deproxy_auto_parser()
         self.common_check(headers=("Date", "invalid"))
 
-    def test_expect1(self):
-        """
-        https://tools.ietf.org/html/rfc7231#section-5.1.1
-
-        A server that receives an Expect field-value other than 100-continue
-        MAY respond with a 417 (Expectation Failed) status code to indicate
-        that the unexpected expectation cannot be met.
-        """
-        self.common_check(headers=("Expect", "invalid"))
-
-    @unittest.expectedFailure
-    def test_expect2(self):
+    def test_expect(self):
         """
         https://tools.ietf.org/html/rfc7231#section-5.1.1
         A client MUST NOT generate a 100-continue expectation in a request


### PR DESCRIPTION
The test runner must not return 0 status when `expectedFailure` tests have `unexpected success` status. 
