### PR TITLE
2466: Add ability to specify clickhouse database name in TFW_Logger c…

### DIFF
--- a/helpers/clickhouse.py
+++ b/helpers/clickhouse.py
@@ -19,6 +19,7 @@ try:
     _connection: Client = clickhouse_connect.get_client(
         host=tf_cfg.cfg.get("TFW_Logger", "ip"),
         port=int(tf_cfg.cfg.get("TFW_Logger", "clickhouse_port")),
+        database=tf_cfg.cfg.get("TFW_Logger", "clickhouse_database"),
         username=tf_cfg.cfg.get("TFW_Logger", "clickhouse_username"),
         password=tf_cfg.cfg.get("TFW_Logger", "clickhouse_password"),
     )

--- a/helpers/tempesta.py
+++ b/helpers/tempesta.py
@@ -231,8 +231,12 @@ class TfwLogger(object):
     max_events: int = 1000
     max_wait_ms: int = 100
 
-    # table and log_path must not change in tests. These are global tests variables,
+    # database, table and log_path must not change in tests. These are global tests variables,
     # and they must be changed in the main configuration
+
+    @property
+    def database(self) -> str:
+        return tf_cfg.cfg.get("TFW_Logger", "clickhouse_database")
 
     @property
     def table(self) -> str:
@@ -279,8 +283,9 @@ class Config(object):
                     "port": self._logger_config.port,
                     "user": self._logger_config.user,
                     "password": self._logger_config.password,
+                    "db_name": self._logger_config.database,
                     "table_name": self._logger_config.table,
-                    "max_ecents": self._logger_config.max_events,
+                    "max_events": self._logger_config.max_events,
                     "max_wait_ms": self._logger_config.max_wait_ms,
                 },
             }

--- a/helpers/tf_cfg.py
+++ b/helpers/tf_cfg.py
@@ -179,6 +179,7 @@ class TestFrameworkCfg:
                     "clickhouse_port": "8123",
                     "clickhouse_username": "default",
                     "clickhouse_password": "",
+                    "clickhouse_database": os.getenv("CLICKHOUSE_DATABASE", "default"),
                     "clickhouse_table": os.getenv("CLICKHOUSE_TABLE", "access_log"),
                     "log_path": "/tmp/tfw_logger.log",
                     "logger_config": "/tmp/tfw_logger.json",

--- a/tests_config.ini.sample
+++ b/tests_config.ini.sample
@@ -332,6 +332,12 @@ clickhouse_password =
 #
 clickhouse_database = default
 
+# The table name in the Clickhouse Database
+#
+# ex.: clickhouse_table = my_table (default access_log)
+#
+clickhouse_table = access_log
+
 # The TFW Logger daemon log file path.
 #
 # ex.: daemon_log = /var/log/tfw_logger.log (default /tmp/tfw_logger.log)


### PR DESCRIPTION
…onfig

A new key was added to the "TFW_Logger" section of the config file: "clickhouse_database." This database name is used for configuring the logger and acquiring the collected data.