### PR TITLE
Add functional test for HTTP/2 method support

### DIFF
--- a/http2_general/test_h2_supported_methods.py
+++ b/http2_general/test_h2_supported_methods.py
@@ -1,0 +1,70 @@
+from test_suite import tester
+
+
+class TestHttp2Methods(tester.TempestaTest):
+    backends = [
+        {
+            "id": "deproxy",
+            "type": "deproxy",
+            "port": "8000",
+            "response": "static",
+            "response_content": (
+                "HTTP/1.1 200 OK\r\n"
+                "Content-Length: 0\r\n"
+                "Connection: close\r\n"
+                "\r\n"
+            ),
+        },
+    ]
+
+    clients = [
+        {
+            "id": "deproxy-h2",
+            "type": "deproxy-h2",
+            "addr": "${tempesta_ip}",
+            "port": "443",
+        },
+    ]
+
+    tempesta = {
+        "config": (
+            "listen 443 proto=h2;\n"
+            "tls none;\n"
+            "server ${server_ip}:8000;\n"
+            "frang_limits {\n"
+            "    http_methods GET HEAD POST PUT DELETE OPTIONS PATCH "
+            "PROPFIND PROPPATCH MKCOL COPY MOVE LOCK UNLOCK TRACE;\n"
+            "}\n"
+        )
+    }
+
+    def _test_method(self, method):
+        self.start_all_services(client=False)
+
+        client = self.get_client("deproxy-h2")
+        client.start()
+
+        print(f"Sending method: {method} via HTTP/2")
+        client.send_request(
+            request=client.create_request(
+                method=method,
+                uri="/test_method",
+                headers=[
+                    ("Content-Length", "0"),
+                    ("Content-Type", "application/json"),
+                ],
+            ),
+            expected_status_code="200",
+        )
+
+    def test_common_methods(self):
+        for method in ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH"]:
+            self._test_method(method)
+
+    def test_extended_methods(self):
+        for method in [
+            "PROPFIND", "PROPPATCH", "MKCOL", "COPY", "MOVE",
+            "LOCK", "UNLOCK", "TRACE"
+        ]:
+            self._test_method(method)
+


### PR DESCRIPTION
This test verifies that Tempesta correctly parses and handles various HTTP methods over HTTP/2,
as implemented in `tfw_http_meth_str2id()` and fixed in issue #2436.

It covers both standard and extended methods:
- Standard: GET, POST, PUT, DELETE, HEAD, OPTIONS, PATCH
- Extended (WebDAV, etc.): PROPFIND, PROPPATCH, MKCOL, COPY, MOVE, LOCK, UNLOCK, TRACE

The test uses `deproxy-h2` client to send HTTP/2 requests to Tempesta with each method.
Backend always returns 200 OK. The test passes if each method is correctly accepted
and proxied through Tempesta.

Related to: #2436