### PR TITLE
Disable unstable tests

### DIFF
--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -324,6 +324,14 @@
         {
             "name": "t_stress.test_clickhouse",
             "reason": "Disabled by test issue #778"
+        },
+	{
+            "name": "t_stress.test_stress.TestRequestsUnderCtrlFrameFlood",
+            "reason": "Disabled by test issue #817"
+        },
+	{
+            "name": "t_stress.test_stress.TestContinuationFlood",
+            "reason": "Disabled by test issue #817"
         }
     ]
 }

--- a/tests_disabled_remote.json
+++ b/tests_disabled_remote.json
@@ -136,6 +136,14 @@
         {
             "name" : "t_stress.test_stress.TlsWrkStressDocker",
             "reason" : "Disabled by issue #2266"
+        },
+	{
+            "name": "t_stress.test_stress.TestRequestsUnderCtrlFrameFlood",
+            "reason": "Disabled by test issue #817"
+        },
+	{
+            "name": "t_stress.test_stress.TestContinuationFlood",
+            "reason": "Disabled by test issue #817"
         }
     ]
 }

--- a/tests_disabled_tcpseg.json
+++ b/tests_disabled_tcpseg.json
@@ -300,6 +300,14 @@
         {
             "name": "http_general.test_expect_100_continue.TestExpect100ContinueBehavior.test_request_pipeline_3_requests_encoding_chunked",
             "reason": "These tests should not be run with TCP segmentation."
+        },
+	{
+            "name": "t_stress.test_stress.TestRequestsUnderCtrlFrameFlood",
+            "reason": "Disabled by test issue #817"
+        },
+	{
+            "name": "t_stress.test_stress.TestContinuationFlood",
+            "reason": "Disabled by test issue #817"
         }
     ]
 }


### PR DESCRIPTION
After upgrading CI we got unstable tests, disable them while finding out the reasons.