### PR TITLE
add `_set_recv_buffer_size` to deproxy

### DIFF
--- a/framework/deproxy/deproxy_base.py
+++ b/framework/deproxy/deproxy_base.py
@@ -28,6 +28,7 @@ class BaseDeproxy(asyncore.DeproxyAsyncore, Stateful, ABC):
         segment_size: int,
         segment_gap: int,
         is_ipv6: bool,
+        rcv_buf_size: int,
     ):
         asyncore.DeproxyAsyncore.__init__(self, is_ipv6)
 
@@ -36,6 +37,7 @@ class BaseDeproxy(asyncore.DeproxyAsyncore, Stateful, ABC):
         self.bind_addr = bind_addr
         self.segment_size = segment_size or run_config.TCP_SEGMENTATION or 0
         self.segment_gap = segment_gap
+        self._rcv_buf_size = rcv_buf_size
         self.__polling_lock: Optional[threading.Lock] = None
 
         self._tcp_logger = logging.LoggerAdapter(
@@ -58,6 +60,12 @@ class BaseDeproxy(asyncore.DeproxyAsyncore, Stateful, ABC):
 
     def set_lock(self, polling_lock: threading.Lock) -> None:
         self.__polling_lock = polling_lock
+
+    def _set_recv_buffer_size(self, sock: socket.socket) -> None:
+        if self._rcv_buf_size >= 0:
+            # don't expect that buffer will have exactly the same size as passed to `setsockopt()`,
+            # the kernel may increase this size.
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, self._rcv_buf_size)
 
     def _bind(self, address: tuple) -> None:
         """

--- a/framework/deproxy/deproxy_client.py
+++ b/framework/deproxy/deproxy_client.py
@@ -55,6 +55,7 @@ class BaseDeproxyClient(BaseDeproxy, abc.ABC):
         conn_addr: Optional[str],
         is_ssl: bool,
         server_hostname: str,
+        rcv_buf_size: int,
     ):
         # Initialize the `BaseDeproxy`
         super().__init__(
@@ -65,6 +66,7 @@ class BaseDeproxyClient(BaseDeproxy, abc.ABC):
             segment_size=segment_size,
             segment_gap=segment_gap,
             is_ipv6=is_ipv6,
+            rcv_buf_size=rcv_buf_size,
         )
 
         self.writable = self._in_connecting_state
@@ -253,6 +255,7 @@ class BaseDeproxyClient(BaseDeproxy, abc.ABC):
 
     def _run_deproxy(self):
         self._create_socket()
+        self._set_recv_buffer_size(self._socket)
         if self.bind_addr:
             self._bind(
                 (self.bind_addr, 0),

--- a/framework/deproxy/deproxy_server.py
+++ b/framework/deproxy/deproxy_server.py
@@ -179,6 +179,7 @@ class StaticDeproxyServer(BaseDeproxy, base_server.BaseServer):
         delay_before_sending_response: float,
         hang_on_req_num: int,
         pipelined: int,
+        rcv_buf_size: int,
     ):
         # this variable is needed for tests with common response for all tests in one class.
         self._default_response = response
@@ -193,6 +194,7 @@ class StaticDeproxyServer(BaseDeproxy, base_server.BaseServer):
             segment_size=segment_size,
             segment_gap=segment_gap,
             is_ipv6=is_ipv6,
+            rcv_buf_size=rcv_buf_size,
         )
         base_server.BaseServer.__init__(self, id_)
         self.keep_alive = keep_alive
@@ -214,6 +216,7 @@ class StaticDeproxyServer(BaseDeproxy, base_server.BaseServer):
             sock, _ = pair
             if self.segment_size:
                 sock.setsockopt(socket.SOL_TCP, socket.TCP_NODELAY, 1)
+            self._set_recv_buffer_size(sock)
             handler = ServerConnection(server=self, sock=sock)
             self._connections.append(handler)
             # ATTENTION
@@ -238,6 +241,7 @@ class StaticDeproxyServer(BaseDeproxy, base_server.BaseServer):
     def _run_deproxy(self):
         self._create_socket()
         self._set_reuse_addr()
+        self._set_recv_buffer_size(self._socket)
         self._bind((self.bind_addr, self.port))
         self._listen()
 
@@ -351,6 +355,7 @@ def deproxy_srv_initializer(
         delay_before_sending_response=server.get("delay_before_sending_response", 0.0),
         hang_on_req_num=server.get("hang_on_req_num", 0),
         pipelined=server.get("pipelined", 0),
+        rcv_buf_size=server.get("rcv_buf_size", -1),
     )
 
     tester.deproxy_manager.add_server(srv)

--- a/framework/test_suite/tester.py
+++ b/framework/test_suite/tester.py
@@ -196,6 +196,7 @@ class TempestaTest(WaitUntilAsserts, unittest.IsolatedAsyncioTestCase):
             conn_addr=fill_template(client["addr"], client),
             is_ssl=ssl,
             server_hostname=fill_template(client.get("ssl_hostname", None), client),
+            rcv_buf_size=client.get("rcv_buf_size", -1),
         )
 
     def __create_client_wrk(self, client, ssl):
@@ -239,7 +240,7 @@ class TempestaTest(WaitUntilAsserts, unittest.IsolatedAsyncioTestCase):
         if ctype in ["curl", "deproxy", "deproxy_h2"]:
             if client.get("interface", False):
                 networker = NetWorker(node=remote.client)
-                (_, bind_addr) = networker.create_interface(len(self.__ips))
+                _, bind_addr = networker.create_interface(len(self.__ips))
                 networker.create_route(bind_addr)
                 self.__ips.append(bind_addr)
             else:

--- a/tests/nonidempotent/test_nonidempotent.py
+++ b/tests/nonidempotent/test_nonidempotent.py
@@ -108,27 +108,9 @@ class DeproxyDropServer(deproxy_server.StaticDeproxyServer):
 
 
 def build_deproxy_drop(server, name, tester):
-    is_ipv6 = server.get("is_ipv6", False)
-    srv = DeproxyDropServer(
-        # BaseDeproxy
-        id_=name,
-        deproxy_auto_parser=tester._deproxy_auto_parser,
-        port=int(server["port"]),
-        bind_addr=tf_cfg.cfg.get("Server", "ipv6" if is_ipv6 else "ip"),
-        segment_size=server.get("segment_size", 0),
-        segment_gap=server.get("segment_gap", 0),
-        is_ipv6=is_ipv6,
-        # StaticDeproxyServer
-        response=fill_template(server.get("response_content", ""), server),
-        keep_alive=server.get("keep_alive", 0),
-        drop_conn_when_request_received=server.get("drop_conn_when_request_received", False),
-        send_after_conn_established=server.get("send_after_conn_established", False),
-        delay_before_sending_response=server.get("delay_before_sending_response", 0.0),
-        hang_on_req_num=server.get("hang_on_req_num", 0),
-        pipelined=server.get("pipelined", 0),
+    return deproxy_server.deproxy_srv_initializer(
+        server, name, tester, default_server_class=DeproxyDropServer
     )
-    tester.deproxy_manager.add_server(srv)
-    return srv
 
 
 tester.register_backend("deproxy_drop", build_deproxy_drop)


### PR DESCRIPTION
We set the new size before call `connect()` to have buffer of desired size after `connect()`, otherwise it may take some time to resize buffer.