### PR TITLE
feat: Add test verifies correctness of frang limits

### DIFF
--- a/tests_disabled_remote.json
+++ b/tests_disabled_remote.json
@@ -129,6 +129,10 @@
             "name": "t_frang.test_concurrent_connections.ConcurrentConnections.test_three_clients_same_ip",
             "reason": "Disabled by test issue #529."
         },
+	{
+            "name": "t_frang.test_concurrent_connections.TestConcurrentConnectionsNonTempesta",
+            "reason": "Is not intended to run on remote setup. Local only."
+        },
         {
             "name": "very_many_backends.test_deadtime_1M",
             "reason": "Disabled by test issue #56."

--- a/tests_disabled_tcpseg.json
+++ b/tests_disabled_tcpseg.json
@@ -302,6 +302,10 @@
             "reason": "These tests should not be run with TCP segmentation."
         },
 	{
+            "name": "t_frang.test_concurrent_connections.TestConcurrentConnectionsNonTempesta",
+            "reason": "Is not intended to run with segmentation."
+        },
+	{
             "name": "t_stress.test_stress.TestRequestsUnderCtrlFrameFlood",
             "reason": "Disabled by test issue #817"
         },
@@ -320,6 +324,6 @@
         {
             "name": "t_stress.test_stress.WrkStressMTU80",
             "reason": "Disabled by test issue #817"
-        }
+	}
     ]
 }


### PR DESCRIPTION
Add test that verifies Tempesta applies frang limits only to socket listining by it.