### PR TITLE
Implement new error injection tests.

### DIFF
--- a/t_fault_injection/test_fault_injection_base.py
+++ b/t_fault_injection/test_fault_injection_base.py
@@ -70,7 +70,7 @@ class TestFailFunctionBase(tester.TempestaTest):
     }
 
     @staticmethod
-    def setup_fail_function_test(func_name, times, retval):
+    def setup_fail_function_test(func_name, times, space, retval):
         # Write function name to special debug fs file.
         cmd = f"echo {func_name} > /sys/kernel/debug/fail_function/inject"
         out = remote.client.run_cmd(cmd)
@@ -91,6 +91,10 @@ class TestFailFunctionBase(tester.TempestaTest):
         # A value of -1 means “no limit”.
         cmd = f"echo {times} > /sys/kernel/debug/fail_function/times"
         out = remote.client.run_cmd(cmd)
+        # Specifies how many times function is called without failuers.
+        # A value of 0 means "immediately".
+        cmd = f"echo {space} > /sys/kernel/debug/fail_function/space"
+        cmd = remote.client.run_cmd(cmd)
 
     @staticmethod
     def teardown_fail_function_test():
@@ -100,6 +104,9 @@ class TestFailFunctionBase(tester.TempestaTest):
         # Restore times
         cmd = f"echo -1 > /sys/kernel/debug/fail_function/times"
         out = remote.client.run_cmd(cmd)
+        # Restore space
+        cmd = f"echo 0 > /sys/kernel/debug/fail_function/space"
+        cmd = remote.client.run_cmd(cmd)
 
 
 class TestFailFunction(TestFailFunctionBase, NetWorker):
@@ -115,6 +122,7 @@ class TestFailFunction(TestFailFunctionBase, NetWorker):
                 id="deproxy",
                 msg="can't allocate a new client connection",
                 times=-1,
+                space=0,
                 response=deproxy.Response.create_simple_response(
                     status="200",
                     headers=[("content-length", "0")],
@@ -128,6 +136,7 @@ class TestFailFunction(TestFailFunctionBase, NetWorker):
                 id="deproxy",
                 msg="can't obtain a client for frang accounting",
                 times=-1,
+                space=0,
                 response=deproxy.Response.create_simple_response(
                     status="200",
                     headers=[("content-length", "0")],
@@ -141,6 +150,7 @@ class TestFailFunction(TestFailFunctionBase, NetWorker):
                 id="deproxy_h2",
                 msg="cannot establish a new h2 connection",
                 times=-1,
+                space=0,
                 response=deproxy.Response.create_simple_response(
                     status="200",
                     headers=[("content-length", "0")],
@@ -154,6 +164,7 @@ class TestFailFunction(TestFailFunctionBase, NetWorker):
                 id="deproxy_h2",
                 msg="tfw_tls_encrypt: cannot encrypt data",
                 times=1,
+                space=0,
                 response=deproxy.Response.create_simple_response(
                     status="200",
                     headers=[("content-length", "0")],
@@ -167,6 +178,7 @@ class TestFailFunction(TestFailFunctionBase, NetWorker):
                 id="deproxy_h2",
                 msg="tfw_tls_encrypt: cannot encrypt data",
                 times=1,
+                space=0,
                 response=deproxy.Response.create_simple_response(
                     status="200",
                     headers=[("content-length", "0")],
@@ -180,6 +192,7 @@ class TestFailFunction(TestFailFunctionBase, NetWorker):
                 id="deproxy_h2",
                 msg=None,
                 times=1,
+                space=0,
                 response=deproxy.Response.create_simple_response(
                     status="200",
                     headers=[("content-length", "0")],
@@ -193,6 +206,7 @@ class TestFailFunction(TestFailFunctionBase, NetWorker):
                 id="deproxy_h2",
                 msg=None,
                 times=1,
+                space=0,
                 response=deproxy.Response.create_simple_response(
                     status="200",
                     headers=[("content-length", "0")],
@@ -206,6 +220,7 @@ class TestFailFunction(TestFailFunctionBase, NetWorker):
                 id="deproxy_ssl",
                 msg=None,
                 times=1,
+                space=0,
                 response=deproxy.Response.create_simple_response(
                     status="200",
                     headers=[("content-length", "0")],
@@ -219,6 +234,7 @@ class TestFailFunction(TestFailFunctionBase, NetWorker):
                 id="deproxy_h2",
                 msg=None,
                 times=1,
+                space=0,
                 response=deproxy.Response.create_simple_response(
                     status="200",
                     headers=[("content-length", "0")],
@@ -232,6 +248,7 @@ class TestFailFunction(TestFailFunctionBase, NetWorker):
                 id="deproxy_ssl",
                 msg="Cannot setup hash ctx",
                 times=1,
+                space=0,
                 response=deproxy.Response.create_simple_response(
                     status="200",
                     headers=[("content-length", "0")],
@@ -245,6 +262,7 @@ class TestFailFunction(TestFailFunctionBase, NetWorker):
                 id="deproxy_h2",
                 msg="Cannot setup hash ctx",
                 times=1,
+                space=0,
                 response=deproxy.Response.create_simple_response(
                     status="200",
                     headers=[("content-length", "0")],
@@ -252,11 +270,101 @@ class TestFailFunction(TestFailFunctionBase, NetWorker):
                 ),
                 retval=-12,
             ),
+            marks.Param(
+                name="ss_skb_realloc_headroom_1",
+                func_name="ss_skb_realloc_headroom",
+                id="deproxy",
+                msg=None,
+                times=1,
+                space=4,
+                response=deproxy.Response.create_simple_response(
+                    status="200",
+                    headers=[("qwerty", "x" * 50000), ("content-length", "200000")],
+                    date=deproxy.HttpMessage.date_time_string(),
+                    body="y" * 200000,
+                ),
+                retval=-12,
+            ),
+            marks.Param(
+                name="ss_skb_realloc_headroom_2",
+                func_name="ss_skb_realloc_headroom",
+                id="deproxy",
+                msg=None,
+                times=1,
+                space=7,
+                response=deproxy.Response.create_simple_response(
+                    status="200",
+                    headers=[("qwerty", "x" * 50000), ("content-length", "200000")],
+                    date=deproxy.HttpMessage.date_time_string(),
+                    body="y" * 200000,
+                ),
+                retval=-12,
+            ),
+            marks.Param(
+                name="ss_skb_realloc_headroom_ssl_1",
+                func_name="ss_skb_realloc_headroom",
+                id="deproxy_ssl",
+                msg=None,
+                times=1,
+                space=4,
+                response=deproxy.Response.create_simple_response(
+                    status="200",
+                    headers=[("qwerty", "x" * 50000), ("content-length", "200000")],
+                    date=deproxy.HttpMessage.date_time_string(),
+                    body="y" * 200000,
+                ),
+                retval=-12,
+            ),
+            marks.Param(
+                name="ss_skb_realloc_headroom_ssl_2",
+                func_name="ss_skb_realloc_headroom",
+                id="deproxy_ssl",
+                msg=None,
+                times=1,
+                space=7,
+                response=deproxy.Response.create_simple_response(
+                    status="200",
+                    headers=[("qwerty", "x" * 50000), ("content-length", "200000")],
+                    date=deproxy.HttpMessage.date_time_string(),
+                    body="y" * 200000,
+                ),
+                retval=-12,
+            ),
+            marks.Param(
+                name="ss_skb_realloc_headroom_h2_1",
+                func_name="ss_skb_realloc_headroom",
+                id="deproxy_h2",
+                msg=None,
+                times=1,
+                space=4,
+                response=deproxy.Response.create_simple_response(
+                    status="200",
+                    headers=[("qwerty", "x" * 50000), ("content-length", "200000")],
+                    date=deproxy.HttpMessage.date_time_string(),
+                    body="y" * 200000,
+                ),
+                retval=-12,
+            ),
+            marks.Param(
+                name="ss_skb_realloc_headroom_h2_2",
+                func_name="ss_skb_realloc_headroom",
+                id="deproxy_h2",
+                msg=None,
+                times=1,
+                space=7,
+                response=deproxy.Response.create_simple_response(
+                    status="200",
+                    headers=[("qwerty", "x" * 50000), ("content-length", "200000")],
+                    date=deproxy.HttpMessage.date_time_string(),
+                    body="y" * 200000,
+                ),
+                retval=-12,
+            ),
         ]
     )
     @dmesg.unlimited_rate_on_tempesta_node
-    def test(self, name, func_name, id, msg, times, response, retval):
-        self._test(name, func_name, id, msg, times, response, retval)
+    def test(self, name, func_name, id, msg, times, space, response, retval):
+        self._test(name, func_name, id, msg, times, space, response, retval)
 
     @marks.Parameterize.expand(
         [
@@ -266,6 +374,7 @@ class TestFailFunction(TestFailFunctionBase, NetWorker):
                 id="deproxy_h2",
                 msg="tfw_tls_encrypt: cannot encrypt data",
                 times=1,
+                space=0,
                 response=deproxy.Response.create_simple_response(
                     status="200",
                     headers=[("qwerty", "x" * 50000), ("content-length", "100000")],
@@ -280,6 +389,7 @@ class TestFailFunction(TestFailFunctionBase, NetWorker):
                 id="deproxy_h2",
                 msg="tfw_tls_encrypt: cannot encrypt data",
                 times=1,
+                space=0,
                 response=deproxy.Response.create_simple_response(
                     status="200",
                     headers=[("qwerty", "x" * 50000), ("content-length", "100000")],
@@ -300,10 +410,10 @@ class TestFailFunction(TestFailFunctionBase, NetWorker):
         ]
     )
     @dmesg.unlimited_rate_on_tempesta_node
-    def test_mtu_100(self, name, func_name, id, msg, times, response, retval):
-        self._test(name, func_name, id, msg, times, response, retval)
+    def test_mtu_100(self, name, func_name, id, msg, times, space, response, retval):
+        self._test(name, func_name, id, msg, times, space, response, retval)
 
-    def _test(self, name, func_name, id, msg, times, response, retval):
+    def _test(self, name, func_name, id, msg, times, space, response, retval):
         """
         Basic test to check how Tempesta FW works when some internal
         function fails. Function should be marked as ALLOW_ERROR_INJECTION
@@ -314,7 +424,7 @@ class TestFailFunction(TestFailFunctionBase, NetWorker):
         server.set_response(response)
         self.start_all_services(client=False)
 
-        self.setup_fail_function_test(func_name, times, retval)
+        self.setup_fail_function_test(func_name, times, space, retval)
         client = self.get_client(id)
         request = client.create_request(method="GET", headers=[])
         client.start()
@@ -370,7 +480,7 @@ class TestFailFunctionPrepareResp(TestFailFunctionBase):
         )
         self.start_all_services(client=False)
 
-        self.setup_fail_function_test("tfw_h2_append_predefined_body", -1, -12)
+        self.setup_fail_function_test("tfw_h2_append_predefined_body", -1, 0, -12)
         client = self.get_client("deproxy_h2")
         request1 = client.create_request(method="GET", headers=[])
         request2 = client.create_request(method="GET", headers=[("Content-Type", "!!!!")])
@@ -426,7 +536,7 @@ class TestFailFunctionPrepareResp(TestFailFunctionBase):
         ),
 
         self.start_all_services(client=False)
-        self.setup_fail_function_test("tfw_h2_append_predefined_body", 1, -12)
+        self.setup_fail_function_test("tfw_h2_append_predefined_body", 1, 0, -12)
         client = self.get_client("deproxy_h2")
         request = client.create_request(method="GET", headers=[("accept", "text/html")])
         client.start()
@@ -490,7 +600,7 @@ class TestFailFunctionPipelinedResponses(TestFailFunctionBase):
         srv.pipelined = 3
         srv.conns_n = 1
         self.start_all_services(client=False)
-        self.setup_fail_function_test(func_name, times, retval)
+        self.setup_fail_function_test(func_name, times, 0, retval)
 
         i = 0
         for id in self.clients_ids:
@@ -625,7 +735,7 @@ class TestFailFunctionStaleFwd(TestFailFunctionBase):
         server.hang_on_req_num = hang_on_req_num
         self.start_all_services()
 
-        self.setup_fail_function_test(func_name, -1, 0)
+        self.setup_fail_function_test(func_name, -1, 0, 0)
 
         server.set_response(
             deproxy.Response.create(


### PR DESCRIPTION
New function `ss_skb_realloc_headroom` was implemented in Tempesta FW source code to be sure, that headroom of skb which is pushed in socket write queue is great or equal to MAX_TCP_HEADER. Add error injection tests to be sure that we gracefully handle situation when this function fails.