### PR TITLE
Enable t_clickhouse.test_clickhouse_logs.TestClickhouseLogTiming tests

### DIFF
--- a/helpers/control.py
+++ b/helpers/control.py
@@ -327,7 +327,6 @@ class Tempesta(stateful.Stateful):
             if not self.clickhouse.find("worker threads started"):
                 return True
 
-            time.sleep(1)
             return False
 
         return wait_until(wait_cond=wait, timeout=timeout, poll_freq=0.1)

--- a/tests_disabled.json
+++ b/tests_disabled.json
@@ -252,10 +252,6 @@
         {
             "name": "t_sites.test_tempesta_tech.TestTempestaTechSite.test_blog_post_flow",
             "reason": "Disabled by test issue #835"
-        },
-        {
-            "name": "t_clickhouse.test_clickhouse_logs.TestClickhouseLogTiming",
-            "reason": "Disabled by issue #2314"
         }
     ]
 }


### PR DESCRIPTION
Remove unnecessary 1sec wait for tfw_logger to start.