### PR TITLE
Implement tests to check WARNING in Tempesta

### DIFF
--- a/http_general/test_headers.py
+++ b/http_general/test_headers.py
@@ -932,6 +932,16 @@ class TestHostWithCache(TestHostBase):
                 request=f"GET http:///path HTTP/1.1\r\nHost: \r\n\r\n",
                 expected_status_code="400",
             ),
+            marks.Param(
+                name="14",
+                request=f"GET http://localhost:443 HTTP/1.1\r\nHost: localhost\r\n\r\n",
+                expected_status_code="200",
+            ),
+            marks.Param(
+                name="15",
+                request=f"GET http://localhost HTTP/1.1\r\nHost: localhost\r\n\r\n",
+                expected_status_code="200",
+            ),
         ]
     )
     def test_different_host_in_uri_and_headers(self, name, request, expected_status_code):


### PR DESCRIPTION
Kernel warning occurs when Tempesta FW handles request with empty uri (if cache is enabled in Tempesta FW config). Add several tests to check this problem.