### PR TITLE
Fix tests for SUT

### DIFF
--- a/helpers/remote.py
+++ b/helpers/remote.py
@@ -210,7 +210,7 @@ class LocalNode(ANode):
             error.ProcessKilledException: if a process was killed
         """
         self._logger.info(f"'{cmd}'")
-        if is_blocking:
+        if not is_blocking:
             self._logger.debug("***NON-BLOCKING (no wait to finish)***")
 
         # Popen() expects full environment
@@ -457,7 +457,7 @@ class RemoteNode(ANode):
                 ],
             )
         self._logger.info(f"'{cmd}'")
-        if is_blocking:
+        if not is_blocking:
             self._logger.debug("***NON-BLOCKING (no wait to finish)***")
         self._logger.debug(f"All environment variables after updating: {env}")
 


### PR DESCRIPTION
fix ja5 tests with block requests:
- remove creating directories in `write_ja5_config` method because `copy_file` method does this;
- add a new client with pipelined requests to `test_clear_traffic_block` test. The slow clients sometimes do not have time to receive block.