### PR TITLE
fix flacky `sessions.test_sticky_sess_stress.TestStressStickyCookie.test_one_client`

### DIFF
--- a/tests/sessions/test_sticky_sess_stress.py
+++ b/tests/sessions/test_sticky_sess_stress.py
@@ -106,20 +106,12 @@ frang_limits {http_strict_host_checking false;}
         servers_with_requests = list(server for server in self.get_servers() if server.requests)
         self.assertEqual(len(servers_with_requests), 1, "Only one server must pull all the load.")
 
-        # Negative allowance: this means some requests are not forwarded to the
-        # server. This happens because some (at least one per wrk thread,
-        # at most one per connection) requests are sent without a session cookie
-        # and replied 302 by Tempesta without any forwarding, which is still
-        # considered a "success" by wrk. So, [1; concurrent_connections]
-        # requests will not be received by the backend.
-        # This allowance is specific to the session stress tests.
-        exp_min = wrk.statuses.get(200, 0) - wrk.connections
         # Positive allowance: this means some responses are missed by the client.
-        # It is believed (nobody actually checked though...) that wrk does not
-        # wait for responses to last requests in each connection before closing
-        # it and does not account for those requests.
+        # wrk does not wait for responses to last requests in each connection
+        # before closing it and does not account for those requests.
         # So, [0; concurrent_connections] responses will be missed by the client.
-        exp_max = wrk.statuses.get(200, 0) + wrk.connections - 1
+        exp_max = wrk.statuses.get(200, 0) + wrk.connections
+        exp_min = wrk.statuses.get(200, 0)
 
         self.assertTrue(
             exp_min <= servers_with_requests[0].requests <= exp_max,
@@ -152,20 +144,12 @@ frang_limits {http_strict_host_checking false;}
             "All server must pull all the load.",
         )
 
-        # Negative allowance: this means some requests are not forwarded to the
-        # server. This happens because some (at least one per wrk thread,
-        # at most one per connection) requests are sent without a session cookie
-        # and replied 302 by Tempesta without any forwarding, which is still
-        # considered a "success" by wrk. So, [1; concurrent_connections]
-        # requests will not be received by the backend.
-        # This allowance is specific to the session stress tests.
-        exp_min = wrk.statuses.get(200, 0) - wrk.connections
         # Positive allowance: this means some responses are missed by the client.
-        # It is believed (nobody actually checked though...) that wrk does not
-        # wait for responses to last requests in each connection before closing
-        # it and does not account for those requests.
+        # wrk does not wait for responses to last requests in each connection
+        # before closing it and does not account for those requests.
         # So, [0; concurrent_connections] responses will be missed by the client.
-        exp_max = wrk.statuses.get(200, 0) + wrk.connections - 1
+        exp_max = wrk.statuses.get(200, 0) + wrk.connections
+        exp_min = wrk.statuses.get(200, 0)
         servers_requests_sum = sum(list(server.requests for server in servers_with_requests))
 
         self.assertTrue(

--- a/tests/tests_disabled.json
+++ b/tests/tests_disabled.json
@@ -204,10 +204,6 @@
         {
             "name": "tests.regress.test_stress_failovering.TestStressFailovering.test_failovering_sched_hash",
             "reason": "Disabled by test issue #905"
-        },
-        {
-            "name": "tests.sessions.test_sticky_sess_stress.TestStressStickyCookie.test_one_client",
-            "reason": "Disabled by test issue #921"
         }
     ]
 }


### PR DESCRIPTION
range of requests is [statuses[200], statuses[200] + wrk.connections]. We should not reduce the number of requests. This is a mistake. The old tests counted 200+302 responses, so they worked correctly (but the check was less accurate)