### PR TITLE
fix unstable tests

### DIFF
--- a/helpers/tf_cfg.py
+++ b/helpers/tf_cfg.py
@@ -116,7 +116,7 @@ class TestFrameworkCfg:
                     "stress_requests_count": "100",
                     "stress_mtu": "1500",
                     "long_body_size": "500",
-                    "memory_leak_threshold": "65536",
+                    "memory_leak_threshold": "131072",
                     "unavailable_timeout": "300",
                 },
                 "Loggers": {

--- a/run_tests.py
+++ b/run_tests.py
@@ -128,30 +128,30 @@ def test_from_failstr(failstr):
 
 def __check_memory_consumption(python_memory_before_: int, used_memory_before_: int) -> None:
     """Check a memory consumption after all tests."""
-    if run_config.CHECK_MEMORY_LEAKS:
-        gc.collect()
-        time.sleep(1)
-        python_memory_after = psutil.Process().memory_info().rss // 1024
-        delta_python = python_memory_after - python_memory_before_
+    gc.collect()
+    time.sleep(1)
+    python_memory_after = psutil.Process().memory_info().rss // 1024
+    delta_python = python_memory_after - python_memory_before_
 
-        used_memory_after = util.get_used_memory()
-        memleak_msg = (
-            "----------------------------------------------------------------------------\n"
-            "Check memory leaks for test suite:\n"
-            f"Before: used memory: {used_memory_before_};\n"
-            f"Before: python memory: {python_memory_before_};\n"
-            f"After: used memory: {used_memory_after};\n"
-            f"After: python memory: {python_memory_after};\n"
-            "----------------------------------------------------------------------------"
+    used_memory_after = util.get_used_memory()
+    delta_used_memory = used_memory_after - delta_python - used_memory_before_
+    memleak_msg = (
+        "----------------------------------------------------------------------------\n"
+        "Check memory leaks for test suite:\n"
+        f"Before: used memory: {used_memory_before_};\n"
+        f"Before: python memory: {python_memory_before_};\n"
+        f"After: used memory: {used_memory_after};\n"
+        f"After: python memory: {python_memory_after};\n"
+        f"Delta: {delta_used_memory} KB\n"
+        "----------------------------------------------------------------------------"
+    )
+    test_logger.critical(memleak_msg)
+    if run_config.CHECK_MEMORY_LEAKS and delta_used_memory >= run_config.MEMORY_LEAK_THRESHOLD:
+        raise error.MemoryConsumptionException(
+            memleak_msg,
+            delta_used_memory=delta_used_memory,
+            memory_leak_threshold=run_config.MEMORY_LEAK_THRESHOLD,
         )
-        test_logger.critical(memleak_msg)
-        delta_used_memory = used_memory_after - delta_python - used_memory_before_
-        if delta_used_memory >= run_config.MEMORY_LEAK_THRESHOLD:
-            raise error.MemoryConsumptionException(
-                memleak_msg,
-                delta_used_memory=delta_used_memory,
-                memory_leak_threshold=run_config.MEMORY_LEAK_THRESHOLD,
-            )
 
 
 def __check_kmemleak() -> None:

--- a/tls/test_tls_handshake.py
+++ b/tls/test_tls_handshake.py
@@ -486,8 +486,8 @@ class TlsVhostHandshakeTest(tester.TempestaTest):
         if not sniffer.packets:
             raise error.TestConditionsAreNotCompleted(self.id())
 
-        self.assertEqual(
-            sniffer.packets[-1].sprintf("%TCP.flags%"), "RA", "No Connection reset recieved"
+        self.assertIn(
+            sniffer.packets[-1].sprintf("%TCP.flags%"), ["R", "RA"], "No Connection reset recieved"
         )
 
 


### PR DESCRIPTION
- now `test_bad_host` except `RST+ACK` or only `RST` flags. Sometimes these flags come in separate packages;
- rework `leaks` tests. Now they use MEMORY_LEAK_THRESHOLD variable like for other checks;
- add memory consumption output after all tests (without `check-memory-leaks` flag) and increase MEMORY_LEAK_THRESHOLD (6.12.12 kernel require more memory for these tests);