### PR TITLE
Fix and exbale some control frame flood tests.

### DIFF
--- a/t_stress/test_stress.py
+++ b/t_stress/test_stress.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from helpers import dmesg, remote, tf_cfg
 from helpers.networker import NetWorker
 from test_suite import marks, tester
+from t_frang.frang_test_case import FrangTestCase
 
 __author__ = "Tempesta Technologies, Inc."
 __copyright__ = "Copyright (C) 2022-2026 Tempesta Technologies, Inc."
@@ -1046,7 +1047,7 @@ class TestContinuationFlood(tester.TempestaTest):
         self.assertEqual(0, client.returncode)
 
 
-class TestRequestsUnderCtrlFrameFlood(tester.TempestaTest):
+class TestRequestsUnderCtrlFrameFlood(FrangTestCase):
     """
     Test ability to handle requests from the client
     under control frames frame flood.
@@ -1069,6 +1070,10 @@ class TestRequestsUnderCtrlFrameFlood(tester.TempestaTest):
         listen 443 proto=h2;
 
         server ${server_ip}:8000;
+
+        frang_limits {
+            ctrl_frame_rate 1000;
+        }
 
         tls_certificate ${tempesta_workdir}/tempesta.crt;
         tls_certificate_key ${tempesta_workdir}/tempesta.key;
@@ -1094,50 +1099,8 @@ class TestRequestsUnderCtrlFrameFlood(tester.TempestaTest):
         },
     ]
 
-    stop_flag = False
-
-    def setUp(self):
-        self.enable_memleak_check()
-        super().setUp()
-
-    @marks.Parameterize.expand(
-        [
-            marks.Param(
-                name="PingFlood",
-                cmd_args=f"-address %s:443 -threads 4 -connections 100 -debug 1 -ctrl_frame_type ping_frame -frame_count 100000",
-                timeout=120,
-            ),
-            marks.Param(
-                name="SettingsFlood",
-                cmd_args=f"-address %s:443 -threads 4 -connections 100 -debug 1 -ctrl_frame_type settings_frame -frame_count 100000",
-                timeout=120,
-            ),
-            marks.Param(
-                name="WndUpdateFlood",
-                cmd_args=f"-address %s:443 -threads 4 -connections 100 -debug 1 -ctrl_frame_type window_update -frame_count 100000",
-                timeout=120,
-            ),
-            marks.Param(
-                name="RstFloodByHeaders",
-                cmd_args=f"-address %s:443 -threads 4 -connections 100 -debug 1 -ctrl_frame_type rst_stream_frame -rst_reason_type headers -frame_count 100000",
-                timeout=120,
-            ),
-            marks.Param(
-                name="RstFloodByWndUpdate",
-                cmd_args=f"-address %s:443 -threads 4 -connections 100 -debug 1 -ctrl_frame_type rst_stream_frame -rst_reason_type window_update -frame_count 100000",
-                timeout=120,
-            ),
-            marks.Param(
-                name="RstFloodByPriority",
-                cmd_args=f"-address %s:443 -threads 4 -connections 100 -debug 1 -ctrl_frame_type rst_stream_frame -rst_reason_type priority -frame_count 100000",
-                timeout=240,
-            ),
-        ]
-    )
-    @dmesg.limited_rate_on_tempesta_node
-    def test(self, name, cmd_args, timeout):
+    def _test(self, cmd_args):
         self.start_all_services(client=False)
-        tempesta = self.get_tempesta()
 
         client = self.get_client("deproxy")
         client.start()
@@ -1148,22 +1111,41 @@ class TestRequestsUnderCtrlFrameFlood(tester.TempestaTest):
         flood_client.options = [cmd_args % tf_cfg.cfg.get("Tempesta", "ip")]
         flood_client.start()
 
-        # TODO Currently this part is not stable. Wait until #1346 in Tempesta
-        # will be implemented.
-        # for _ in range(1, 20):
-        # client.send_request(request, "200")
-
-        self.wait_while_busy(flood_client, timeout=timeout)
+        self.wait_while_busy(flood_client)
         flood_client.stop()
 
-        tempesta.get_stats()
-        """
-        For remote setup we can't be sure that load is enough for overload
-        Tempesta FW wq, so we check that at least all connections were
-        established.
-        """
-        self.assertTrue(
-            tempesta.stats.wq_full > 0 or tempesta.stats.cl_established_connections == 101
+    @marks.Parameterize.expand(
+        [
+            marks.Param(
+                name="PingFlood",
+                cmd_args=f"-address %s:443 -threads 4 -connections 100 -ctrl_frame_type ping_frame -frame_count 100000",
+            ),
+            marks.Param(
+                name="SettingsFlood",
+                cmd_args=f"-address %s:443 -threads 4 -connections 100 -ctrl_frame_type settings_frame -frame_count 100000",
+            ),
+            marks.Param(
+                name="WndUpdateFlood",
+                cmd_args=f"-address %s:443 -threads 4 -connections 100 -ctrl_frame_type window_update -frame_count 100000",
+            ),
+            marks.Param(
+                name="RstFloodByWndUpdate",
+                cmd_args=f"-address %s:443 -threads 4 -connections 100 -ctrl_frame_type rst_stream_frame -rst_reason_type window_update -frame_count 100000",
+            ),
+            marks.Param(
+                name="RstFloodByPriority",
+                cmd_args=f"-address %s:443 -threads 4 -connections 100 -ctrl_frame_type rst_stream_frame -rst_reason_type priority -frame_count 100000",
+            ),
+        ]
+    )
+    @dmesg.unlimited_rate_on_tempesta_node
+    def test(self, name, cmd_args):
+        self._test(cmd_args)
+        self.assertFrangWarning("Warning: frang: control frames rate exceeded", 100)
+
+    def test_RstFloodByHeaders(self):
+        self._test(
+            "-address %s:443 -threads 4 -connections 100 -debug 1 -ctrl_frame_type rst_stream_frame -rst_reason_type headers -frame_count 100000"
         )
 
 

--- a/t_stress/test_stress.py
+++ b/t_stress/test_stress.py
@@ -8,8 +8,8 @@ from pathlib import Path
 
 from helpers import dmesg, remote, tf_cfg
 from helpers.networker import NetWorker
-from test_suite import marks, tester
 from t_frang.frang_test_case import FrangTestCase
+from test_suite import marks, tester
 
 __author__ = "Tempesta Technologies, Inc."
 __copyright__ = "Copyright (C) 2022-2026 Tempesta Technologies, Inc."
@@ -1130,11 +1130,23 @@ class TestRequestsUnderCtrlFrameFlood(FrangTestCase):
             ),
             marks.Param(
                 name="RstFloodByWndUpdate",
-                cmd_args=f"-address %s:443 -threads 4 -connections 100 -ctrl_frame_type rst_stream_frame -rst_reason_type window_update -frame_count 100000",
+                cmd_args=f"-address %s:443 -threads 4 -connections 100 -ctrl_frame_type rapid_reset -rapid_reset_type window_update -frame_count 100000",
             ),
             marks.Param(
                 name="RstFloodByPriority",
-                cmd_args=f"-address %s:443 -threads 4 -connections 100 -ctrl_frame_type rst_stream_frame -rst_reason_type priority -frame_count 100000",
+                cmd_args=f"-address %s:443 -threads 4 -connections 100 -ctrl_frame_type rapid_reset -rapid_reset_type priority -frame_count 100000",
+            ),
+            marks.Param(
+                name="RstFloodByRst",
+                cmd_args=f"-address %s:443 -threads 4 -connections 100 -ctrl_frame_type rapid_reset -rapid_reset_type rst -frame_count 100000",
+            ),
+            marks.Param(
+                name="RstFloodByRstBatch",
+                cmd_args=f"-address %s:443 -threads 4 -connections 100 -ctrl_frame_type rapid_reset -rapid_reset_type batch -frame_count 100000",
+            ),
+            marks.Param(
+                name="RstFloodByHeaders",
+                cmd_args=f"-address %s:443 -threads 4 -connections 100 -ctrl_frame_type rapid_reset -rapid_reset_type headers -frame_count 100000",
             ),
         ]
     )
@@ -1142,11 +1154,6 @@ class TestRequestsUnderCtrlFrameFlood(FrangTestCase):
     def test(self, name, cmd_args):
         self._test(cmd_args)
         self.assertFrangWarning("Warning: frang: control frames rate exceeded", 100)
-
-    def test_RstFloodByHeaders(self):
-        self._test(
-            "-address %s:443 -threads 4 -connections 100 -debug 1 -ctrl_frame_type rst_stream_frame -rst_reason_type headers -frame_count 100000"
-        )
 
 
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -245,11 +245,7 @@
             "name": "t_stress.test_clickhouse",
             "reason": "Disabled by test issue #778"
         },
-	{
-            "name": "t_stress.test_stress.TestRequestsUnderCtrlFrameFlood",
-            "reason": "Disabled by test issue #817"
-        },
-	{
+        {
             "name": "t_stress.test_stress.TestContinuationFlood",
             "reason": "Disabled by test issue #817"
         },

--- a/tests_disabled_remote.json
+++ b/tests_disabled_remote.json
@@ -105,17 +105,13 @@
             "name": "t_frang.test_concurrent_connections.ConcurrentConnections.test_three_clients_same_ip",
             "reason": "Disabled by test issue #529."
         },
-	{
+        {
             "name": "t_frang.test_concurrent_connections.TestConcurrentConnectionsNonTempesta",
             "reason": "Is not intended to run on remote setup. Local only."
         },
         {
             "name": "very_many_backends.test_deadtime_1M",
             "reason": "Disabled by test issue #56."
-        },
-	    {
-            "name": "t_stress.test_stress.TestRequestsUnderCtrlFrameFlood",
-            "reason": "Disabled by test issue #817"
         },
 	    {
             "name": "t_stress.test_stress.TestContinuationFlood",

--- a/tests_disabled_tcpseg.json
+++ b/tests_disabled_tcpseg.json
@@ -265,15 +265,11 @@
             "name": "http_general.test_expect_100_continue.TestExpect100ContinueBehavior.test_request_pipeline_3_requests_encoding_chunked",
             "reason": "These tests should not be run with TCP segmentation."
         },
-	{
+        {
             "name": "t_frang.test_concurrent_connections.TestConcurrentConnectionsNonTempesta",
             "reason": "Is not intended to run with segmentation."
         },
-	{
-            "name": "t_stress.test_stress.TestRequestsUnderCtrlFrameFlood",
-            "reason": "Disabled by test issue #817"
-        },
-	{
+        {
             "name": "t_stress.test_stress.TestContinuationFlood",
             "reason": "Disabled by test issue #817"
         },
@@ -288,6 +284,6 @@
         {
             "name": "t_stress.test_stress.WrkStressMTU80",
             "reason": "Disabled by test issue #817"
-	}
+        }
     ]
 }


### PR DESCRIPTION
Since control frames rate limit was implemented in Tempesta FW, we rework control frame flood tests:
- now we expected that all conntections will be closed and frang message will be present in dmesg.
- remove `enable_memleak_check` because it is not work correctly.