### PR TITLE
Add test to check big request and huffman decoding

### DIFF
--- a/http2_general/test_h2_hpack.py
+++ b/http2_general/test_h2_hpack.py
@@ -6,6 +6,8 @@ __license__ = "GPL2"
 
 import itertools
 import time
+import random
+import string
 
 from h2.connection import AllowedStreamIDs, ConnectionInputs
 from h2.errors import ErrorCodes
@@ -594,6 +596,41 @@ class TestHpack(TestHpackBase):
         self.assertTrue(client.wait_for_response(3))
         self.assertEqual(client.last_response.status, "200")
         self.assertEqual(server.last_request.method, "GET")
+
+    @staticmethod
+    def __randomword(length):
+        letters = string.ascii_lowercase
+        return "".join(random.choice(letters) for i in range(length))
+
+    def test_big_header_in_request(self):
+        """
+        Tempesta FW allocates several chunks from the pool for
+        each big header during huffman decoding. This test checks
+        situation when new pages are allocated during new chunk
+        alllocation. In this case Tempesta FW copies all chunks
+        to the new place.
+        """
+        self.start_all_services()
+        client: DeproxyClientH2 = self.get_client("deproxy")
+
+        request = client.create_request(
+            method="POST",
+            headers=[
+                ("a", "da"),
+                ("c", "da"),
+                ("q", "ca"),
+                ("e", "qa"),
+                ("f", "fa"),
+                ("b", "ba"),
+                ("d", "ra"),
+                (self.__randomword(1000), self.__randomword(43399)),
+                (self.__randomword(444), self.__randomword(55344)),
+                (self.__randomword(333), self.__randomword(55347)),
+                (self.__randomword(333), self.__randomword(23124)),
+                (self.__randomword(333), self.__randomword(33333)),
+            ],
+        )
+        client.send_request(request, "200")
 
 
 class TestHpackStickyCookie(TestHpackBase):

--- a/tests_disabled_tcpseg.json
+++ b/tests_disabled_tcpseg.json
@@ -198,10 +198,6 @@
             "reason": "Disabled by issue #450"
         },
         {
-            "name": "http2_general.test_h2_headers.TestConnectionHeaders",
-            "reason": "Disabled by issue #450"
-        },
-        {
             "name": "http2_general.test_h2_headers.HeadersParsing",
             "reason": "Disabled by issue #450"
         },


### PR DESCRIPTION
If Tempesta FW receives request with a several big headers, Tempesta FW allocates new page from pool. This test checks it.