### PR TITLE
Fix tests according changes in Tempesta FW

### DIFF
--- a/tests/cache/test_cache_stale.py
+++ b/tests/cache/test_cache_stale.py
@@ -66,7 +66,6 @@ cache_fulfill * *;
             deproxy_message.Response.create(
                 status="200",
                 headers=[("Content-Length", "0"), ("cache-control", "max-age=1")] + resp1_headers,
-                date=deproxy_message.HttpMessage.date_time_string(),
             )
         )
 
@@ -89,7 +88,6 @@ cache_fulfill * *;
             deproxy_message.Response.create(
                 status=resp_status,
                 headers=[("Content-Length", "0")] + resp2_headers,
-                date=deproxy_message.HttpMessage.date_time_string(),
             )
         )
 
@@ -297,7 +295,6 @@ class TestCacheUseStale(TestCacheUseStaleBase):
             deproxy_message.Response.create(
                 status="200",
                 headers=[("Content-Length", "0"), ("cache-control", "max-age=1")],
-                date=deproxy_message.HttpMessage.date_time_string(),
             )
         )
 
@@ -320,7 +317,6 @@ class TestCacheUseStale(TestCacheUseStaleBase):
             deproxy_message.Response.create(
                 status="400",
                 headers=[("Content-Length", "0")],
-                date=deproxy_message.HttpMessage.date_time_string(),
             )
         )
 
@@ -389,7 +385,6 @@ class TestCacheUseStale(TestCacheUseStaleBase):
             deproxy_message.Response.create(
                 status="200",
                 headers=[("Content-Length", "0"), ("cache-control", "max-age=1")] + resp_headers,
-                date=deproxy_message.HttpMessage.date_time_string(),
             )
         )
 
@@ -422,12 +417,14 @@ class TestCacheUseStale(TestCacheUseStaleBase):
         # expect non stale
         self.assertIsNone(client.last_response.headers.get("age", None))
 
+        # Response from backend was received, wait while response become
+        # stale again
+        await asyncio.sleep(3)
+
         for status in resp_codes:
             server.set_response(
                 deproxy_message.Response.create(
-                    status=status,
-                    headers=[("Content-Length", "0")] + resp_headers,
-                    date=deproxy_message.HttpMessage.date_time_string(),
+                    status=status, headers=[("Content-Length", "0")] + resp_headers
                 )
             )
 
@@ -477,7 +474,6 @@ class TestCacheUseStale(TestCacheUseStaleBase):
             deproxy_message.Response.create(
                 status="200",
                 headers=[("Content-Length", "0"), ("cache-control", "max-age=1")] + resp_headers,
-                date=deproxy_message.HttpMessage.date_time_string(),
             )
         )
 
@@ -500,7 +496,6 @@ class TestCacheUseStale(TestCacheUseStaleBase):
             deproxy_message.Response.create(
                 status="500",
                 headers=[("Content-Length", "0")] + resp_headers,
-                date=deproxy_message.HttpMessage.date_time_string(),
             )
         )
 
@@ -564,7 +559,6 @@ class TestCacheUseStale(TestCacheUseStaleBase):
             deproxy_message.Response.create(
                 status="200",
                 headers=[("Content-Length", "0")] + resp_headers,
-                date=deproxy_message.HttpMessage.date_time_string(),
             )
         )
 

--- a/tests/cache/test_conditional.py
+++ b/tests/cache/test_conditional.py
@@ -311,7 +311,7 @@ cache_methods GET HEAD POST;
             marks.Param(
                 name="last_modified",
                 response_headers="Date: Mon, 12 Dec 2016 13:59:39 GMT\r\n",
-                if_modified_since=HttpMessage.date_time_string,
+                if_modified_since=lambda: "Mon, 12 Dec 5016 13:59:39 GMT",
                 expected_status="304",
             ),
             marks.Param(
@@ -323,7 +323,7 @@ cache_methods GET HEAD POST;
             marks.Param(
                 name="last_modified_and_date",
                 response_headers="",
-                if_modified_since=HttpMessage.date_time_string,
+                if_modified_since=lambda: "Mon, 12 Dec 5016 13:59:39 GMT",
                 expected_status="304",
             ),
             marks.Param(

--- a/tests/cache/test_conditional.py
+++ b/tests/cache/test_conditional.py
@@ -311,7 +311,7 @@ cache_methods GET HEAD POST;
             marks.Param(
                 name="last_modified",
                 response_headers="Date: Mon, 12 Dec 2016 13:59:39 GMT\r\n",
-                if_modified_since=HttpMessage.date_time_string,
+                if_modified_since=lambda timestamp: "Mon, 12 Dec 5016 13:59:39 GMT",
                 expected_status="304",
             ),
             marks.Param(
@@ -323,7 +323,7 @@ cache_methods GET HEAD POST;
             marks.Param(
                 name="last_modified_and_date",
                 response_headers="",
-                if_modified_since=HttpMessage.date_time_string,
+                if_modified_since=lambda timestamp: "Mon, 12 Dec 5016 13:59:39 GMT",
                 expected_status="304",
             ),
             marks.Param(

--- a/tests/server_connections/test_established_connections.py
+++ b/tests/server_connections/test_established_connections.py
@@ -143,8 +143,8 @@ srv_group default {{
             tfw.get_stats()
             await self.check_total_sockets(
                 server_ip_and_port=self.get_server_ip_and_port(server),
-                expected_n=self.conns_n,
-                msg=f"Tempesta FW must create {self.conns_n} sockets to server.",
+                expected_n=1,
+                msg=f"Tempesta FW must create only one socket to server.",
             )
             await self.check_established_sockets(
                 server_ip_and_port=self.get_server_ip_and_port(server),
@@ -156,7 +156,7 @@ srv_group default {{
         msg = "Tempesta must not open connections to server."
         self.assertEqual(len(server.connections), 0, msg)
         self.assertEqual(tfw.stats.srv_conns_active, 0, msg)
-        self.assertGreaterEqual(tfw.stats.srv_conn_attempts, 32, msg)
+        self.assertGreaterEqual(tfw.stats.srv_conn_attempts, 1, msg)
         self.assertGreaterEqual(tfw.stats.srv_established_connections, 0, msg)
 
     async def test_drop_server_connections(self):
@@ -211,7 +211,6 @@ srv_group default {{
         msg = "Tempesta must not open connections to server."
         self.assertEqual(len(server.connections), 0, msg)
         self.assertEqual(tfw.stats.srv_conns_active, 0, msg)
-        self.assertGreaterEqual(tfw.stats.srv_conn_attempts, 32, msg)
         self.assertGreaterEqual(tfw.stats.srv_established_connections, 0, msg)
 
         await self.check_total_sockets(
@@ -238,8 +237,8 @@ srv_group default {{
             tfw.get_stats()
             await self.check_total_sockets(
                 server_ip_and_port=self.get_server_ip_and_port(server),
-                expected_n=self.conns_n,
-                msg=f"Tempesta FW must create {self.conns_n} sockets to server.",
+                expected_n=1,
+                msg=f"Tempesta FW must create only one socket to server.",
             )
             await self.check_established_sockets(
                 server_ip_and_port=self.get_server_ip_and_port(server),


### PR DESCRIPTION
Tempesta FW try to establish only one connection and if it fails, wait and try again. Tempesta FW doesn't try to establish new connections until first one will be establish. Change tests according these changes.