### PR TITLE
rework start and stop method in lxc_server.py

### DIFF
--- a/helpers/tf_cfg.py
+++ b/helpers/tf_cfg.py
@@ -174,6 +174,7 @@ class TestFrameworkCfg:
                     "lxc_container_name": "tempesta-site-stage",
                     "website_user": os.getenv("WEBSITE_USER", ""),
                     "website_password": os.getenv("WEBSITE_PASSWORD", ""),
+                    "website_port": "7000",
                 },
                 "TFW_Logger": {
                     "clickhouse_host": "127.0.0.1",

--- a/selftests/test_lxc_server.py
+++ b/selftests/test_lxc_server.py
@@ -1,6 +1,5 @@
 """Tests for `framework.lxc_server.LXCServer`."""
 
-from helpers import remote
 from test_suite import tester
 
 
@@ -8,11 +7,11 @@ class TestLxcServer(tester.TempestaTest):
     tempesta = {
         "config": """
         listen 80 proto=http;
-        server ${server_ip}:8000;
+        server ${server_ip}:${server_website_port};
         """
     }
 
-    backends = [{"id": "lxc", "type": "lxc", "external_port": "8000", "make_snapshot": False}]
+    backends = [{"id": "lxc", "type": "lxc"}]
 
     clients = [
         {
@@ -38,21 +37,14 @@ class TestLxcServer(tester.TempestaTest):
     def test_wait_for_connections_negative(self):
         """
         `wait_for_connections` method MUST return False
-        if Tempesta and server has different connection ports.
+        if Tempesta doesn't create connection to lxc ports.
         """
         server = self.get_server("lxc")
-        server.external_port = "19000"
 
         server.start()
-        self.start_tempesta()
         self.assertFalse(server.wait_for_connections(1))
 
     def test_status(self):
         """`server.status` MUST return a correct container status."""
         server = self.get_server("lxc")
-        self.assertEqual(server.status, "stopped")
-
-        server.start()
-        self.start_tempesta()
-        self.assertTrue(server.wait_for_connections(3))
         self.assertEqual(server.status, "running")

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,17 @@
+#!/usr/bin/env python3
+
+__author__ = "Tempesta Technologies, Inc."
+__copyright__ = "Copyright (C) 2025 Tempesta Technologies, Inc."
+__license__ = "GPL2"
+
 import logging
 import os
 import shutil
 import subprocess
 from pathlib import Path
 from typing import Optional
+
+from helpers.tf_cfg import cfg
 
 RED = "\033[91m"
 GREEN = "\033[92m"
@@ -205,8 +213,11 @@ def main():
 
     # create tempesta-site-stage container
     try:
-        shell("env/bin/python3 tempesta-tech.com/container/lxc/create.py --type=stage")
-        shell("sudo lxc stop tempesta-site-stage")
+        shell(
+            "env/bin/python3 tempesta-tech.com/container/lxc/create.py "
+            "--type=stage "
+            f"--proxy=0.0.0.0:{cfg.get('Server', 'website_port')}"
+        )
     except RuntimeError:
         pass
 

--- a/t_sites/test_tempesta_tech.py
+++ b/t_sites/test_tempesta_tech.py
@@ -1,7 +1,7 @@
 """The basic tests for tempesta-tech.com with TempestaFW."""
 
 __author__ = "Tempesta Technologies, Inc."
-__copyright__ = "Copyright (C) 2024 Tempesta Technologies, Inc."
+__copyright__ = "Copyright (C) 2024-2025 Tempesta Technologies, Inc."
 __license__ = "GPL2"
 
 import json
@@ -14,9 +14,7 @@ from test_suite.mixins import NetfilterMarkMixin
 
 
 class TestTempestaTechSite(NetfilterMarkMixin, tester.TempestaTest):
-    backends = [
-        {"id": "tempesta_tech_site", "type": "lxc", "external_port": "8000"},
-    ]
+    backends = [{"id": "tempesta_tech_site", "type": "lxc"}]
 
     clients = [
         {
@@ -130,7 +128,7 @@ class TestTempestaTechSite(NetfilterMarkMixin, tester.TempestaTest):
             tls_match_any_server_name;
 
             srv_group default {
-                    server ${server_ip}:8000;
+                    server ${server_ip}:${server_website_port};
 
             }
             vhost default {

--- a/t_stress/test_ddos.py
+++ b/t_stress/test_ddos.py
@@ -1,5 +1,5 @@
 __author__ = "Tempesta Technologies, Inc."
-__copyright__ = "Copyright (C) 2024 Tempesta Technologies, Inc."
+__copyright__ = "Copyright (C) 2024-2025 Tempesta Technologies, Inc."
 __license__ = "GPL2"
 
 import os
@@ -93,7 +93,7 @@ tls_certificate ${{tempesta_workdir}}/tempesta.crt;
 tls_certificate_key ${{tempesta_workdir}}/tempesta.key;
 tls_match_any_server_name;
 
-srv_group main {{server ${{server_ip}}:8000 conns_n=128;}}
+srv_group main {{server ${{server_ip}}:${{server_website_port}} conns_n=128;}}
 
 vhost tempesta-tech.com {{proxy_pass main;}}
 
@@ -123,7 +123,7 @@ http_chain {{
 """
     }
 
-    backends = [{"id": "wordpress", "type": "lxc", "external_port": "8000"}]
+    backends = [{"id": "wordpress", "type": "lxc"}]
 
     proxies = []
 

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -264,6 +264,10 @@
         {
             "name": "t_stress.test_stress.WrkStressMTU80",
             "reason": "Disabled by test issue #817"
+        },
+        {
+            "name": "t_sites.test_tempesta_tech.TestTempestaTechSite.test_blog_post_flow",
+            "reason": "Disabled by test issue #835"
         }
     ]
 }


### PR DESCRIPTION
- remove the starting and stopping lxc container, because it's require a lot of resources and time;
- now lxc container must be run first;
- rework setup.py for that (now lxc container uses 7000 port);

related to [PR49](https://github.com/tempesta-tech/tempesta-ci/pull/49)