### PR TITLE
Verify new behavior of JS challenge tests

### DIFF
--- a/t_fault_injection/test_fault_injection_base.py
+++ b/t_fault_injection/test_fault_injection_base.py
@@ -410,6 +410,15 @@ class TestFailFunctionPrepareResp(TestFailFunctionBase):
                 cookie enforce name=cname max_misses=5;
                 js_challenge resp_code=503 delay_min=1 delay_range=3 %s/js1.html;
             }
+
+            vhost default {
+                proxy_pass default;
+            }
+
+            http_chain {
+                hdr accept == "text/html" -> jsch;
+                -> default;
+            }
         """
             % workdir
         )


### PR DESCRIPTION
Now Tempesta FW sends JS challenge to a client only if request beign matched by http chain "jsch" rule and this is GET request.