### PR TITLE
Use ssh authorization for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tempesta-tech.com"]
 	path = tempesta-tech.com
-	url = https://github.com/tempesta-tech/tempesta-tech.com.git
+	url = git@github.com:tempesta-tech/tempesta-tech.com.git


### PR DESCRIPTION
Currently, HTTPS is used for the tempesta-tech.com submodule, but since it is a private repository, users need an access token to clone the repository. It is easier to rely on SSH authorization than to provide an access token to every user.