### PR TITLE
rework `wait_for*` methods

### DIFF
--- a/framework/deproxy/deproxy_client.py
+++ b/framework/deproxy/deproxy_client.py
@@ -281,35 +281,34 @@ class BaseDeproxyClient(BaseDeproxy, abc.ABC):
 
     async def send_request(
         self,
-        request,
+        request: deproxy_message.Request | deproxy_message.H2Request | str,
         expected_status_code: Optional[str] = None,
-        timeout=5,
+        timeout: float = 5.0,
         msg: Optional[str] = None,
     ) -> None:
         """
         Form and send one HTTP request. And also check that the client has received a response and
         the status code matches.
         """
-        curr_responses = len(self.responses)
-
         self.make_request(request)
-        await self.wait_for_response(timeout=timeout, strict=bool(expected_status_code), msg=msg)
+        await self.wait_for_response(timeout=timeout, msg=msg)
 
         if expected_status_code:
-            assert curr_responses + 1 == len(self.responses), "Deproxy client has lost response."
             assert expected_status_code in self.last_response.status, (
                 msg
                 or f"HTTP response status codes mismatch. Expected - {expected_status_code}. "
                 + f"Received - {self.last_response.status}\nThe last response:\n{self.last_response}\n"
             )
 
-    def send_bytes(self, data: bytes, expect_response=False):
+    def send_bytes(self, data: bytes, expect_response: bool = False) -> None:
         self._add_to_request_buffers(data=data, end_stream=None)
         self._nrreq += 1
         if expect_response:
             self._valid_req_num += 1
 
-    async def wait_for_connection_open(self, timeout=5, strict=False, adjust_timeout=True):
+    async def wait_for_connection_open(
+        self, timeout: float = 5, adjust_timeout: bool = True, msg: Optional[str] = None
+    ) -> None:
         """
         Try to use strict mode whenever it's possible
         to prevent tests from hard to detect errors.
@@ -320,19 +319,16 @@ class BaseDeproxyClient(BaseDeproxy, abc.ABC):
             abort_cond=lambda: not self._connecting,
             adjust_timeout=adjust_timeout,
         )
-        if strict:
-            assert (
-                timeout_not_exceeded != False
-            ), f"Timeout exceeded while waiting connection open: {timeout}"
-        return timeout_not_exceeded
+        assert timeout_not_exceeded, f"{timeout_not_exceeded} is not True." + (
+            msg or f"Timeout exceeded while waiting connection open: {timeout}"
+        )
 
     async def wait_for_connection_close(
         self,
         timeout: float = 5,
-        strict: bool = False,
         adjust_timeout: bool = True,
-        msg: str = "",
-    ):
+        msg: Optional[str] = None,
+    ) -> None:
         """
         Try to use strict mode whenever it's possible
         to prevent tests from hard to detect errors.
@@ -343,20 +339,17 @@ class BaseDeproxyClient(BaseDeproxy, abc.ABC):
             abort_cond=lambda: self.state == stateful.STATE_ERROR,
             adjust_timeout=adjust_timeout,
         )
-        if strict:
-            assert timeout_not_exceeded != False, (
-                msg or f"Timeout exceeded while waiting connection close: {timeout}"
-            )
-        return timeout_not_exceeded
+        assert timeout_not_exceeded, f"{timeout_not_exceeded} is not True." + (
+            msg or f"Timeout exceeded while waiting connection close: {timeout}"
+        )
 
     async def wait_for_response(
         self,
-        timeout=5,
-        strict=False,
-        adjust_timeout=True,
+        timeout: float = 5,
+        adjust_timeout: bool = True,
         n: Optional[int] = None,
         msg: Optional[str] = None,
-    ):
+    ) -> None:
         """
         Try to use strict mode whenever it's possible
         to prevent tests from hard to detect errors.
@@ -367,11 +360,9 @@ class BaseDeproxyClient(BaseDeproxy, abc.ABC):
             abort_cond=lambda: self.connection_is_closed and not self._connecting,
             adjust_timeout=adjust_timeout,
         )
-        if strict:
-            assert timeout_not_exceeded != False, (
-                msg or f"Timeout exceeded while waiting response: {timeout}"
-            )
-        return timeout_not_exceeded
+        assert timeout_not_exceeded, f"{timeout_not_exceeded} is not True." + (
+            msg or f"Timeout exceeded while waiting response: {timeout}"
+        )
 
     def receive_response(self, response: deproxy_message.Response) -> None:
         self.responses.append(response)
@@ -705,36 +696,60 @@ class DeproxyClientH2(BaseDeproxyClient):
         self.h2_connection.close_connection(error_code=error_code, last_stream_id=last_stream_id)
         self.send_bytes(data=self.h2_connection.data_to_send())
 
-    async def wait_for_ack_settings(self, timeout=5):
+    async def wait_for_ack_settings(self, timeout: float = 5, msg: Optional[str] = None) -> None:
         """Wait SETTINGS frame with ack flag."""
-        return await util.wait_until(
+        timeout_not_exceeded = await util.wait_until(
             lambda: not self._ack_settings,
             timeout,
             abort_cond=lambda: self.connection_is_closed and not self._connecting,
         )
 
-    async def wait_for_reset_stream(self, stream_id: int, timeout=5):
+        assert timeout_not_exceeded, f"{timeout_not_exceeded} is not True." + (
+            msg or f"Timeout exceeded while waiting ACK in SETTINGS frame: {timeout}"
+        )
+
+    async def wait_for_reset_stream(
+        self, stream_id: int, timeout: float = 5, msg: Optional[str] = None
+    ) -> None:
         """Wait RST_STREAM frame for stream."""
-        return await util.wait_until(
+        timeout_not_exceeded = await util.wait_until(
             lambda: not self.h2_connection._stream_is_closed_by_reset(stream_id=stream_id),
             timeout,
             abort_cond=lambda: self.connection_is_closed and not self._connecting,
         )
 
-    async def wait_for_headers_frame(self, stream_id: int, timeout=5):
+        assert timeout_not_exceeded, f"{timeout_not_exceeded} is not True." + (
+            msg
+            or f"Timeout exceeded while waiting RST_STREAM frame for stream_id={stream_id}: {timeout}"
+        )
+
+    async def wait_for_headers_frame(
+        self, stream_id: int, timeout: float = 5, msg: Optional[str] = None
+    ) -> None:
         """Wait HEADERS frame for stream."""
         stream: h2.connection.H2Stream = self.h2_connection._get_stream_by_id(stream_id=stream_id)
-        return await util.wait_until(
+        timeout_not_exceeded = await util.wait_until(
             lambda: not stream.state_machine.headers_received,
             timeout,
             abort_cond=lambda: self.connection_is_closed and not self._connecting,
         )
 
-    async def wait_for_ping_frames(self, ping_count: int, timeout=5):
-        return await util.wait_until(
+        assert timeout_not_exceeded, f"{timeout_not_exceeded} is not True." + (
+            msg
+            or f"Timeout exceeded while waiting HEADERS frame for stream_id={stream_id}: timeout={timeout}"
+        )
+
+    async def wait_for_ping_frames(
+        self, ping_count: int, timeout: float = 5, msg: Optional[str] = None
+    ) -> None:
+        timeout_not_exceeded = await util.wait_until(
             lambda: self._ping_received < ping_count,
             timeout,
             abort_cond=lambda: self.connection_is_closed and not self._connecting,
+        )
+
+        assert timeout_not_exceeded, f"{timeout_not_exceeded} is not True." + (
+            msg or f"Timeout exceeded while waiting {ping_count} PING frames: {timeout}"
         )
 
     @property

--- a/framework/deproxy/deproxy_server.py
+++ b/framework/deproxy/deproxy_server.py
@@ -254,10 +254,21 @@ class StaticDeproxyServer(BaseDeproxy, base_server.BaseServer):
     def _wait_for_connections(self) -> bool:
         return len(self._connections) < self.conns_n
 
-    async def wait_for_connections_closed(self, timeout=1):
+    async def wait_for_connections_closed(
+        self, timeout: float = 1.0, msg: Optional[str] = None
+    ) -> None:
         if self.state != stateful.STATE_STARTED:
-            return False
-        return await util.wait_until(lambda: len(self._connections) != 0, timeout)
+            raise AssertionError(f"The {self} server is not started.")
+        timeout_not_exceeded = await util.wait_until(
+            lambda: len(self._connections) != 0,
+            timeout=timeout,
+            abort_cond=lambda: self.state != stateful.STATE_STARTED,
+        )
+
+        assert timeout_not_exceeded, f"{timeout_not_exceeded} is not True." + (
+            msg
+            or f"The server connections are not closed. The current connections N - {len(self.connections)}."
+        )
 
     def flush(self):
         for conn in self._connections:
@@ -318,8 +329,8 @@ class StaticDeproxyServer(BaseDeproxy, base_server.BaseServer):
         return self.__response, False
 
     async def wait_for_requests(
-        self, n: int, timeout=10, strict=False, adjust_timeout=False
-    ) -> bool:
+        self, n: int, timeout: float = 5.0, adjust_timeout: bool = False, msg: Optional[str] = None
+    ) -> None:
         """wait for the `n` number of responses to be received"""
         timeout_not_exceeded = await util.wait_until(
             lambda: len(self.requests) < n,
@@ -327,11 +338,10 @@ class StaticDeproxyServer(BaseDeproxy, base_server.BaseServer):
             abort_cond=lambda: not self._accepting,
             adjust_timeout=adjust_timeout,
         )
-        if strict:
-            assert (
-                timeout_not_exceeded != False
-            ), f"Timeout exceeded while waiting connection close: {timeout}"
-        return timeout_not_exceeded
+
+        assert timeout_not_exceeded, f"{timeout_not_exceeded} is not True." + (
+            msg or f"Timeout exceeded while waiting connection close: {timeout}"
+        )
 
 
 def deproxy_srv_initializer(

--- a/framework/services/base_client.py
+++ b/framework/services/base_client.py
@@ -6,7 +6,7 @@ import abc
 import multiprocessing
 import os
 import queue
-import typing
+from typing import Callable, Optional
 
 from framework.helpers import error, remote, tf_cfg, util
 from framework.services import stateful
@@ -66,7 +66,7 @@ class BaseClient(stateful.Stateful, metaclass=abc.ABCMeta):
 
     def clear_stats(self):
         super().clear_stats()
-        self.proc: typing.Optional[multiprocessing.Process] = None
+        self.proc: Optional[multiprocessing.Process] = None
         self.returncode = 0
         self.resq = multiprocessing.Queue()
         self.requests = 0
@@ -91,7 +91,7 @@ class BaseClient(stateful.Stateful, metaclass=abc.ABCMeta):
                 self._logger.debug("Client is not running")
         return busy
 
-    def _stop_procedures(self) -> list[typing.Callable]:
+    def _stop_procedures(self) -> list[Callable]:
         return [self.__on_finish]
 
     def __on_finish(self):
@@ -160,5 +160,10 @@ class BaseClient(stateful.Stateful, metaclass=abc.ABCMeta):
     def set_user_agent(self, ua):
         self.options.append("-H 'User-Agent: %s'" % ua)
 
-    async def wait_for_finish(self, timeout=5) -> bool:
-        return await util.wait_until(lambda: self.is_busy(verbose=False), timeout)
+    async def wait_for_finish(self, timeout: float = 5, msg: Optional[str] = None) -> None:
+        self._logger.debug(f'Client "{self}" wait for finish')
+        timeout_not_exceeded = await util.wait_until(lambda: self.is_busy(verbose=False), timeout)
+        assert timeout_not_exceeded, f"{timeout_not_exceeded} is not True." + (
+            msg or f"Waiting for client {self} failed."
+        )
+        self._logger.debug(f'Waiting for client "{self}" is completed')

--- a/framework/services/base_server.py
+++ b/framework/services/base_server.py
@@ -3,6 +3,7 @@ __copyright__ = "Copyright (C) 2026 Tempesta Technologies, Inc."
 __license__ = "GPL2"
 
 import abc
+from typing import Optional
 
 from framework.helpers import port_checks, remote, tf_cfg, util
 from framework.services import stateful, tempesta
@@ -30,25 +31,23 @@ class BaseServer(stateful.Stateful, abc.ABC):
             raise ValueError("`conns_n` MUST be greater than or equal to 0.")
         self._conns_n = conns_n
 
-    async def wait_for_connections(
-        self, timeout: float = 1.0, strict: bool = False, msg: str = None
-    ) -> bool | None:
+    async def wait_for_connections(self, timeout: float = 1.0, msg: Optional[str] = "") -> None:
         """
         Wait until the container becomes healthy
         and Tempesta establishes connections to the server ports.
         """
         if self.state != stateful.STATE_STARTED:
-            return False
+            raise AssertionError(f"The {self} server is not started.")
 
-        result = await util.wait_until(
+        timeout_not_exceeded = await util.wait_until(
             self._wait_for_connections,
             abort_cond=lambda: self.state != stateful.STATE_STARTED,
             timeout=timeout,
         )
 
-        if strict:
-            assert result, msg or f"Tempesta FW don't create connection to {self}."
-        return result
+        assert timeout_not_exceeded, f"{timeout_not_exceeded} is not True." + (
+            msg or f"Tempesta FW don't create connection to {self}."
+        )
 
     @abc.abstractmethod
     def _wait_for_connections(self) -> bool: ...

--- a/framework/services/nginx_server.py
+++ b/framework/services/nginx_server.py
@@ -1,6 +1,6 @@
 import os
 import re
-import typing
+from typing import Callable, Optional
 
 from framework.helpers import remote, tf_cfg, util
 from framework.helpers.util import fill_template
@@ -56,7 +56,7 @@ class Nginx(base_server.BaseServer):
             # Get rid of stats requests influence to statistics.
             self._requests = int(m.group(2)) - self._stats_ask_times
 
-    def _stop_procedures(self) -> list[typing.Callable]:
+    def _stop_procedures(self) -> list[Callable]:
         return [self.stop_nginx, self.remove_config]
 
     def _wait_for_connections(self):
@@ -102,8 +102,8 @@ class Nginx(base_server.BaseServer):
         return self._requests
 
     async def wait_for_requests(
-        self, n: int, timeout=1, strict=False, adjust_timeout=False
-    ) -> bool:
+        self, n: int, timeout: float = 1.0, adjust_timeout: bool = False, msg: Optional[str] = None
+    ) -> None:
         """wait for the `n` number of responses to be received"""
         timeout_not_exceeded = await util.wait_until(
             lambda: self.requests < n,
@@ -111,11 +111,10 @@ class Nginx(base_server.BaseServer):
             abort_cond=lambda: self.state != stateful.STATE_STARTED,
             adjust_timeout=adjust_timeout,
         )
-        if strict:
-            assert (
-                timeout_not_exceeded != False
-            ), f"Timeout exceeded while waiting connection close: {timeout}"
-        return timeout_not_exceeded
+
+        assert timeout_not_exceeded, f"{timeout_not_exceeded} is not True." + (
+            msg or f"Timeout exceeded while waiting connection close: {timeout}"
+        )
 
 
 def nginx_srv_factory(server, name, tester):

--- a/framework/test_suite/tester.py
+++ b/framework/test_suite/tester.py
@@ -8,8 +8,8 @@ import re
 import signal
 import subprocess
 import threading
-import typing
 import unittest
+from typing import Callable, Optional, Union
 from unittest.util import strclass
 
 import run_config
@@ -24,6 +24,7 @@ from framework.helpers.util import fill_template
 from framework.services import curl_client, external_client
 from framework.services import tempesta as tfw
 from framework.services import wrk_client
+from framework.services.base_client import BaseClient
 from framework.services.docker_server import DockerServer, docker_srv_factory
 from framework.services.nginx_server import Nginx, nginx_srv_factory
 from framework.services.stateful import Stateful
@@ -55,7 +56,7 @@ register_backend("docker", docker_srv_factory)
 @dataclasses.dataclass
 class TempestaLoggers:
     dmesg: dmesg.DmesgFinder
-    _get_tempesta: typing.Callable
+    _get_tempesta: Callable
 
     @property
     def clickhouse(self) -> clickhouse.ClickHouseFinder:
@@ -65,7 +66,7 @@ class TempestaLoggers:
 class WaitUntilAsserts(unittest.TestCase):
     async def assertWaitUntilEqual(
         self,
-        func: typing.Callable,
+        func: Callable,
         second,
         msg: str = None,
         timeout: int = 5,
@@ -79,7 +80,7 @@ class WaitUntilAsserts(unittest.TestCase):
 
     async def assertWaitUntilNotEqual(
         self,
-        func: typing.Callable,
+        func: Callable,
         second,
         msg: str = None,
         timeout: int = 5,
@@ -93,7 +94,7 @@ class WaitUntilAsserts(unittest.TestCase):
 
     async def assertWaitUntilIsNotNone(
         self,
-        func: typing.Callable,
+        func: Callable,
         msg: str = None,
         timeout: int = 5,
     ):
@@ -106,7 +107,7 @@ class WaitUntilAsserts(unittest.TestCase):
 
     async def assertWaitUntilCountEqual(
         self,
-        func: typing.Callable,
+        func: Callable,
         count,
         msg: str = None,
         timeout: int = 5,
@@ -120,7 +121,7 @@ class WaitUntilAsserts(unittest.TestCase):
 
     async def assertWaitUntilTrue(
         self,
-        func: typing.Callable,
+        func: Callable,
         msg: str = None,
         timeout: int = 5,
     ):
@@ -133,7 +134,7 @@ class WaitUntilAsserts(unittest.TestCase):
 
     async def assertWaitUntilFalse(
         self,
-        func: typing.Callable,
+        func: Callable,
         msg: str = None,
         timeout: int = 5,
         poll_freq: float = run_config.asyncio_freq,
@@ -303,7 +304,7 @@ class TempestaTest(WaitUntilAsserts, unittest.IsolatedAsyncioTestCase):
             # Copy description to keep it clean between several tests.
             self.__create_client(client.copy())
 
-    def get_client(self, cid) -> typing.Union[
+    def get_client(self, cid) -> Union[
         deproxy_client.DeproxyClientH2,
         deproxy_client.DeproxyClient,
         curl_client.CurlClient,
@@ -320,7 +321,7 @@ class TempestaTest(WaitUntilAsserts, unittest.IsolatedAsyncioTestCase):
     def get_clients(self) -> list:
         return list(self.__clients.values())
 
-    def get_all_services(self) -> typing.List[Stateful]:
+    def get_all_services(self) -> list[Stateful]:
         return (
             ([self.__tempesta] if self.__tempesta is not None else [])
             + self.get_clients()
@@ -506,23 +507,17 @@ class TempestaTest(WaitUntilAsserts, unittest.IsolatedAsyncioTestCase):
             test_logger.info("Cleanup: Check memory leaks.")
             self._memworker.check_memory_consumption_of_test(self._mem_stats, self)
 
-    async def wait_while_busy(self, *items, timeout=20):
-        if items is None:
-            return
-
-        success = True
-        for item in items:
-            if item.is_running():
-                test_logger.debug(f'Client "{item}" wait for finish')
-                success = success and await item.wait_for_finish(timeout)
-                test_logger.debug(f'Waiting for client "{item}" is completed')
-
-        self.assertTrue(success, f"Some of items exceeded the timeout {timeout}s while finishing")
-
-    async def wait_all_connections(self, tmt=5) -> None:
+    @staticmethod
+    async def wait_while_busy(*items: BaseClient, timeout: float = 20) -> None:
+        if not items:
+            return None
         await asyncio.gather(
-            *[srv.wait_for_connections(timeout=tmt, strict=True) for srv in self.get_servers()],
-            return_exceptions=True,
+            *[item.wait_for_finish(timeout) for item in items if item.is_running()]
+        ),
+
+    async def wait_all_connections(self, tmt: float = 5.0, msg: Optional[str] = None) -> None:
+        await asyncio.gather(
+            *[srv.wait_for_connections(timeout=tmt, msg=msg) for srv in self.get_servers()],
         )
 
     async def start_all_services(self, client: bool = True) -> None:
@@ -538,7 +533,7 @@ class TempestaTest(WaitUntilAsserts, unittest.IsolatedAsyncioTestCase):
         conn_task = asyncio.create_task(self.wait_all_connections())
         tfw_logger_task = asyncio.create_task(self.__tempesta.wait_while_logger_start())
 
-        await asyncio.gather(conn_task, tfw_logger_task, return_exceptions=True)
+        await asyncio.gather(conn_task, tfw_logger_task)
 
         if client:
             self.start_all_clients()

--- a/tests/access_log/test_access_log.py
+++ b/tests/access_log/test_access_log.py
@@ -188,6 +188,7 @@ class AccessLogFrang(CheckedResponses):
             cache 0;
             listen 80;
             access_log dmesg;
+            block_action attack reply;
 
             frang_limits {
                 http_uri_len 10;

--- a/tests/cache/test_cache.py
+++ b/tests/cache/test_cache.py
@@ -1922,9 +1922,8 @@ frang_limits {
             client.update_initial_settings(max_header_list_size=65536 * 2)
             client.send_bytes(client.h2_connection.data_to_send())
             client.h2_connection.clear_outbound_data_buffer()
-            self.assertTrue(
-                await client.wait_for_ack_settings(),
-                "Tempesta foes not returns SETTINGS frame with ACK flag.",
+            await client.wait_for_ack_settings(
+                msg="Tempesta foes not returns SETTINGS frame with ACK flag."
             )
         request = client.create_request(method="GET", uri="/", headers=[])
 

--- a/tests/clickhouse/test_clickhouse_logs.py
+++ b/tests/clickhouse/test_clickhouse_logs.py
@@ -433,7 +433,7 @@ class TestClickhouseLogTiming(tester.TempestaTest):
         client = self.get_client("curl")
 
         client.start()
-        self.assertTrue(await client.wait_for_finish())
+        await client.wait_for_finish()
         client.stop()
 
         await self.assertWaitUntilEqual(
@@ -449,7 +449,7 @@ class TestClickhouseLogTiming(tester.TempestaTest):
         client = self.get_client("parallel")
 
         client.start()
-        self.assertTrue(await client.wait_for_finish())
+        await client.wait_for_finish()
         client.stop()
 
         await self.assertWaitUntilEqual(

--- a/tests/client_mem/test_client_mem.py
+++ b/tests/client_mem/test_client_mem.py
@@ -6,6 +6,7 @@ __license__ = "GPL2"
 
 import asyncio
 import time
+
 import run_config
 from framework.helpers import error
 from framework.test_suite import marks, tester
@@ -108,7 +109,7 @@ tls_match_any_server_name;
         frame level, so connection will be closed with
         TCP RST without any response
         """
-        await client.wait_for_connection_close(strict=True)
+        await client.wait_for_connection_close()
 
 
 @marks.parameterize_class(
@@ -173,7 +174,7 @@ class TestBlockByMemExceeded(TestBlockByMemExceededBase):
         )
 
         await client.send_request(request, "403")
-        await client.wait_for_connection_close(strict=True)
+        await client.wait_for_connection_close()
 
 
 class TestReconfigClientMemStress(tester.TempestaTest):
@@ -323,7 +324,7 @@ tls_match_any_server_name;
         for _ in range(0, ping_count):
             client.send_ping()
 
-        await client.wait_for_connection_close(strict=True)
+        await client.wait_for_connection_close()
 
 
 class TestSeveralClientsWithSmallLrusize(tester.TempestaTest):
@@ -375,6 +376,6 @@ tls_match_any_server_name;
             client.start()
             request = client.create_request(method="GET", uri="/", headers=[])
             client.make_requests([request] * 10)
-            await server.wait_for_requests((i + 1) * 10, strict=True)
+            await server.wait_for_requests((i + 1) * 10)
             await client.wait_for_response()
             self.assertTrue(len(client.responses), 10)

--- a/tests/custom_branges/test_http_brange.py
+++ b/tests/custom_branges/test_http_brange.py
@@ -231,7 +231,7 @@ tls_match_any_server_name;
         if expected_status == "200":
             self.assertTrue(client.conn_is_active)
         else:
-            self.assertTrue(await client.wait_for_connection_close())
+            await client.wait_for_connection_close()
 
     @marks.Parameterize.expand(
         [
@@ -258,7 +258,7 @@ tls_match_any_server_name;
         if expected_status == "200":
             self.assertTrue(client.conn_is_active)
         else:
-            self.assertTrue(await client.wait_for_connection_close())
+            await client.wait_for_connection_close()
 
     @marks.Parameterize.expand(
         [
@@ -284,7 +284,7 @@ tls_match_any_server_name;
         if expected_status == "200":
             self.assertTrue(client.conn_is_active)
         else:
-            self.assertTrue(await client.wait_for_connection_close())
+            await client.wait_for_connection_close()
 
     @marks.Parameterize.expand(
         [
@@ -327,7 +327,7 @@ tls_match_any_server_name;
         if expected_status == "200":
             self.assertTrue(client.conn_is_active)
         else:
-            self.assertTrue(await client.wait_for_connection_close())
+            await client.wait_for_connection_close()
 
     @marks.Parameterize.expand(
         [
@@ -363,7 +363,7 @@ tls_match_any_server_name;
         if expected_status == "200":
             self.assertTrue(client.conn_is_active)
         else:
-            self.assertTrue(await client.wait_for_connection_close())
+            await client.wait_for_connection_close()
 
     @marks.Parameterize.expand(
         [
@@ -411,7 +411,7 @@ tls_match_any_server_name;
         if expected_status == "200":
             self.assertTrue(client.conn_is_active)
         else:
-            self.assertTrue(await client.wait_for_connection_close())
+            await client.wait_for_connection_close()
 
     @marks.Parameterize.expand(
         [
@@ -441,7 +441,7 @@ tls_match_any_server_name;
         if expected_status == "200":
             self.assertTrue(client.conn_is_active)
         else:
-            self.assertTrue(await client.wait_for_connection_close())
+            await client.wait_for_connection_close()
 
     @marks.Parameterize.expand(
         [
@@ -470,7 +470,7 @@ tls_match_any_server_name;
         if expected_status == "200":
             self.assertTrue(client.conn_is_active)
         else:
-            self.assertTrue(await client.wait_for_connection_close())
+            await client.wait_for_connection_close()
 
     @marks.Parameterize.expand(
         [
@@ -507,7 +507,7 @@ tls_match_any_server_name;
         if expected_status == "200":
             self.assertTrue(client.conn_is_active)
         else:
-            self.assertTrue(await client.wait_for_connection_close())
+            await client.wait_for_connection_close()
 
     @marks.Parameterize.expand(
         [
@@ -539,7 +539,7 @@ tls_match_any_server_name;
         if expected_status == "200":
             self.assertTrue(client.conn_is_active)
         else:
-            self.assertTrue(await client.wait_for_connection_close())
+            await client.wait_for_connection_close()
 
     @marks.Parameterize.expand(
         [

--- a/tests/cve/test_cve.py
+++ b/tests/cve/test_cve.py
@@ -142,7 +142,6 @@ http {
         clients.make_requests([request] * 100)
 
         await clients.wait_for_connection_close(
-            strict=True,
             timeout=30,
             msg="`client_mem` doesn't block the clients that using a small window_update (~0).",
         )
@@ -174,7 +173,6 @@ http {
         clients.make_requests([request] * 100)
         await clients.wait_for_connection_close(
             timeout=20,
-            strict=True,
             msg="`client_mem` doesn't block the clients that using a small TCP rcv_buf_size (~0).",
         )
 
@@ -292,7 +290,7 @@ class TestHttp2FrameFlood(tester.TempestaTest):
                     exclusive=bool(random.randint(0, 1)),
                 ).serialize()
             )
-        await client.wait_for_connection_close(strict=True)
+        await client.wait_for_connection_close()
 
     @dmesg.limited_rate_on_tempesta_node
     async def test_cve_2024_2758(self):
@@ -553,9 +551,9 @@ http {
                     expect_response=True,
                 )
 
-            self.assertTrue(await client.wait_for_response(120))
+            await client.wait_for_response(120)
 
         # close first stream and http2 connection and finish test
         client.stream_id = 1
         client.make_request("data", end_stream=True)
-        self.assertTrue(await client.wait_for_response())
+        await client.wait_for_response()

--- a/tests/deadtime/test_deadtime_1M.py
+++ b/tests/deadtime/test_deadtime_1M.py
@@ -140,7 +140,7 @@ class TestModifyServerGroup(tester.TempestaTest):
         client.start()
         await server.wait_for_requests(n=self.requests_n // 3)
         tfw.reload()
-        self.assertTrue(await client.wait_for_finish())
+        await client.wait_for_finish()
         client.stop()
 
         self.assertGreater(
@@ -165,7 +165,7 @@ class TestModifyServerGroup(tester.TempestaTest):
         await server.wait_for_requests(n=self.requests_n // 3)
         self._generate_tempesta_config_with_multiple_srv_group(server_listeners)
         tfw.reload()
-        self.assertTrue(await client.wait_for_finish())
+        await client.wait_for_finish()
         client.stop()
 
         self.assertGreater(
@@ -190,7 +190,7 @@ class TestModifyServerGroup(tester.TempestaTest):
         await server.wait_for_requests(n=self.requests_n // 3)
         self._generate_tempesta_config_with_multiple_srv_group(first_part)
         tfw.reload()
-        self.assertTrue(await client.wait_for_finish())
+        await client.wait_for_finish()
         client.stop()
 
         self.assertGreater(

--- a/tests/encoding/test_encoding.py
+++ b/tests/encoding/test_encoding.py
@@ -37,9 +37,8 @@ class CommonUtils:
             if not request
             else request
         )
-        client.make_request(request)
-        got_response = await client.wait_for_response(timeout=5)
-        return got_response
+        await client.send_request(request)
+        return client.last_response
 
 
 class TestH2BodyDechunking(tester.TempestaTest, CommonUtils):
@@ -109,12 +108,8 @@ class TestH2BodyDechunking(tester.TempestaTest, CommonUtils):
             (":scheme", "https"),
             (":method", method),
         ]
-        client.make_request(request)
-        got_response = await client.wait_for_response(timeout=5)
-        response = client.responses[-1] if len(client.responses) else None
-
-        self.assertTrue(got_response, "Got no response")
-        self.assertEqual(response.status, "200")
+        await client.send_request(request, "200")
+        response = client.last_response
         self.assertFalse(
             "Transfer-Encoding" in response.headers,
             "The response should not have Transfer-Encoding",
@@ -129,11 +124,7 @@ class TestH2BodyDechunking(tester.TempestaTest, CommonUtils):
             self.assertFalse(response.body)
 
         # from now on the response is cached
-        client.make_request(request)
-        got_response = await client.wait_for_response(timeout=5)
-
-        self.assertTrue(got_response, "Got no response")
-        self.assertEqual(client.last_response.status, "200")
+        await client.send_request(request, "200")
         if body_expected:
             self.assertEqual(
                 client.last_response.body,
@@ -201,7 +192,7 @@ class TestH2BodyDechunkingWithMovingBody(TestH2BodyDechunking):
         client = self.get_client("client")
         client.update_initial_settings(max_header_list_size=65536 * 2)
         client.send_bytes(client.h2_connection.data_to_send())
-        self.assertTrue(await client.wait_for_ack_settings())
+        await client.wait_for_ack_settings()
         await self.run_test("GET", True)
 
 
@@ -353,12 +344,7 @@ class TestH2ChunkedIsNotLast(tester.TempestaTest, CommonUtils):
             (":scheme", "https"),
             (":method", "GET"),
         ]
-        client.make_request(request)
-        got_response = await client.wait_for_response(timeout=5)
-        response1 = client.responses[-1] if len(client.responses) else None
-
-        self.assertTrue(got_response, "Got no response")
-        self.assertEqual(response1.status, "502")
+        await client.send_request(request, "502")
 
 
 class TestH1ChunkedNonCacheable(tester.TempestaTest, CommonUtils):
@@ -400,20 +386,16 @@ class TestH1ChunkedNonCacheable(tester.TempestaTest, CommonUtils):
         client = self.get_client("client")
         server = self.get_server("backend")
 
-        got_response = await self.send_req(client)
-        response = client.responses[-1] if len(client.responses) else None
+        response = await self.send_req(client)
 
-        self.assertTrue(got_response, "There should be a response")
         self.assertEqual(response.status, "200")
         self.assertEqual(
             response.headers.get("Transfer-Encoding"), "chunked", "Wrong response Transfer-Encoding"
         )
 
         # second request
-        got_response = await self.send_req(client)
-        response = client.responses[-1] if len(client.responses) else None
+        response = await self.send_req(client)
 
-        self.assertTrue(got_response, "There should be a response")
         self.assertEqual(response.status, "200")
         self.assertEqual(len(server.requests), 2, "The response has to be server from cache")
 
@@ -453,11 +435,8 @@ class TestH1BothTEAndCE(tester.TempestaTest, CommonUtils):
 
         client = self.get_client("client")
 
-        got_response = await self.send_req(client)
-        got_response = await client.wait_for_response(timeout=5)
-        response = client.responses[-1] if len(client.responses) else None
+        response = await self.send_req(client)
 
-        self.assertTrue(got_response, "Got no response")
         self.assertEqual(response.status, "502", "Wrong response status code")
 
 
@@ -520,12 +499,8 @@ class TestH2TEMovedToCE(tester.TempestaTest, CommonUtils):
             (":scheme", "https"),
             (":method", "GET"),
         ]
-        client.make_request(request)
-        got_response = await client.wait_for_response(timeout=5)
-        response = client.responses[-1] if len(client.responses) else None
-
-        self.assertTrue(got_response, "Got no response")
-        self.assertEqual(response.status, "200")
+        await client.send_request(request, "200")
+        response = client.last_response
         self.assertFalse(
             "Transfer-Encoding" in response.headers,
             "The response should not have Transfer-Encoding",
@@ -718,13 +693,8 @@ class TestH2ChunkedExtensionRemoved(tester.TempestaTest, CommonUtils):
             (":scheme", "https"),
             (":method", "GET"),
         ]
-        client.make_request(request)
-        got_response = await client.wait_for_response(timeout=5)
-        response = client.responses[-1] if len(client.responses) else None
-
-        self.assertTrue(got_response, "Got no response")
-        self.assertEqual(response.status, "200")
-        self.assertEqual(response.body, "some data", "Wrong response body value")
+        await client.send_request(request, "200")
+        self.assertEqual(client.last_response.body, "some data", "Wrong response body value")
 
 
 class TestRequestTEAndCL(tester.TempestaTest, CommonUtils):

--- a/tests/fault_injection/test_fault_injection_base.py
+++ b/tests/fault_injection/test_fault_injection_base.py
@@ -965,8 +965,6 @@ srv_group test {{
                 self.get_tempesta().start()
             except error.ProcessBadExitStatusException:
                 pass
-            except:
-                self.assertTrue(False)
             else:
                 need_stop = True
             self.get_tempesta().stop()
@@ -1033,7 +1031,7 @@ http_chain {{
         self.deproxy_manager.start()
         for srv_name in ["deproxy_3", "deproxy_4", "deproxy_5"]:
             server = self.get_server(srv_name)
-            self.assertTrue(await server.wait_for_connections(timeout=5))
+            await server.wait_for_connections(timeout=5)
 
         self.get_tempesta().config.set_defconfig(
             f"""
@@ -1048,9 +1046,9 @@ grace_shutdown_time 1;
         self.get_tempesta().reload()
         for srv_name in ["deproxy_3", "deproxy_4", "deproxy_5"]:
             server = self.get_server(srv_name)
-            self.assertTrue(await server.wait_for_connections_closed(timeout=5))
+            await server.wait_for_connections_closed(timeout=5)
         server = self.get_server("deproxy_1")
-        self.assertTrue(await server.wait_for_connections(timeout=5))
+        await server.wait_for_connections(timeout=5)
 
     async def test_failed_disconnect_srv_connection(self):
         """
@@ -1105,11 +1103,11 @@ http_chain {{
         self.deproxy_manager.start()
         for srv_name in ["deproxy_3", "deproxy_4", "deproxy_5"]:
             server = self.get_server(srv_name)
-            self.assertTrue(await server.wait_for_connections(timeout=5))
+            await server.wait_for_connections(timeout=5)
         self.get_tempesta().stop_tempesta()
         for srv_name in ["deproxy_3", "deproxy_4", "deproxy_5"]:
             server = self.get_server(srv_name)
-            self.assertTrue(await server.wait_for_connections_closed())
+            await server.wait_for_connections_closed()
 
     async def test_abort_client_connection(self):
         """
@@ -1153,7 +1151,7 @@ http_chain {{
         )
         server.start()
         self.deproxy_manager.start()
-        self.assertTrue(await server.wait_for_connections(timeout=5))
+        await server.wait_for_connections(timeout=5)
 
         client = self.get_client("deproxy_h2")
         client.start()
@@ -1276,7 +1274,7 @@ grace_shutdown_time 5;
 
         server.start()
         self.deproxy_manager.start()
-        self.assertTrue(await server.wait_for_connections(timeout=5))
+        await server.wait_for_connections(timeout=5)
 
         client = self.get_client("deproxy")
         request = client.create_request(method="GET", headers=[])
@@ -1834,10 +1832,7 @@ class TestFailFunction(TestFailFunctionBase):
         self.oops_ignore = ["ERROR"]
         client.make_request(request)
 
-        # This is necessary to be sure that Tempesta FW write
-        # appropriate message in dmesg.
-        self.assertFalse(await client.wait_for_response(3))
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
 
         if msg:
             self.assertTrue(
@@ -1881,9 +1876,8 @@ class TestFailFunctionPrepareResp(TestFailFunctionBase):
         client.update_initial_settings(max_header_list_size=1600000)
         client.send_bytes(client.h2_connection.data_to_send())
         client.h2_connection.clear_outbound_data_buffer()
-        self.assertTrue(
-            await client.wait_for_ack_settings(),
-            "Tempesta foes not returns SETTINGS frame with ACK flag.",
+        await client.wait_for_ack_settings(
+            msg="Tempesta foes not returns SETTINGS frame with ACK flag."
         )
 
         self.oops_ignore = ["ERROR"]
@@ -1891,10 +1885,7 @@ class TestFailFunctionPrepareResp(TestFailFunctionBase):
         await server.wait_for_requests(1)
         client.make_request(request2)
 
-        # This is necessary to be sure that Tempesta FW write
-        # appropriate message in dmesg.
-        self.assertFalse(await client.wait_for_response(3))
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
 
     @dmesg.unlimited_rate_on_tempesta_node
     async def test_tfw_h2_prep_resp_for_sticky_ccokie(self):
@@ -1940,9 +1931,9 @@ class TestFailFunctionPrepareResp(TestFailFunctionBase):
 
         # This is necessary to be sure that Tempesta FW write
         # appropriate message in dmesg.
-        self.assertTrue(await client.wait_for_response(3))
+        await client.wait_for_response(3)
         self.assertEqual(client.last_response.status, "500")
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
 
 
 class TestFailFunctionPipelinedResponses(TestFailFunctionBase):
@@ -1972,25 +1963,15 @@ class TestFailFunctionPipelinedResponses(TestFailFunctionBase):
 
     clients_ids = ["deproxy_1", "deproxy_2", "deproxy_3"]
 
-    @marks.Parameterize.expand(
-        [
-            marks.Param(
-                name="tfw_http_msg_create_sibling",
-                func_name="tfw_http_msg_create_sibling",
-                id="deproxy_h2",
-                msg="Can't create pipelined response",
-                times=-1,
-                retval=0,
-            )
-        ]
-    )
     @dmesg.unlimited_rate_on_tempesta_node
-    async def test(self, name, func_name, id, msg, times, retval):
+    async def test_tfw_http_msg_create_sibling(self):
         srv = self.get_server("deproxy")
         srv.pipelined = 3
         srv.conns_n = 1
         await self.start_all_services(client=False)
-        TestFailFunctionBaseStress.setup_fail_function_test(func_name, 100, times, 0, retval)
+        TestFailFunctionBaseStress.setup_fail_function_test(
+            "tfw_http_msg_create_sibling", 100, -1, 0, 0
+        )
 
         i = 0
         for id in self.clients_ids:
@@ -2005,13 +1986,13 @@ class TestFailFunctionPipelinedResponses(TestFailFunctionBase):
         for id in self.clients_ids:
             i = i + 1
             client = self.get_client(id)
-            if i >= 2:
-                self.assertFalse(await client.wait_for_response(1))
-            else:
-                self.assertTrue(await client.wait_for_response())
+            if i < 2:
+                await client.wait_for_response()
                 self.assertTrue(client.last_response.status, "200")
         self.assertTrue(
-            await self.loggers.dmesg.find(msg, cond=dmesg.amount_positive),
+            await self.loggers.dmesg.find(
+                "Can't create pipelined response", cond=dmesg.amount_positive
+            ),
             "Tempesta doesn't report error",
         )
 
@@ -2025,9 +2006,9 @@ class TestFailFunctionPipelinedResponses(TestFailFunctionBase):
             client = self.get_client(id)
             if i >= 2:
                 j = j + 1
-                self.assertTrue(await srv.wait_for_requests(req_count + j))
+                await srv.wait_for_requests(req_count + j)
                 srv.flush()
-                self.assertTrue(await client.wait_for_response())
+                await client.wait_for_response()
                 self.assertEqual(client.last_response.status, "200")
 
 

--- a/tests/frang/frang_test_case.py
+++ b/tests/frang/frang_test_case.py
@@ -115,7 +115,7 @@ block_action attack reply;
             self.assertFalse(client.connection_is_closed)
             await self.assertFrangWarning(warning=warning_msg, expected=0)
         else:
-            self.assertTrue(await client.wait_for_connection_close())
+            await client.wait_for_connection_close()
             await self.assertFrangWarning(warning=warning_msg, expected=1)
 
     async def check_last_response(self, client, status_code: str, warning_msg: str):

--- a/tests/frang/test_client_body_and_header_timeout.py
+++ b/tests/frang/test_client_body_and_header_timeout.py
@@ -28,7 +28,7 @@ class TestTimeoutBase(FrangTestCase):
         client.make_request(request=self.request_segment_1, end_stream=False)
         await asyncio.sleep(sleep)
         client.make_request(self.request_segment_2)
-        self.assertTrue(await client.wait_for_response(n=1))
+        await client.wait_for_response(n=1)
 
 
 class ClientBodyTimeout(TestTimeoutBase):
@@ -124,7 +124,7 @@ class ClientHeaderTimeoutH2(H2Config, ClientHeaderTimeout):
         await asyncio.sleep(sleep)
         client.send_bytes(cont_frame.serialize(), expect_response=True)
 
-        await client.wait_for_response(strict=True)
+        await client.wait_for_response()
 
     async def test_starting_timeout_counter(self):
         """

--- a/tests/frang/test_concurrent_connections.py
+++ b/tests/frang/test_concurrent_connections.py
@@ -97,7 +97,7 @@ frang_limits {
             client.make_request(client.create_request(method="GET", headers=[]))
 
         for client in self.get_clients():
-            await client.wait_for_response(timeout=2, strict=True)
+            await client.wait_for_response(timeout=2)
 
         for client in self.get_clients():
             for resp in client.responses:
@@ -152,24 +152,19 @@ frang_limits {
         for client in clients:
             client.make_request("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
 
-        for client in clients:
-            await client.wait_for_response(timeout=2)
-
         if responses == 0:
             for client in clients:
+                await client.wait_for_connection_close()
                 self.assertEqual(0, len(client.responses))
-                self.assertTrue(await client.wait_for_connection_close())
         elif responses == 2:
-            self.assertEqual(1, len(clients[0].responses))
-            self.assertEqual(1, len(clients[1].responses))
-            self.assertEqual(0, len(clients[2].responses))
-            self.assertTrue(await clients[2].wait_for_connection_close())
+            await clients[0].wait_for_response()
+            await clients[1].wait_for_response()
+            await clients[2].wait_for_connection_close()
             self.assertFalse(clients[0].connection_is_closed)
             self.assertFalse(clients[1].connection_is_closed)
         elif responses == 3:
-            self.assertEqual(1, len(clients[0].responses))
-            self.assertEqual(1, len(clients[1].responses))
-            self.assertEqual(1, len(clients[2].responses))
+            for client in clients:
+                await client.wait_for_response()
             self.assertFalse(clients[0].connection_is_closed)
             self.assertFalse(clients[1].connection_is_closed)
             self.assertFalse(clients[2].connection_is_closed)
@@ -251,13 +246,12 @@ frang_limits {
         for n in [warning_n, warning_n * 2]:
             for client in non_blocked_clients:
                 client.start()
-                await client.wait_for_connection_open(strict=True)
+                await client.wait_for_connection_open()
 
             for client in blocked_clients:  # establish 2 or more connections
                 client.start()
-                self.assertTrue(
-                    await client.wait_for_connection_close(),
-                    "Tempesta did not block concurrent TCP connections.",
+                await client.wait_for_connection_close(
+                    msg="Tempesta did not block concurrent TCP connections."
                 )
             for client in non_blocked_clients:
                 self.assertTrue(

--- a/tests/frang/test_config.py
+++ b/tests/frang/test_config.py
@@ -91,7 +91,7 @@ block_action error reply;
         df.flags.add("END_STREAM")
         client.send_bytes(df.serialize(), expect_response=True)
 
-        self.assertTrue(await client.wait_for_response(30))
+        await client.wait_for_response(30)
         self.assertEqual(client.last_response.status, "403")
         self.assertTrue(await self.loggers.dmesg.find("frang: HTTP body length exceeded for"))
 
@@ -156,7 +156,7 @@ block_action error reply;
         )
         client.send_bytes(data=tf.serialize(), expect_response=True)
 
-        self.assertTrue(await client.wait_for_response())
+        await client.wait_for_response()
         self.assertEqual(client.last_response.status, "403")
         self.assertTrue(
             await self.loggers.dmesg.find("frang: HTTP field appear in header and trailer")
@@ -370,7 +370,7 @@ block_action error reply;
         client.make_request(
             client.create_request(authority="vh1", method="GET", headers=[("x-my-xdr", "a" * 150)])
         )
-        await client.wait_for_connection_close(strict=True)
+        await client.wait_for_connection_close()
         self.assertTrue(await self.loggers.dmesg.find("frang: HTTP header length exceeded for"))
         self.assertTrue(await self.loggers.dmesg.find("Warning: block client"))
 
@@ -380,7 +380,7 @@ block_action error reply;
                 authority="another", method="GET", headers=[("x-my-xdr", "a" * 150)]
             )
         )
-        await another_client.wait_for_connection_close(strict=True)
+        await another_client.wait_for_connection_close()
         self.assertTrue(
             await self.loggers.dmesg.find(
                 "frang: HTTP header length exceeded for", cond=amount_equals(2)
@@ -418,7 +418,7 @@ block_action error reply;
         client.make_request(
             client.create_request(authority="vh1", method="GET", headers=[("x-my-xdr", "a" * 150)])
         )
-        await client.wait_for_connection_close(strict=True)
+        await client.wait_for_connection_close()
         self.assertTrue(await self.loggers.dmesg.find("frang: HTTP header length exceeded for"))
         self.assertTrue(await self.loggers.dmesg.find("Warning: block client"))
         await asyncio.sleep(2)
@@ -735,14 +735,17 @@ block_action error reply;
     async def _test_not_override_concurrent_tcp_connections(self):
         client = self.get_client("deproxy")
         client_1 = self.get_client("deproxy_1")
+        server = self.get_server("deproxy")
+
         client.start()
         client_1.start()
 
         client.make_request(client.create_request(method="GET", headers=[]))
+        await server.wait_for_requests(n=1)
         client_1.make_request(client.create_request(method="GET", headers=[]))
 
-        await client.wait_for_response(timeout=2)
-        await client_1.wait_for_response(timeout=2)
+        await client.wait_for_response()
+        await client_1.wait_for_connection_close()
 
         self.assertTrue(await self.loggers.dmesg.find("frang: connections max num. exceeded for"))
         self.assertEqual(1, len(client.responses) + len(client_1.responses))

--- a/tests/frang/test_http_body_and_header_chunk_cnt.py
+++ b/tests/frang/test_http_body_and_header_chunk_cnt.py
@@ -33,7 +33,7 @@ class HttpHeaderChunkCnt(FrangTestCase):
         client.start()
         for data in requests:
             client.make_request(data)
-        await client.wait_for_response(n=1, strict=True)
+        await client.wait_for_response(n=1)
         return client
 
     async def test_chunk_cnt_ok(self):

--- a/tests/frang/test_http_resp_code_block.py
+++ b/tests/frang/test_http_resp_code_block.py
@@ -15,6 +15,8 @@ __author__ = "Tempesta Technologies, Inc."
 __copyright__ = "Copyright (C) 2022-2023 Tempesta Technologies, Inc."
 __license__ = "GPL2"
 
+import asyncio
+
 from framework.test_suite.marks import parameterize_class
 from tests.frang.frang_test_case import FrangTestCase, H2Config
 
@@ -120,9 +122,8 @@ class TestRespCodeBlockOneClient(FrangTestCase):
             [client.create_request(method="GET", uri=self.uri_405, headers=[]).msg] * 3
             + [client.create_request(method="GET", uri=self.uri_404, headers=[]).msg] * 4
         )
-        await client.wait_for_response()
 
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
         await self.assertFrangWarning(warning=self.warning, expected=1)
 
     async def test_reaching_the_limit_2(self):
@@ -141,9 +142,8 @@ class TestRespCodeBlockOneClient(FrangTestCase):
             + [client.create_request(method="GET", uri=self.uri_200, headers=[]).msg]
             + [client.create_request(method="GET", uri=self.uri_405, headers=[]).msg] * 2
         )
-        await client.wait_for_response()
 
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
         await self.assertFrangWarning(warning=self.warning, expected=1)
 
 
@@ -242,16 +242,16 @@ tls_match_any_server_name;
         request_2 = deproxy_cl.create_request(method="GET", uri="/uri2", headers=[])
 
         deproxy_cl.make_requests([request_1] * 10)
-        self.assertIsNone(await deproxy_cl.wait_for_response(timeout=4))
+        await asyncio.sleep(4)
 
         deproxy_cl2.make_requests([request_2] * 10)
-        self.assertIsNone(await deproxy_cl2.wait_for_response(timeout=6))
+        await asyncio.sleep(6)
 
         self.assertEqual(5, len(deproxy_cl.responses))
         self.assertEqual(0, len(deproxy_cl2.responses))
 
-        self.assertTrue(await deproxy_cl.wait_for_connection_close())
-        self.assertTrue(await deproxy_cl2.wait_for_connection_close())
+        await deproxy_cl.wait_for_connection_close()
+        await deproxy_cl2.wait_for_connection_close()
 
         await self.assertFrangWarning(warning=self.warning, expected=1)
 
@@ -278,13 +278,12 @@ tls_match_any_server_name;
         deproxy_cl.make_requests(([request_1] + [request_2]) * 6)
         deproxy_cl2.make_requests(([request_1] + [request_2]) * 10)
 
-        self.assertIsNone(await deproxy_cl.wait_for_response(timeout=4))
-        self.assertTrue(await deproxy_cl2.wait_for_response(timeout=10))
+        await deproxy_cl.wait_for_connection_close(timeout=4)
+        await deproxy_cl2.wait_for_response(timeout=10)
 
         self.assertEqual(10, len(deproxy_cl.responses))
         self.assertEqual(20, len(deproxy_cl2.responses))
 
-        self.assertTrue(await deproxy_cl.wait_for_connection_close())
         self.assertFalse(deproxy_cl2.connection_is_closed)
 
         await self.assertFrangWarning(warning=self.warning, expected=1)

--- a/tests/frang/test_http_strict_host_checking.py
+++ b/tests/frang/test_http_strict_host_checking.py
@@ -260,7 +260,7 @@ block_action error reply;
             ]
             head.extend(header)
             client.make_request(head)
-            self.assertTrue(await client.wait_for_response(1))
+            await client.wait_for_response(1)
 
         await self.check_response(client, status_code="200", warning_msg="frang: ")
 

--- a/tests/frang/test_http_trailer_split_allowed.py
+++ b/tests/frang/test_http_trailer_split_allowed.py
@@ -105,5 +105,5 @@ class TestFrangHttpTrailerSplitAllowedH2(H2Config, FrangTestCase):
         )
         client.send_bytes(data=tf.serialize() + cf.serialize(), expect_response=True)
 
-        self.assertTrue(await client.wait_for_response())
+        await client.wait_for_response()
         await self.check_response(client, status_code=expected_status, warning_msg=WARN)

--- a/tests/frang/test_ip_block.py
+++ b/tests/frang/test_ip_block.py
@@ -98,7 +98,8 @@ block_action attack drop;
 
         # Bad request:
         # reset all current clients with the same IPs
-        await c2.send_request(self.BAD_REQ)
+        c2.make_request(self.BAD_REQ)
+        await c2.wait_for_connection_close()
         # Last client wasn't blocked due to different IP
         self.assertTrue(c4.conn_is_active)
         await c4.send_request(self.GOOD_REQ, "200")
@@ -108,8 +109,7 @@ block_action attack drop;
         # and network not heavy loaded, thus doesn't make sense to wait 60 seconds on tcp
         # segmentation, 5 sec must be enough
         c5.make_request(self.GOOD_REQ)
-        await c5.wait_for_response(timeout=5, adjust_timeout=False)
-        self.assertFalse(c5.conn_is_active)
+        await c5.wait_for_connection_close(timeout=5, adjust_timeout=False)
 
         self.sniffer.stop()
         self.assert_reset_socks(self.sniffer.packets, [c1, c2, c3])
@@ -137,16 +137,17 @@ block_action attack drop;
 
         # Bad request:
         # reset all current clients with the same IPs
-        await c1.send_request(self.BAD_REQ)
+        c1.make_request(self.BAD_REQ)
+        await c1.wait_for_connection_close()
         # Last client wasn't blocked due to different IP
         self.assertTrue(c3.conn_is_active)
         await c3.send_request(self.GOOD_REQ, "200", timeout=5)
         # c2 disconnected during ip blocking
-        self.assertTrue(await c2.wait_for_connection_close(timeout=2))
+        await c2.wait_for_connection_close(timeout=2)
         # New clients with blocked IP won't be accepted
         # wait 3 seconds timeout - client is blocked
         c2.restart()
-        self.assertFalse(await c2.wait_for_connection_open(timeout=3, adjust_timeout=False))
+        await c2.wait_for_connection_close(timeout=3, adjust_timeout=False)
         self.assertFalse(c2.conn_is_active)
         # Wait 12 seconds to have in most fastest case atleast 12 seconds wait that greater
         # than block duration
@@ -177,7 +178,8 @@ block_action attack drop;
 
         # Blocking is off: clients with the same IPs
         # handled separately
-        await c1.send_request(self.BAD_REQ)
+        c1.make_request(self.BAD_REQ)
+        await c1.wait_for_connection_close()
         await c2.send_request(self.GOOD_REQ, "200")
         self.assertTrue(c2.conn_is_active)
 
@@ -223,12 +225,12 @@ block_action attack drop;
         await self.start_all_services(client=False)
         for cl in [c1, c2, c3]:
             cl.start()
-            self.assertTrue(await cl.wait_for_connection_open())
+            await cl.wait_for_connection_open()
 
         await c2.send_request(self.REQ, "200")
         # On connection to c4 client - block expected
         c4.start()
-        self.assertTrue(await c4.wait_for_connection_close(timeout=2))
+        await c4.wait_for_connection_close(timeout=2)
         self.assertFalse(c4.conn_is_active)
 
         # Reset all current clients with the same IPs
@@ -242,7 +244,7 @@ block_action attack drop;
         # don't adjust timeout. At this moment Tempesta doesn't accepts SYN from blocked client
         # and network not heavy loaded, thus doesn't make sense to wait 60 seconds on tcp
         # segmentation, 5 sec must be enough
-        self.assertTrue(await c5.wait_for_connection_close(timeout=5, adjust_timeout=False))
+        await c5.wait_for_connection_close(timeout=5, adjust_timeout=False)
         self.assertFalse(c5.conn_is_active)
 
         self.sniffer.stop()
@@ -265,14 +267,14 @@ block_action attack drop;
         await self.start_all_services(client=False)
         for cl in [c1, c2, c3]:
             cl.start()
-            await cl.wait_for_connection_open(strict=True)
+            await cl.wait_for_connection_open()
 
         # Reset all current clients with the same IPs
         # New clients with blocked IP won't be accepted
         c4.start()
         for cl in [c1, c2, c4]:
             cl.start()
-            await cl.wait_for_connection_close(strict=True)
+            await cl.wait_for_connection_close()
 
         # Client with different IP wasn't blocked
         await c3.send_request(self.REQ, "200")
@@ -284,9 +286,8 @@ block_action attack drop;
         # be sure that ip is blocked we do this connection attempt. At this moment connection will
         # not be established and SYN from client "c5" will be dropped
         c5.start()
-        self.assertTrue(
-            await c5.wait_for_connection_close(timeout=3, adjust_timeout=False),
-            "Client has not been blocked",
+        await c5.wait_for_connection_close(
+            timeout=3, adjust_timeout=False, msg="Client has not been blocked"
         )
         self.assertFalse(c5.conn_is_active, "Client has not been blocked")
         # Wait 11 seconds to have in most fastest case atleast 11 seconds wait that greater
@@ -315,8 +316,11 @@ block_action attack drop;
         await self.start_all_services(client=False)
         for cl in [c1, c2, c3]:
             cl.start()
-            # The last connection triggers block by concurrent_tcp_connections.
-            await cl.wait_for_connection_open()
+
+        # The last connection triggers block by concurrent_tcp_connections.
+        await c1.wait_for_connection_open()
+        await c2.wait_for_connection_open()
+        await c3.wait_for_connection_close()
 
         # Blocking is off: clients with the same IPs
         # handled separately

--- a/tests/frang/test_request_rate_burst.py
+++ b/tests/frang/test_request_rate_burst.py
@@ -135,13 +135,11 @@ tls_certificate_key ${tempesta_workdir}/tempesta.key;
         c1.start()
         c2.start()
 
-    async def do_requests(self, c1, c2, request_cnt_1: int, request_cnt_2: int):
+    def do_requests(self, c1, c2, request_cnt_1: int, request_cnt_2: int):
         for _ in range(request_cnt_1):
             c1.make_request(self.request)
         for _ in range(request_cnt_2):
             c2.make_request(self.request)
-        await c1.wait_for_response(10, strict=True)
-        await c2.wait_for_response(10, strict=True)
 
     @marks.retry_if_not_conditions
     async def test_two_clients_two_ip(self):
@@ -157,7 +155,9 @@ tls_certificate_key ${tempesta_workdir}/tempesta.key;
         await self.arrange(c1, c2)
 
         start_time = time.monotonic()
-        await self.do_requests(c1, c2, request_cnt_1=4, request_cnt_2=8)
+        self.do_requests(c1, c2, request_cnt_1=4, request_cnt_2=8)
+        await c1.wait_for_response(timeout=10)
+        await c2.wait_for_connection_close(timeout=10)
         end_time = time.monotonic()
 
         if end_time - start_time > self.delay:
@@ -189,7 +189,9 @@ tls_certificate_key ${tempesta_workdir}/tempesta.key;
         await self.arrange(c1, c2)
 
         start_time = time.monotonic()
-        await self.do_requests(c1, c2, request_cnt_1=4, request_cnt_2=4)
+        self.do_requests(c1, c2, request_cnt_1=4, request_cnt_2=4)
+        await c1.wait_for_connection_close(timeout=10)
+        await c2.wait_for_connection_close(timeout=10)
         end_time = time.monotonic()
 
         if end_time - start_time > self.delay:
@@ -234,13 +236,28 @@ class TestFrangRequestRateBurst(FrangTestCase):
 
     @marks.Parameterize.expand(
         [
-            marks.Param(name="burst_reached", req_n=10, warns_expected=range(1, 15)),
-            marks.Param(name="burst_without_reaching_the_limit", req_n=3, warns_expected=0),
-            marks.Param(name="burst_on_the_limit", req_n=5, warns_expected=0),
+            marks.Param(
+                name="burst_reached",
+                req_n=10,
+                warns_expected=range(1, 15),
+                client_wait_method="wait_for_connection_close",
+            ),
+            marks.Param(
+                name="burst_without_reaching_the_limit",
+                req_n=3,
+                warns_expected=0,
+                client_wait_method="wait_for_response",
+            ),
+            marks.Param(
+                name="burst_on_the_limit",
+                req_n=5,
+                warns_expected=0,
+                client_wait_method="wait_for_response",
+            ),
         ]
     )
     @marks.retry_if_not_conditions
-    async def test_request(self, name, req_n: int, warns_expected):
+    async def test_request(self, name, req_n: int, warns_expected, client_wait_method):
         """
         Send several requests, if number of requests
         is more than 5 some of them will be blocked.
@@ -254,30 +271,41 @@ class TestFrangRequestRateBurst(FrangTestCase):
         start_time = time.monotonic()
         for _ in range(req_n):
             client.make_request(client.create_request(method="GET", uri="/", headers=[]))
-        self.assertIn(
-            await client.wait_for_response(),
-            [True, None],
-            "The client didn't get responses or connection block.",
+        await getattr(client, client_wait_method)(
+            msg="The client didn't get responses or connection block."
         )
         end_time = time.monotonic()
 
         if end_time - start_time > DELAY:
             raise error.TestConditionsAreNotCompleted(self.id())
 
-        if warns_expected:
-            self.assertTrue(await client.wait_for_connection_close())
         await self.assertFrangWarning(warning=ERROR_MSG_BURST, expected=warns_expected)
         await self.assertFrangWarning(warning=ERROR_MSG_RATE, expected=0)
 
     @marks.Parameterize.expand(
         [
-            marks.Param(name="rate_reached", req_n=10, warns_expected=range(1, 15)),
-            marks.Param(name="rate_without_reaching_the_limit", req_n=3, warns_expected=0),
-            marks.Param(name="rate_on_the_limit", req_n=5, warns_expected=0),
+            marks.Param(
+                name="rate_reached",
+                req_n=10,
+                warns_expected=range(1, 15),
+                client_wait_method="wait_for_connection_close",
+            ),
+            marks.Param(
+                name="rate_without_reaching_the_limit",
+                req_n=3,
+                warns_expected=0,
+                client_wait_method="wait_for_response",
+            ),
+            marks.Param(
+                name="rate_on_the_limit",
+                req_n=5,
+                warns_expected=0,
+                client_wait_method="wait_for_response",
+            ),
         ]
     )
     @marks.retry_if_not_conditions
-    async def test_request(self, name, req_n: int, warns_expected):
+    async def test_request(self, name, req_n: int, warns_expected, client_wait_method):
         """
         Send several requests, if number of requests
         is more than 5 some of them will be blocked.
@@ -291,10 +319,8 @@ class TestFrangRequestRateBurst(FrangTestCase):
         start_time = time.monotonic()
         for _ in range(req_n):
             client.make_request(client.create_request(method="GET", uri="/", headers=[]))
-        self.assertIn(
-            await client.wait_for_response(),
-            [True, None],
-            "The client didn't get responses or connection block.",
+        await getattr(client, client_wait_method)(
+            msg="The client didn't get responses or connection block."
         )
         end_time = time.monotonic()
 
@@ -303,5 +329,3 @@ class TestFrangRequestRateBurst(FrangTestCase):
 
         await self.assertFrangWarning(warning=ERROR_MSG_RATE, expected=warns_expected)
         await self.assertFrangWarning(warning=ERROR_MSG_BURST, expected=0)
-        if warns_expected:
-            self.assertTrue(client.connection_is_closed)

--- a/tests/health_monitoring/test_health_monitor.py
+++ b/tests/health_monitoring/test_health_monitor.py
@@ -644,17 +644,17 @@ class TestHmCrc(tester.TempestaTest):
         server.set_response(self.build_response(self.content[0]))
         # step 1
         if self.auto_mode:
-            self.assertTrue(await server.wait_for_requests(n, timeout=12))
+            await server.wait_for_requests(n, timeout=12)
             n += 1
 
         # step 2
-        self.assertTrue(await server.wait_for_requests(n, timeout=12))
+        await server.wait_for_requests(n, timeout=12)
         n += 1
         self.assertFalse(await self.klog.find(warning))
 
         # step 3
         server.set_response(self.build_response(self.content[1]))
-        self.assertTrue(await server.wait_for_requests(n, timeout=12))
+        await server.wait_for_requests(n, timeout=12)
         self.assertTrue(await self.klog.find(warning))
 
 
@@ -717,14 +717,13 @@ class H2HmResponsesPipelined(H2ResponsesPipelinedBase):
         clients = self.get_clients()
         for client, i in zip(clients, list(range(1, 5))):
             if i == hm_num:
-                self.assertTrue(
-                    await srv.wait_for_requests(i),
-                    "Server did not receive hm request from TempestaFW.",
+                await srv.wait_for_requests(
+                    i, msg="Server did not receive hm request from TempestaFW."
                 )
                 i = i + 1
             client.make_request(self.get_request)
-            self.assertTrue(await srv.wait_for_requests(i))
+            await srv.wait_for_requests(i)
 
         for client in clients:
-            self.assertTrue(await client.wait_for_response())
+            await client.wait_for_response()
             self.assertEqual(client.last_response.status, "200")

--- a/tests/http2_general/helpers.py
+++ b/tests/http2_general/helpers.py
@@ -87,9 +87,8 @@ class H2Base(tester.TempestaTest):
         client.send_bytes(client.h2_connection.data_to_send())
         client.h2_connection.clear_outbound_data_buffer()
 
-        self.assertTrue(
-            await client.wait_for_ack_settings(),
-            "Tempesta foes not returns SETTINGS frame with ACK flag.",
+        await client.wait_for_ack_settings(
+            msg="Tempesta foes not returns SETTINGS frame with ACK flag."
         )
 
 
@@ -165,7 +164,6 @@ class BlockActionH2Base(H2Base, asserts.Sniffer):
         client.update_initial_settings(initial_window_size=self.INITIAL_WINDOW_SIZE)
         client.send_bytes(client.h2_connection.data_to_send())
         client.h2_connection.clear_outbound_data_buffer()
-        self.assertTrue(
-            await client.wait_for_ack_settings(),
-            "Tempesta does not returns SETTINGS frame with ACK flag.",
+        await client.wait_for_ack_settings(
+            msg="Tempesta does not returns SETTINGS frame with ACK flag."
         )

--- a/tests/http2_general/test_flow_control_window.py
+++ b/tests/http2_general/test_flow_control_window.py
@@ -31,7 +31,7 @@ class TestFlowControl(H2Base, asserts.Sniffer):
     async def _wait_data_frame_and_check_response(
         self, client, response_body: str, valid_req_num: int
     ):
-        await client.wait_for_response(strict=True, n=valid_req_num)
+        await client.wait_for_response(n=valid_req_num)
 
         self.assertEqual(client.last_response.status, "200", "Status code mismatch.")
         self.assertEqual(
@@ -83,7 +83,7 @@ class TestFlowControl(H2Base, asserts.Sniffer):
         client, server = await self._initiate_client_and_server(response=(response_str))
 
         client.make_request(self.get_request)
-        self.assertTrue(await client.wait_for_headers_frame(stream_id=1))
+        await client.wait_for_headers_frame(stream_id=1)
 
         # client send WindowUpdate with 1k flow control window
         client.increment_flow_control_window(stream_id=1, flow_controlled_length=1000)
@@ -118,7 +118,7 @@ class TestFlowControl(H2Base, asserts.Sniffer):
 
         # send request and wait for an only HEADERS frame for stream 1
         client.make_request(self.get_request)
-        self.assertTrue(await client.wait_for_headers_frame(stream_id=1))
+        await client.wait_for_headers_frame(stream_id=1)
 
         server.set_response(
             "HTTP/1.1 200 OK\r\n"
@@ -130,7 +130,7 @@ class TestFlowControl(H2Base, asserts.Sniffer):
 
         # send request and wait for an only HEADERS frame for stream 3
         client.make_request(self.get_request)
-        self.assertTrue(await client.wait_for_headers_frame(stream_id=3))
+        await client.wait_for_headers_frame(stream_id=3)
 
         # send WindowUpdate for stream 1 and wait for a DATA frame for it
         client.increment_flow_control_window(stream_id=1, flow_controlled_length=14)
@@ -164,7 +164,7 @@ class TestFlowControl(H2Base, asserts.Sniffer):
 
         # send request and wait for a HEADERS + CONTINUATION frames
         client.make_request(self.get_request)
-        self.assertTrue(await client.wait_for_headers_frame(stream_id=1))
+        await client.wait_for_headers_frame(stream_id=1)
 
         client.increment_flow_control_window(stream_id=1, flow_controlled_length=100)
         await self._wait_data_frame_and_check_response(
@@ -191,12 +191,11 @@ class TestFlowControl(H2Base, asserts.Sniffer):
         )
 
         client.make_request(self.get_request)
-        self.assertTrue(await client.wait_for_headers_frame(stream_id=1))
+        await client.wait_for_headers_frame(stream_id=1)
 
         client.send_settings_frame(header_table_size=2048)
-        self.assertTrue(
-            await client.wait_for_ack_settings(),
-            "Tempesta did not forward the SETTINGS frame when the window size is 0.",
+        await client.wait_for_ack_settings(
+            msg="Tempesta did not forward the SETTINGS frame when the window size is 0."
         )
 
         client.increment_flow_control_window(stream_id=1, flow_controlled_length=100)
@@ -222,14 +221,14 @@ class TestFlowControl(H2Base, asserts.Sniffer):
         )
 
         client.make_request(self.get_request)
-        self.assertTrue(await client.wait_for_headers_frame(stream_id=1))
+        await client.wait_for_headers_frame(stream_id=1)
 
         # send DATA frame for GET request and wait for RST_STREAM
         client.send_bytes(DataFrame(stream_id=1, data=b"123", flags=["END_STREAM"]).serialize())
 
-        self.assertTrue(
-            await client.wait_for_reset_stream(stream_id=1),
-            "Tempesta did not forward the RST_STREAM frame when a window size is 0.",
+        await client.wait_for_reset_stream(
+            stream_id=1,
+            msg="Tempesta did not forward the RST_STREAM frame when a window size is 0.",
         )
         self.assertFalse(
             client.connection_is_closed,
@@ -257,16 +256,15 @@ class TestFlowControl(H2Base, asserts.Sniffer):
         )
 
         client.make_request(self.get_request)
-        self.assertTrue(await client.wait_for_headers_frame(stream_id=1))
+        await client.wait_for_headers_frame(stream_id=1)
         # Client send DATA frame with stream id 0.
         # Tempesta MUST return GOAWAY frame with PROTOCOL_ERROR
         client.send_bytes(b"\x00\x00\x03\x00\x01\x00\x00\x00\x00123")
 
-        self.assertTrue(
-            await client.wait_for_connection_close(),
-            "Tempesta did not close connection when sending "
-            "the GOAWAY frame with a window size is 0.",
+        await client.wait_for_connection_close(
+            msg="Tempesta did not close connection when sending the GOAWAY frame with a window size is 0."
         )
+
         client.assert_error_code(
             expected_error_code=ErrorCodes.PROTOCOL_ERROR,
             msg="Tempesta did not forward the GOAWAY frame when a window size is 0.",

--- a/tests/http2_general/test_h2_block_action.py
+++ b/tests/http2_general/test_h2_block_action.py
@@ -44,7 +44,7 @@ class TestBlockActionH2(BlockActionH2Base):
         self.check_fin_and_rst_in_sniffer(sniffer, clients)
 
     async def check_last_error_response(self, client, expected_status_code, expected_goaway_code):
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
         if self.INITIAL_WINDOW_SIZE > len(self.ERROR_RESPONSE_BODY):
             self.assertEqual(client.last_response.status, expected_status_code)
             self.assertEqual(client.last_response.body, self.ERROR_RESPONSE_BODY)
@@ -186,7 +186,7 @@ class TestBlockActionH2Drop(BlockActionH2Base):
             ],
         )
 
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
         self.assertIsNone(client.last_response)
 
         self.check_rst_no_fin_in_sniffer(sniffer, [client])
@@ -207,7 +207,7 @@ class TestBlockActionH2Drop(BlockActionH2Base):
             end_stream=False,
         )
 
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
         self.assertIsNone(client.last_response)
 
         self.check_rst_no_fin_in_sniffer(sniffer, [client])

--- a/tests/http2_general/test_h2_frame.py
+++ b/tests/http2_general/test_h2_frame.py
@@ -69,7 +69,7 @@ class TestH2Frame(H2Base):
         deproxy_cl.send_bytes(DataFrame(stream_id=1, data=b"").serialize(), expect_response=False)
         deproxy_cl.send_bytes(DataFrame(stream_id=1, data=b"").serialize(), expect_response=False)
 
-        self.assertTrue(await deproxy_cl.wait_for_connection_close(timeout=5))
+        await deproxy_cl.wait_for_connection_close(timeout=5)
         deproxy_cl.assert_error_code(expected_error_code=ErrorCodes.PROTOCOL_ERROR)
 
     async def test_empty_data_frame(self):
@@ -89,7 +89,7 @@ class TestH2Frame(H2Base):
         deproxy_cl.make_request(request=self.post_request, end_stream=False)
         deproxy_cl.send_bytes(DataFrame(stream_id=1, data=b"").serialize())
 
-        self.assertTrue(await deproxy_cl.wait_for_connection_close(timeout=5))
+        await deproxy_cl.wait_for_connection_close(timeout=5)
         deproxy_cl.assert_error_code(expected_error_code=ErrorCodes.PROTOCOL_ERROR)
 
     async def test_opening_same_stream_after_invalid(self):
@@ -126,8 +126,8 @@ class TestH2Frame(H2Base):
         )
 
         deproxy_cl.send_bytes(hf_bad.serialize() + hf_good.serialize())
-        self.assertTrue(await deproxy_cl.wait_for_reset_stream(stream.stream_id))
-        self.assertTrue(await deproxy_cl.wait_for_connection_close())
+        await deproxy_cl.wait_for_reset_stream(stream.stream_id)
+        await deproxy_cl.wait_for_connection_close()
 
     async def test_multiple_empty_headers_frames(self):
         """
@@ -158,7 +158,7 @@ class TestH2Frame(H2Base):
             deproxy_cl.send_bytes(hf_empty.serialize())
         deproxy_cl.send_bytes(hf_end.serialize(), expect_response=True)
 
-        self.assertTrue(await deproxy_cl.wait_for_connection_close(timeout=5))
+        await deproxy_cl.wait_for_connection_close(timeout=5)
         deproxy_cl.assert_error_code(expected_error_code=ErrorCodes.PROTOCOL_ERROR)
 
     @marks.Parameterize.expand(
@@ -191,7 +191,7 @@ class TestH2Frame(H2Base):
         deproxy_cl.send_bytes(hf_start.serialize())
         deproxy_cl.send_bytes(hf_empty.serialize())
 
-        self.assertTrue(await deproxy_cl.wait_for_connection_close(timeout=5))
+        await deproxy_cl.wait_for_connection_close(timeout=5)
         deproxy_cl.assert_error_code(expected_error_code=ErrorCodes.PROTOCOL_ERROR)
 
     async def test_empty_headers_empty_continuation_multiple(self):
@@ -213,7 +213,7 @@ class TestH2Frame(H2Base):
         deproxy_cl.send_bytes(cf_empty.serialize())
         deproxy_cl.send_bytes(cf_empty.serialize())
 
-        self.assertTrue(await deproxy_cl.wait_for_connection_close(timeout=5))
+        await deproxy_cl.wait_for_connection_close(timeout=5)
         deproxy_cl.assert_error_code(expected_error_code=ErrorCodes.PROTOCOL_ERROR)
 
     async def test_empty_continuation_end_headers(self):
@@ -265,7 +265,7 @@ class TestH2Frame(H2Base):
         deproxy_cl.send_bytes(cf_empty_end.serialize(), expect_response=False)
         deproxy_cl.send_bytes(df_end.serialize(), expect_response=False)
 
-        self.assertTrue(await deproxy_cl.wait_for_connection_close(timeout=5))
+        await deproxy_cl.wait_for_connection_close(timeout=5)
         deproxy_cl.assert_error_code(expected_error_code=ErrorCodes.PROTOCOL_ERROR)
 
     async def test_settings_frame(self):
@@ -301,7 +301,7 @@ class TestH2Frame(H2Base):
         # send preamble + settings frame
         client.send_bytes(client.h2_connection.data_to_send())
         client.h2_connection.clear_outbound_data_buffer()
-        self.assertTrue(await client.wait_for_ack_settings())
+        await client.wait_for_ack_settings()
 
         # send WindowUpdate frame with window size increment = 5000
         client.h2_connection.increment_flow_control_window(5000)
@@ -414,9 +414,8 @@ class TestH2Frame(H2Base):
         # send RST_STREAM with id 0
         client.send_bytes(b"\x00\x00\x04\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00")
 
-        self.assertTrue(
-            await client.wait_for_connection_close(),
-            "Tempesta did not close connection after receiving RST_STREAM with id 0.",
+        await client.wait_for_connection_close(
+            msg="Tempesta did not close connection after receiving RST_STREAM with id 0."
         )
         client.assert_error_code(expected_error_code=ErrorCodes.PROTOCOL_ERROR)
 
@@ -448,9 +447,7 @@ class TestH2Frame(H2Base):
         # Tempesta MUST return GOAWAY frame with PROTOCOL_ERROR
         client.send_bytes(b"\x00\x00\x03\x00\x01\x00\x00\x00\x00asd")
 
-        self.assertTrue(
-            await client.wait_for_connection_close(), "Tempesta did not send GOAWAY frame."
-        )
+        await client.wait_for_connection_close(msg="Tempesta did not send GOAWAY frame.")
         client.assert_error_code(expected_error_code=ErrorCodes.PROTOCOL_ERROR)
         self.assertEqual(
             client.last_stream_id,
@@ -487,9 +484,8 @@ class TestH2Frame(H2Base):
             client.stream_id = stream_id
             client.make_request(request="asd", end_stream=True)
 
-        self.assertTrue(
-            await client.wait_for_response(),
-            "Tempesta closed connection after receiving GOAWAY frame.",
+        await client.wait_for_response(
+            msg="Tempesta closed connection after receiving GOAWAY frame."
         )
 
     async def test_trailer_header_frame_without_end_stream(self):
@@ -509,13 +505,13 @@ class TestH2Frame(H2Base):
         )
         client.send_bytes(data=hf.serialize(), expect_response=False)
 
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
         client.assert_error_code(expected_error_code=ErrorCodes.PROTOCOL_ERROR)
 
     async def __assert_test(self, client, request_body: str, request_number: int):
         server = self.get_server("deproxy")
 
-        self.assertTrue(await client.wait_for_response(timeout=5))
+        await client.wait_for_response(timeout=5)
         self.assertEqual(client.last_response.status, "200")
         self.assertEqual(len(server.requests), request_number)
         checks.check_tempesta_request_and_response_stats(
@@ -631,7 +627,7 @@ class TestH2FrameEnabledDisabledTsoGroGso(TestH2FrameEnabledDisabledTsoGroGsoBas
                 ).serialize(),
                 expect_response=False,
             )
-        self.assertTrue(await client.wait_for_response(timeout, n=count))
+        await client.wait_for_response(timeout, n=count)
         self.assertFalse(client.connection_is_closed)
 
         for i in range(count):
@@ -829,7 +825,7 @@ class TestPostponedFrames(H2Base):
         )
         client.update_initial_settings(initial_window_size=0)
         client.send_bytes(client.h2_connection.data_to_send())
-        self.assertTrue(await client.wait_for_ack_settings())
+        await client.wait_for_ack_settings()
 
         ping_count = 500
 
@@ -838,17 +834,17 @@ class TestPostponedFrames(H2Base):
         for _ in range(0, ping_count):
             client.send_ping()
 
-        self.assertTrue(await client.wait_for_headers_frame(stream_id))
-        self.assertTrue(await client.wait_for_ping_frames(ping_count))
+        await client.wait_for_headers_frame(stream_id)
+        await client.wait_for_ping_frames(ping_count)
 
         client.send_settings_frame(initial_window_size=65535)
-        self.assertTrue(await client.wait_for_ack_settings())
+        await client.wait_for_ack_settings()
 
         for _ in range(0, ping_count):
             client.send_ping()
 
-        self.assertTrue(await client.wait_for_headers_frame(stream_id))
-        self.assertTrue(await client.wait_for_ping_frames(2 * ping_count))
+        await client.wait_for_headers_frame(stream_id)
+        await client.wait_for_ping_frames(2 * ping_count)
 
-        self.assertTrue(await client.wait_for_response())
+        await client.wait_for_response()
         self.assertTrue(client.last_response.status, "200")

--- a/tests/http2_general/test_h2_headers.py
+++ b/tests/http2_general/test_h2_headers.py
@@ -262,7 +262,7 @@ sticky {
                 expected_status_code=expected_status_code,
             )
             if expected_status_code != "200":
-                self.assertTrue(await client.wait_for_connection_close())
+                await client.wait_for_connection_close()
                 break
 
 
@@ -298,7 +298,7 @@ class DuplicateSingularHeader(H2Base):
             data=b"\x00\x00\x14\x01\x05\x00\x00\x00\x03\xbf\x84\x87\x82\xbe@\x07referer\x05test1",
             expect_response=True,
         )
-        self.assertTrue(await client.wait_for_response())
+        await client.wait_for_response()
         self.assertEqual(client.last_response.status, "400")
 
     async def test_header_from_static_table_and_dynamic_table(self):
@@ -440,7 +440,7 @@ class TestPseudoHeaders(H2Base):
             "400",
         )
 
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
 
 
 class TestIncorrectIfModifiedSince(H2Base):
@@ -570,7 +570,7 @@ class TestConnectionHeaders(H2Base):
         client.parsing = False
 
         await client.send_request(self.post_request + [header], "400")
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
 
     async def __test_response(self, header: tuple):
         """
@@ -853,7 +853,7 @@ class TestTrailers(H2Base):
         )
         client.send_bytes(data=tf1.serialize(), expect_response=True)
 
-        self.assertTrue(await client.wait_for_response())
+        await client.wait_for_response()
         self.assertEqual(
             expected_status_code, client.last_response.status, "HTTP response code missmatch."
         )
@@ -902,9 +902,9 @@ class TestTrailers(H2Base):
                 )
                 client.send_bytes(data=tf.serialize(), expect_response=True)
 
-                self.assertTrue(await client.wait_for_response())
+                await client.wait_for_response()
                 self.assertEqual("403", client.last_response.status)
-                self.assertTrue(await client.wait_for_connection_close())
+                await client.wait_for_connection_close()
 
     async def test_trailers_with_continuation_frame_in_request(self):
         """
@@ -930,7 +930,7 @@ class TestTrailers(H2Base):
         )
         client.send_bytes(data=cf.serialize(), expect_response=True)
 
-        self.assertTrue(await client.wait_for_response())
+        await client.wait_for_response()
         self.assertEqual("200", client.last_response.status, "HTTP response code missmatch.")
 
     @marks.Parameterize.expand(
@@ -965,10 +965,10 @@ class TestTrailers(H2Base):
         client.send_bytes(data=cf.serialize(), expect_response=expected_response)
 
         if expected_response:
-            self.assertTrue(await client.wait_for_response())
+            await client.wait_for_response()
             self.assertEqual("200", client.last_response.status, "HTTP response code missmatch.")
         else:
-            self.assertTrue(await client.wait_for_connection_close(timeout=5))
+            await client.wait_for_connection_close(timeout=5)
             client.assert_error_code(expected_error_code=ErrorCodes.PROTOCOL_ERROR)
 
     async def test_trailers_with_pseudo_headers_in_request(self):
@@ -989,7 +989,7 @@ class TestTrailers(H2Base):
         )
         client.send_bytes(data=tf.serialize(), expect_response=True)
 
-        self.assertTrue(await client.wait_for_response())
+        await client.wait_for_response()
         self.assertEqual("403", client.last_response.status, "HTTP response code missmatch.")
 
     async def test_trailers_without_end_stream_in_request(self):
@@ -1011,7 +1011,7 @@ class TestTrailers(H2Base):
         )
         client.send_bytes(data=tf.serialize(), expect_response=True)
 
-        self.assertTrue(await client.wait_for_response())
+        await client.wait_for_response()
         self.assertEqual("400", client.last_response.status, "HTTP response code missmatch.")
 
     @marks.Parameterize.expand(
@@ -1199,8 +1199,8 @@ return 200;
         for line in lines:
             if line.startswith("< set-cookie:"):
                 setcookie_count += 1
-                self.assertTrue(len(line.split(",")) == 1, "Wrong separator")
-        self.assertTrue(setcookie_count == 3, "Set-Cookie headers quantity mismatch")
+                self.assertEqual(len(line.split(",")), 1, "Wrong separator")
+        self.assertEqual(setcookie_count, 3, "Set-Cookie headers quantity mismatch")
 
         self.start_all_clients()
         await self.wait_while_busy(curl)
@@ -1515,8 +1515,7 @@ class MissingDateServerWithBodyTest(tester.TempestaTest):
         deproxy_cl = self.get_client("deproxy")
         deproxy_cl.make_request(head)
 
-        resp = await deproxy_cl.wait_for_response(timeout=5)
-        self.assertTrue(resp)
+        await deproxy_cl.wait_for_response(timeout=5)
         self.assertEqual(deproxy_cl.last_response.status, "200")
 
 
@@ -1603,7 +1602,7 @@ class TestHeadersBlockedByMaxHeaderListSize(tester.TempestaTest):
             deproxy_cl.create_request(method="GET", headers=[("a", "a" * 43)]), huffman=huffman
         )
 
-        await deproxy_cl.wait_for_response(strict=True)
+        await deproxy_cl.wait_for_response()
         self.assertEqual(deproxy_cl.last_response.status, "403")
 
     @marks.Parameterize.expand(
@@ -1625,7 +1624,7 @@ class TestHeadersBlockedByMaxHeaderListSize(tester.TempestaTest):
             deproxy_cl.create_request(method="GET", headers=[("a", "a" * 42)]), huffman=huffman
         )
 
-        await deproxy_cl.wait_for_response(strict=True)
+        await deproxy_cl.wait_for_response()
         self.assertEqual(deproxy_cl.last_response.status, "200")
 
 

--- a/tests/http2_general/test_h2_hpack.py
+++ b/tests/http2_general/test_h2_hpack.py
@@ -116,7 +116,7 @@ class TestHpack(TestHpackBase):
             end_stream=True,
             huffman=False,
         )
-        self.assertTrue(await client.wait_for_response())
+        await client.wait_for_response()
         self.assertEqual(client.last_response.status, "200")
 
     async def test_settings_header_table_size(self):
@@ -246,7 +246,7 @@ class TestHpack(TestHpackBase):
             b"\x00\x00\x0c\x01\x05\x00\x00\x00\x05\x11\x86\xa0\xe4\x1d\x13\x9d\t\x84\x87\x83\xbe",
             expect_response=True,
         )
-        self.assertTrue(await client.wait_for_response())
+        await client.wait_for_response()
 
         # Last forwarded request from Tempesta MUST have second indexed header
         server = self.get_server("deproxy")
@@ -332,7 +332,7 @@ class TestHpack(TestHpackBase):
             expect_response=True,
         )
 
-        self.assertTrue(await client.wait_for_response())
+        await client.wait_for_response()
         self.assertEqual(client.last_response.status, "400", "HTTP response status codes mismatch.")
 
     async def test_clearing_dynamic_table_with_settings_frame(self):
@@ -364,10 +364,10 @@ class TestHpack(TestHpackBase):
 
         # Tempesta MUST clear dynamic table when receive SETTINGS_HEADER_TABLE_SIZE = 0
         client.send_settings_frame(header_table_size=0)
-        self.assertTrue(await client.wait_for_ack_settings())
+        await client.wait_for_ack_settings()
 
         client.send_settings_frame(header_table_size=4096)
-        self.assertTrue(await client.wait_for_ack_settings())
+        await client.wait_for_ack_settings()
 
         # Tempesta MUST saves via header in dynamic table again. Via header is indexed again.
         await client.send_request(request=self.post_request, expected_status_code="200")
@@ -601,7 +601,7 @@ class TestHpack(TestHpackBase):
             expect_response=True,
         )
 
-        self.assertTrue(await client.wait_for_response(3))
+        await client.wait_for_response(3)
         self.assertEqual(client.last_response.status, "200")
         self.assertEqual(server.last_request.method, "GET")
 
@@ -675,11 +675,11 @@ class TestHpackMethod(TestHpackBase):
 
             # send request two times, header :method must be processed from dynamyc table
             client.make_request(request=request, huffman=huffman)
-            self.assertTrue(await client.wait_for_response(timeout=5))
+            await client.wait_for_response(timeout=5)
             self.assertEqual(server.last_request.method, method)
 
             client.make_request(request=request, huffman=huffman)
-            self.assertTrue(await client.wait_for_response(timeout=5))
+            await client.wait_for_response(timeout=5)
             self.assertEqual(server.last_request.method, method)
             self.assertEqual(2 * (count + 1), len(server.requests))
 
@@ -723,11 +723,11 @@ class TestHpackMethod(TestHpackBase):
 
             # send request two times, header :method must be processed from dynamyc table
             client.make_request(request=request, huffman=huffman)
-            self.assertTrue(await client.wait_for_response(timeout=5))
+            await client.wait_for_response(timeout=5)
             self.assertEqual(server.last_request.method, method)
 
             client.make_request(request=request, huffman=huffman)
-            self.assertTrue(await client.wait_for_response(timeout=5))
+            await client.wait_for_response(timeout=5)
             self.assertEqual(server.last_request.method, method)
             self.assertEqual(2 * (count + 1), len(server.requests))
 
@@ -969,13 +969,13 @@ class TestFramePayloadLength(H2Base):
             b"\x00\x00\x05\x01\x05\x00\x00\x00\x03\xbf\x84\x87\x82\xbe\xbe\xbe\xbe",
             expect_response=True,
         )
-        await client.wait_for_response(strict=True)
+        await client.wait_for_response()
 
         client.stream_id += 2
         client.make_request(self.get_request)
 
         # Client will be blocked because Tempesta received extra bytes
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
         client.assert_error_code(expected_error_code=ErrorCodes.FRAME_SIZE_ERROR)
 
     async def test_large_frame_payload_length(self):
@@ -997,7 +997,7 @@ class TestFramePayloadLength(H2Base):
         client.stream_id += 2
         await client.send_request(self.get_request, "400")
 
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
         client.assert_error_code(expected_error_code=ErrorCodes.COMPRESSION_ERROR)
 
     async def test_invalid_data(self):
@@ -1011,10 +1011,10 @@ class TestFramePayloadLength(H2Base):
         # send headers frame with stream_id = 1, header count = 3
         # and headers bytes - \x09\x02\x00 (invalid bytes)
         client.send_bytes(b"\x00\x00\x03\x01\x05\x00\x00\x00\x01\x09\x02\x00", expect_response=True)
-        await client.wait_for_response(strict=True)
+        await client.wait_for_response()
 
         self.assertEqual(client.last_response.status, "400")
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
 
 
 SIZE_BYTES = encode_integer(10, 5)
@@ -1070,10 +1070,10 @@ class TestHpackTableSizeEncodedInInvalidPlace(TestHpackBase):
         client.send_bytes(
             client.h2_connection.data_to_send() + frame.serialize(), expect_response=True
         )
-        self.assertTrue(await client.wait_for_response())
+        await client.wait_for_response()
         self.assertEqual(client.last_response.status, expected_status_code)
         if expected_status_code != "200":
-            self.assertTrue(await client.wait_for_connection_close())
+            await client.wait_for_connection_close()
             client.assert_error_code(expected_error_code=ErrorCodes.COMPRESSION_ERROR)
 
 
@@ -1139,9 +1139,9 @@ class TestHpackBomb(TestHpackBase):
                 )
 
                 client.send_bytes(data=attack_frame.serialize(), expect_response=True)
-                self.assertTrue(await client.wait_for_response())
+                await client.wait_for_response()
                 self.assertEqual(client.last_response.status, "403")
-                self.assertTrue(await client.wait_for_connection_close())
+                await client.wait_for_connection_close()
                 client.assert_error_code(expected_error_code=ErrorCodes.PROTOCOL_ERROR)
 
 
@@ -1388,7 +1388,7 @@ class TestLoadingHeadersFromHpackDynamicTable(H2Base):
         )
         client.send_bytes(data=hf.serialize(), expect_response=True)
 
-        self.assertTrue(await client.wait_for_response())
+        await client.wait_for_response()
         self.assertEqual(client.last_response.status, expected_status_code)
 
         client.stream_id += 2

--- a/tests/http2_general/test_h2_max_frame_size.py
+++ b/tests/http2_general/test_h2_max_frame_size.py
@@ -78,7 +78,7 @@ class TestMaxFrameSize(H2Base):
         client.make_request(
             request=self.post_request + [("qwerty", "x" * 17000)], end_stream=True, huffman=False
         )
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
 
     async def test_data_frame_is_large_than_max_frame_size(self):
         """
@@ -98,4 +98,4 @@ class TestMaxFrameSize(H2Base):
         client.make_request(
             request=(self.post_request, "x" * 18000), end_stream=True, huffman=False
         )
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()

--- a/tests/http2_general/test_h2_responses.py
+++ b/tests/http2_general/test_h2_responses.py
@@ -208,11 +208,11 @@ class TestH2ResponsesPipelined(H2ResponsesPipelinedBase):
         for client in clients:
             client.make_request(self.get_request)
 
-        self.assertTrue(await srv.wait_for_requests(3))
+        await srv.wait_for_requests(3)
 
         self.assertEqual(len(srv.requests), 3)
         for client in clients:
-            self.assertTrue(await client.wait_for_response())
+            await client.wait_for_response()
             self.assertEqual(client.last_response.status, "200")
 
     @marks.Parameterize.expand(
@@ -243,11 +243,11 @@ class TestH2ResponsesPipelined(H2ResponsesPipelinedBase):
         for client, response, i in zip(clients, response_list, list(range(1, 4))):
             srv.set_response(response)
             client.make_request(self.get_request)
-            self.assertTrue(await srv.wait_for_requests(i))
+            await srv.wait_for_requests(i)
 
         for client, expected_status in zip(clients, expected_response_statuses):
             if expected_status:
-                self.assertTrue(await client.wait_for_response())
+                await client.wait_for_response()
                 self.assertEqual(client.last_response.status, expected_status)
             else:
                 self.assertFalse(client.last_response)
@@ -263,7 +263,7 @@ class TestH2ResponsesPipelined(H2ResponsesPipelinedBase):
         for client, expected_status in zip(clients, expected_response_statuses):
             if not expected_status:
                 i = i + 1
-                self.assertTrue(await srv.wait_for_requests(req_count + i))
+                await srv.wait_for_requests(req_count + i)
                 srv.flush()
-                self.assertTrue(await client.wait_for_response())
+                await client.wait_for_response()
                 self.assertEqual(client.last_response.status, "200")

--- a/tests/http2_general/test_h2_stream_priority.py
+++ b/tests/http2_general/test_h2_stream_priority.py
@@ -74,11 +74,11 @@ class TestPriorityBase(H2Base):
         if stream_id_list:
             for stream_id in stream_id_list:
                 await client.wait_for_headers_frame(
-                    stream_id, timeout=15 if run_config.TCP_SEGMENTATION else 5
+                    stream_id, timeout=60 if run_config.TCP_SEGMENTATION else 5
                 )
         client.send_settings_frame(initial_window_size=initial_window_size)
         await client.wait_for_ack_settings()
-        self.assertTrue(await client.wait_for_response(timeout=timeout))
+        await client.wait_for_response(timeout=timeout)
 
     def check_response_sequence(self, client, expected_length, expected_sequence=None):
         self.assertEqual(len(client.responses), len(client.response_sequence))
@@ -649,7 +649,7 @@ class TestMaxConcurrentStreams(TestPriorityBase):
         for i in range(0, self.max_concurrent_streams):
             stream_id = client.stream_id
             client.make_request(self.post_request)
-            self.assertTrue(await client.wait_for_reset_stream(stream_id=stream_id))
+            await client.wait_for_reset_stream(stream_id=stream_id)
 
         return client
 
@@ -681,7 +681,7 @@ class TestMaxConcurrentStreams(TestPriorityBase):
         """
         client, server = await self.setup_test_priority(initial_window_size=1000)
 
-        self.assertTrue(self.max_concurrent_streams == 10)
+        self.assertEqual(self.max_concurrent_streams, 10)
         for i in range(0, self.max_concurrent_streams - 1):
             client.make_request(self.post_request)
 
@@ -698,5 +698,5 @@ class TestMaxConcurrentStreams(TestPriorityBase):
 
         # Here we should wait for a long time since initial_window_size is small, and connection
         # will be closed after all pending data will be send.
-        self.assertTrue(await client.wait_for_connection_close(timeout=10))
+        await client.wait_for_connection_close(timeout=10)
         client.assert_error_code(expected_error_code=ErrorCodes.PROTOCOL_ERROR)

--- a/tests/http2_general/test_h2_stream_states.py
+++ b/tests/http2_general/test_h2_stream_states.py
@@ -96,7 +96,7 @@ class TestLocHalfClosedStreamState(H2Base):
             expect_response=True,
         )
 
-        self.assertTrue(await client.wait_for_reset_stream(stream_id=stream.stream_id))
+        await client.wait_for_reset_stream(stream_id=stream.stream_id)
         # If error message found test fails.
         self.assertFalse(
             await klog.find(self.PARSER_WARN), "Frame is passed to parser in a CLOSED state."
@@ -135,12 +135,12 @@ class TestHalfClosedStreamStateUnexpectedFrames(H2Base):
         # When Tempesta receive RST STREAM frame, it immediately
         # close and delete stream
         if not isinstance(frame, RstStreamFrame):
-            self.assertTrue(await client.wait_for_reset_stream(stream_id=1))
+            await client.wait_for_reset_stream(stream_id=1)
 
         client.stream_id += 2
         client.make_request(self.get_request)
-        await client.wait_for_response(strict=True, n=1)
-        self.assertTrue(client.last_response.status, "200")
+        await client.wait_for_response(n=1)
+        self.assertEqual(client.last_response.status, "200")
 
     async def test_priority_frame_in_half_closed_state(self):
         await self.__base_scenario(frame=PriorityFrame(stream_id=1))
@@ -178,14 +178,14 @@ class TestHalfClosedStreamStateWindowUpdate(H2Base):
         await client.wait_for_ack_settings()
 
         client.make_request(self.post_request)
-        self.assertFalse(await client.wait_for_response(2))
+        await client.wait_for_headers_frame(stream_id=1)
 
         client.h2_connection.increment_flow_control_window(2000)
         client.h2_connection.increment_flow_control_window(2000, stream_id=1)
         client.send_bytes(client.h2_connection.data_to_send())
         client.h2_connection.clear_outbound_data_buffer()
 
-        self.assertTrue(await client.wait_for_response(2))
+        await client.wait_for_response(2)
         self.assertEqual(client.last_response.status, "200")
         self.assertEqual(
             len(client.last_response.body), 2000, "Tempesta did not return full response body."
@@ -251,7 +251,7 @@ class TestStreamState(H2Base):
             flags=["END_HEADERS", "END_STREAM"],
         )
         client.send_bytes(data=hf.serialize(), expect_response=False)
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
         client.assert_error_code(expected_error_code=ErrorCodes.PROTOCOL_ERROR)
 
     async def test_headers_frame_for_other_stream_between_header_blocks(self):
@@ -271,7 +271,7 @@ class TestStreamState(H2Base):
             flags=["END_HEADERS", "END_STREAM"],
         )
         client.send_bytes(data=hf.serialize(), expect_response=False)
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
         client.assert_error_code(expected_error_code=ErrorCodes.PROTOCOL_ERROR)
 
     async def test_headers_frame_for_other_stream_after_rst(self):
@@ -284,7 +284,7 @@ class TestStreamState(H2Base):
         client.send_bytes(hf.serialize())
         client.stream_id = 3
         client.make_request(self.post_request)
-        self.assertTrue(await client.wait_for_response())
+        await client.wait_for_response()
         self.assertEqual(client.last_response.status, "200")
         self.assertEqual(
             len(client.last_response.body), 2000, "Tempesta did not return full response body."
@@ -296,7 +296,7 @@ class TestStreamState(H2Base):
         but have error during processing request.
         """
         client = await self.__setup(self.post_request + [("BAD", "BAD")], True)
-        self.assertTrue(await client.wait_for_response())
+        await client.wait_for_response()
         self.assertEqual(client.last_response.status, "400")
 
 
@@ -327,7 +327,7 @@ class TestTwoHeadersFramesFirstWithoutEndStream(H2Base):
 
         client.stream_id = 3
         client.make_request(self.post_request)
-        self.assertTrue(await client.wait_for_response())
+        await client.wait_for_response()
         self.assertEqual(client.last_response.status, "200")
         self.assertEqual(
             len(client.last_response.body), 2000, "Tempesta did not return full response body."
@@ -335,7 +335,7 @@ class TestTwoHeadersFramesFirstWithoutEndStream(H2Base):
 
         client.stream_id = 1
         client.make_request([("header", "x" * 320)])
-        self.assertTrue(await client.wait_for_response())
+        await client.wait_for_response()
         self.assertEqual(client.last_response.status, "200")
         self.assertEqual(
             len(client.last_response.body), 2000, "Tempesta did not return full response body."
@@ -343,7 +343,7 @@ class TestTwoHeadersFramesFirstWithoutEndStream(H2Base):
 
         client.stream_id = 5
         client.make_request(self.post_request)
-        self.assertTrue(await client.wait_for_response())
+        await client.wait_for_response()
         self.assertEqual(client.last_response.status, "200")
         self.assertEqual(
             len(client.last_response.body), 2000, "Tempesta did not return full response body."
@@ -402,7 +402,7 @@ class TestIdleState(H2Base):
             ).serialize()
         )
 
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
         client.assert_error_code(expected_error_code=ErrorCodes.PROTOCOL_ERROR)
 
     async def test_not_closing_idle_stream(self):
@@ -458,5 +458,5 @@ class TestIdleState(H2Base):
         )
 
         client.send_bytes(pf.serialize() + hf.serialize())
-        self.assertTrue(await client.wait_for_reset_stream(stream.stream_id))
-        self.assertFalse(await client.wait_for_connection_close())
+        await client.wait_for_reset_stream(stream.stream_id)
+        self.assertFalse(client.connection_is_closed)

--- a/tests/http2_general/test_h2_streams.py
+++ b/tests/http2_general/test_h2_streams.py
@@ -36,7 +36,7 @@ class TestH2Stream(H2Base):
         client.h2_connection.remote_settings.acknowledge()
 
         client.make_request(request=self.post_request, end_stream=True)
-        self.assertTrue(await client.wait_for_reset_stream(stream_id=client.stream_id - 2))
+        await client.wait_for_reset_stream(stream_id=client.stream_id - 2)
 
         client.assert_error_code(expected_error_code=ErrorCodes.REFUSED_STREAM)
 
@@ -66,14 +66,14 @@ class TestH2Stream(H2Base):
 
         client.send_settings_frame(initial_window_size=0)
         client.h2_connection.clear_outbound_data_buffer()
-        self.assertTrue(await client.wait_for_ack_settings())
+        await client.wait_for_ack_settings()
 
         for _ in range(max_streams):
             client.make_request(self.post_request)
 
         client.send_settings_frame(initial_window_size=65536)
         client.h2_connection.clear_outbound_data_buffer()
-        self.assertTrue(await client.wait_for_ack_settings())
+        await client.wait_for_ack_settings()
 
         await client.wait_for_response()
         self.assertEqual(len(client.responses), 12)
@@ -98,7 +98,7 @@ class TestH2Stream(H2Base):
             data=b"\x00\x00\n\x01\x05\x00\x00\x00\x01A\x85\x90\xb1\x98u\x7f\x84\x87\x83",
             expect_response=True,
         )
-        await client.wait_for_connection_close(strict=True)
+        await client.wait_for_connection_close()
 
         client.assert_error_code(expected_error_code=ErrorCodes.PROTOCOL_ERROR)
 
@@ -120,7 +120,7 @@ class TestH2Stream(H2Base):
             b"\x00\x00\n\x01\x05\x00\x00\x00\x00A\x85\x90\xb1\x98u\x7f\x84\x87\x83",
             expect_response=True,
         )
-        await client.wait_for_connection_close(strict=True)
+        await client.wait_for_connection_close()
 
         client.assert_error_code(expected_error_code=ErrorCodes.PROTOCOL_ERROR)
 
@@ -140,7 +140,7 @@ class TestH2Stream(H2Base):
             b"\x00\x00\n\x01\x05\x00\x00\x00\x02A\x85\x90\xb1\x98u\x7f\x84\x87\x83",
             expect_response=True,
         )
-        await client.wait_for_connection_close(strict=True)
+        await client.wait_for_connection_close()
 
         client.assert_error_code(expected_error_code=ErrorCodes.PROTOCOL_ERROR)
 
@@ -171,7 +171,7 @@ class TestH2Stream(H2Base):
             expect_response=True,
         )
 
-        self.assertTrue(await client.wait_for_response())
+        await client.wait_for_response()
         self.assertEqual(client.last_response.status, "200")
 
 

--- a/tests/http_general/test_block_action.py
+++ b/tests/http_general/test_block_action.py
@@ -119,7 +119,7 @@ class BlockActionReply(BlockActionBase):
         receive some data on the DEAD sock.
         """
         if not run_config.TCP_SEGMENTATION:
-            self.assertTrue(await client.wait_for_response())
+            await client.wait_for_response()
             self.assertEqual(client.last_response.status, expected_status_code)
             self.assertEqual(client.last_response.body, self.ERROR_RESPONSE_BODY)
 
@@ -140,7 +140,7 @@ class BlockActionReply(BlockActionBase):
         )
         await self.check_last_error_response(client, expected_status_code="403")
 
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
         self.check_fin_no_rst_in_sniffer(sniffer, [client])
 
     @marks.Parameterize.expand(
@@ -161,7 +161,7 @@ class BlockActionReply(BlockActionBase):
         )
         self.assertEqual(client.last_response.body, self.ERROR_RESPONSE_BODY)
 
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
         self.check_fin_no_rst_in_sniffer(sniffer, [client])
 
     @marks.Parameterize.expand(
@@ -248,7 +248,7 @@ class BlockActionReply(BlockActionBase):
         )
         await self.check_last_error_response(client, expected_status_code="403")
 
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
         self.check_fin_no_rst_in_sniffer(sniffer, [client])
 
 
@@ -325,7 +325,7 @@ class BlockActionReplyWithCustomErrorPage(BlockActionBase):
         )
         self.assertEqual(client.last_response.body, self.ERROR_RESPONSE_BODY)
 
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
 
         self.check_fin_no_rst_in_sniffer(sniffer, [client])
 
@@ -353,7 +353,7 @@ class BlockActionDrop(BlockActionBase):
             request=f"GET / HTTP/1.1\r\nHost: bad.com\r\n\r\n",
         )
 
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
         self.assertIsNone(client.last_response)
 
         self.check_rst_no_fin_in_sniffer(sniffer, [client])
@@ -374,7 +374,7 @@ class BlockActionDrop(BlockActionBase):
             request=f"GET / HTTP/1.1\r\nHost:\r\n\r\n",
         )
 
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
         self.assertIsNone(client.last_response)
 
         self.check_rst_no_fin_in_sniffer(sniffer, [client])

--- a/tests/http_general/test_expect_100_continue.py
+++ b/tests/http_general/test_expect_100_continue.py
@@ -93,7 +93,7 @@ class TestExpect100ContinueBehavior(tester.TempestaTest):
             expected_status_code="100",
         )
         client.send_bytes(b"1" * 9, expect_response=True)
-        await client.wait_for_response(strict=True)
+        await client.wait_for_response()
         self.assertEqual(client.last_response.status, "200")
 
     async def test_request_pipeline_delay(self):
@@ -151,7 +151,7 @@ class TestExpect100ContinueBehavior(tester.TempestaTest):
         )
 
         client.send_bytes(b"1" * 9, expect_response=True)
-        await client.wait_for_response(strict=True)
+        await client.wait_for_response()
         self.assertEqual(client.last_response.status, "200")
         self.assertEqual(
             [int(response.status) for response in client.responses],
@@ -262,7 +262,7 @@ class TestExpect100ContinueBehavior(tester.TempestaTest):
         )
         client.send_bytes(b"{}" + request.msg.encode(), expect_response=True)
         client.methods.append("GET")
-        await client.wait_for_response(strict=True, n=4)
+        await client.wait_for_response(n=4)
         self.assertEqual(client.last_response.status, "200")
         self.assertEqual(
             [int(response.status) for response in client.responses],

--- a/tests/http_general/test_headers.py
+++ b/tests/http_general/test_headers.py
@@ -102,7 +102,7 @@ class BackendSetCoookie(tester.TempestaTest):
         ):
             with self.subTest("GET cookies", path=path):
                 client.make_request(f"GET /{path} HTTP/1.1\r\nHost: deproxy\r\n\r\n")
-                self.assertTrue(await client.wait_for_response(timeout=1))
+                await client.wait_for_response(timeout=1)
                 self.assertEqual(client.last_response.status, "200")
 
 
@@ -154,7 +154,7 @@ class RepeatedHeaderCache(tester.TempestaTest):
 
         client.make_request("GET / HTTP/1.1\r\nHost: deproxy\r\n\r\n")
 
-        self.assertTrue(await client.wait_for_response(timeout=1))
+        await client.wait_for_response(timeout=1)
         self.assertEqual(client.last_response.status, "200")
 
 
@@ -196,7 +196,7 @@ class TestSmallHeader(tester.TempestaTest):
             client.start()
             with self.subTest(header=header):
                 client.make_request(f"GET / HTTP/1.1\r\nHost: deproxy\r\n{header}: test\r\n\r\n")
-                self.assertTrue(await client.wait_for_response(timeout=1))
+                await client.wait_for_response(timeout=1)
                 self.assertEqual(client.last_response.status, "200")
             client.stop()
 

--- a/tests/http_rules/test_backup_servers.py
+++ b/tests/http_rules/test_backup_servers.py
@@ -104,7 +104,7 @@ http_chain {
         await client.send_request(request, "200")
 
         primary_server.start()
-        self.assertTrue(await primary_server.wait_for_connections(3))
+        await primary_server.wait_for_connections(3)
         await client.send_request(request, "200")
         got_requests += len(primary_server.requests)
 

--- a/tests/http_rules/test_http_tables.py
+++ b/tests/http_rules/test_http_tables.py
@@ -4,6 +4,8 @@ Set of tests to verify correctness of requests redirection in HTTP table
 (in separate tests).
 """
 
+import asyncio
+
 from framework.deproxy import deproxy_client
 from framework.helpers import dmesg, error, remote
 from framework.helpers.remote import LocalNode
@@ -213,7 +215,7 @@ class HttpTablesTest(tester.TempestaTest):
             self.assertEqual(server.last_request.headers.get(header), value)
         else:
             self.assertIsNone(server.last_request)
-            self.assertTrue(await client.wait_for_connection_close())
+            await client.wait_for_connection_close()
 
     async def test_chains(self):
         """
@@ -337,7 +339,7 @@ class HttpTablesTestBase(tester.TempestaTest, base=True):
         deproxy_cl.start()
         deproxy_cl.make_request(self.requests)
         if self.resp_status:
-            self.assertTrue(await deproxy_cl.wait_for_response())
+            await deproxy_cl.wait_for_response()
             if self.redirect_location:
                 self.assertEqual(
                     deproxy_cl.last_response.headers["location"], self.redirect_location
@@ -345,7 +347,7 @@ class HttpTablesTestBase(tester.TempestaTest, base=True):
             self.assertEqual(int(deproxy_cl.last_response.status), self.resp_status)
         else:
             self.assertFalse(await deproxy_cl.wait_for_response(0.5))
-            self.assertTrue(await deproxy_cl.wait_for_connection_close())
+            await deproxy_cl.wait_for_connection_close()
 
 
 class HttpTablesTestEmptyMainChainReply(HttpTablesTestBase):
@@ -663,16 +665,12 @@ class HttpTablesTestMarkRule(tester.TempestaTest, HttpTablesMarkSetup):
 
         client.make_request(request)
 
-        self.assertFalse(
-            await client.wait_for_response(timeout=3, strict=False, adjust_timeout=False)
-        )
+        await asyncio.sleep(3)
         self.assertFalse(client.last_response)
 
         self.del_reject_nf_mark(1)
 
-        self.assertTrue(
-            await client.wait_for_response(timeout=5, strict=False, adjust_timeout=False)
-        )
+        await client.wait_for_response(timeout=5, adjust_timeout=False)
         self.assertTrue(client.last_response.status, "200")
 
 
@@ -844,7 +842,7 @@ class HttpTablesTestMultipleCookies(tester.TempestaTest):
             await client.send_request(client.create_request(method="GET", headers=[]), "200")
         else:
             self.assertIsNone(server.last_request)
-            self.assertTrue(await client.wait_for_connection_close())
+            await client.wait_for_connection_close()
 
 
 @marks.parameterize_class(

--- a/tests/long_body/test_long_response.py
+++ b/tests/long_body/test_long_response.py
@@ -87,7 +87,7 @@ cache 0;
         client: curl_client.CurlClient = self.get_client(client_id)
         client.options = [" --raw"]
         client.start()
-        self.assertTrue(await client.wait_for_finish(timeout=100))
+        await client.wait_for_finish(timeout=100)
         client.stop()
 
         self.assertIsNotNone(client.last_response)

--- a/tests/malformed/test_h2_field_validity.py
+++ b/tests/malformed/test_h2_field_validity.py
@@ -65,10 +65,10 @@ block_action error reply;
             + header,
             huffman=False,
         )
-        self.assertTrue(await client.wait_for_response())
+        await client.wait_for_response()
         self.assertEqual("400", client.last_response.status)
 
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
         client.stop()
 
     async def test_ascii_uppercase_in_header_name(self):

--- a/tests/malformed/test_malformed_crlfs.py
+++ b/tests/malformed/test_malformed_crlfs.py
@@ -77,16 +77,14 @@ server ${server_ip}:8000 conns_n=1;
 
         deproxy_cl.make_requests(request, True)
 
-        self.assertTrue(await deproxy_cl.wait_for_response(timeout=5), "Response not received")
+        await deproxy_cl.wait_for_response(timeout=5, msg="Response not received")
 
         status = int(deproxy_cl.last_response.status)
-        self.assertTrue(
-            status == expect_status, f"Wrong status: {status}, expected: {expect_status}"
+        self.assertEqual(
+            status, expect_status, f"Wrong status: {status}, expected: {expect_status}"
         )
         if expect is None:
-            self.assertTrue(
-                deproxy_srv.last_request is None, "Request was unexpectedly sent to backend"
-            )
+            self.assertIsNone(deproxy_srv.last_request, "Request was unexpectedly sent to backend")
         elif expect:
             self.assertIn(
                 deproxy_srv.last_request.uri,

--- a/tests/malformed/test_malformed_structure.py
+++ b/tests/malformed/test_malformed_structure.py
@@ -77,7 +77,7 @@ server ${server_ip}:8000;
         await self.start_all_services()
 
         deproxy_cl.make_request("GET / HTTP/1.1\r\nHost : localhost\r\n\r\n")
-        await deproxy_cl.wait_for_response(timeout=5, strict=True)
+        await deproxy_cl.wait_for_response(timeout=5)
         self.assertEqual(deproxy_cl.last_response.status, "400")
 
     async def test_crSPlf(self):

--- a/tests/msg_sequence/test_pairing.py
+++ b/tests/msg_sequence/test_pairing.py
@@ -72,7 +72,7 @@ tls_match_any_server_name;
         for _ in range(chain_size):
             client.make_request(request)
 
-        await server.wait_for_requests(n=chain_size, strict=True)
+        await server.wait_for_requests(n=chain_size)
         client.stop()
 
         server.set_response("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")

--- a/tests/nonidempotent/test_nonidempotent.py
+++ b/tests/nonidempotent/test_nonidempotent.py
@@ -188,8 +188,7 @@ class NonIdempotentH2SchedTest(NonIdempotentH2TestBase):
         deproxy_cl = self.get_client("deproxy")
 
         self.send_requests(self.requests, deproxy_cl)
-        resp = await deproxy_cl.wait_for_response(timeout=5)
-        self.assertTrue(resp, "Response not received")
+        await deproxy_cl.wait_for_response(timeout=5)
         self.assertEqual(2, len(deproxy_cl.responses))
 
         first, second = deproxy_cl.responses
@@ -236,8 +235,7 @@ class RetryNonIdempotentH2Test(NonIdempotentH2TestBase):
 
         deproxy_cl = self.get_client("deproxy")
         self.send_requests(self.requests, deproxy_cl)
-        resp = await deproxy_cl.wait_for_response(timeout=5)
-        self.assertTrue(resp, "Response not received")
+        await deproxy_cl.wait_for_response(timeout=5)
         self.assertEqual(2, len(deproxy_cl.responses))
 
         for response in deproxy_cl.responses:
@@ -285,8 +283,7 @@ class NotRetryNonIdempotentH2Test(NonIdempotentH2TestBase):
 
         deproxy_cl = self.get_client("deproxy")
         self.send_requests(self.requests, deproxy_cl)
-        resp = await deproxy_cl.wait_for_response(timeout=5)
-        self.assertTrue(resp, "Response not received")
+        await deproxy_cl.wait_for_response(timeout=5)
         self.assertEqual(2, len(deproxy_cl.responses))
 
         statuses = []
@@ -346,8 +343,7 @@ class NonIdempotentH1SchedTest(NonIdempotentH1TestBase):
 
         deproxy_cl = self.get_client("deproxy")
         deproxy_cl.make_requests(self.requests, pipelined=True)
-        resp = await deproxy_cl.wait_for_response(timeout=5)
-        self.assertTrue(resp, "Response not received")
+        await deproxy_cl.wait_for_response(timeout=5)
         self.assertEqual(2, len(deproxy_cl.responses))
 
         first, second = deproxy_cl.responses
@@ -397,8 +393,7 @@ class RetryNonIdempotentH1Test(NonIdempotentH1TestBase):
 
         deproxy_cl = self.get_client("deproxy")
         deproxy_cl.make_requests(self.requests)
-        resp = await deproxy_cl.wait_for_response(timeout=5)
-        self.assertTrue(resp, "Response not received")
+        await deproxy_cl.wait_for_response(timeout=5)
         self.assertEqual(2, len(deproxy_cl.responses))
 
         for response in deproxy_cl.responses:
@@ -465,8 +460,7 @@ class NotRetryNonIdempotentH1Test(NonIdempotentH1TestBase):
 
         deproxy_cl = self.get_client("deproxy")
         deproxy_cl.make_requests(self.requests)
-        resp = await deproxy_cl.wait_for_response(timeout=5)
-        self.assertTrue(resp, "Response not received")
+        await deproxy_cl.wait_for_response(timeout=5)
         self.assertEqual(2, len(deproxy_cl.responses))
 
         statuses = []

--- a/tests/normalization/test_http_multipart.py
+++ b/tests/normalization/test_http_multipart.py
@@ -61,11 +61,9 @@ class ContentTypeTestBase(tester.TempestaTest):
         ):
             request = request_tmpl.format(*state)
             self.deproxy_cl.make_request(request)
-            resp = await self.deproxy_cl.wait_for_response(timeout=5)
-            self.assertTrue(resp, "Response not received")
+            await self.deproxy_cl.wait_for_response(timeout=5)
 
         for server_req in self.deproxy_srv.requests:
-            found_content_type_field = False
             val = server_req.headers["Content-Type"]
             self.assertIsNotNone(val)
             self.assertEqual(val, expected_content_type)

--- a/tests/pipelining/test_pipelining.py
+++ b/tests/pipelining/test_pipelining.py
@@ -140,9 +140,8 @@ server ${server_ip}:8000;
         await self.start_all_services()
 
         deproxy_cl.make_requests(request, pipelined=True)
-        resp = await deproxy_cl.wait_for_response(timeout=5)
+        await deproxy_cl.wait_for_response(timeout=5)
 
-        self.assertTrue(resp, "Response not received")
         self.assertEqual(4, len(deproxy_cl.responses))
         self.assertEqual(4, len(deproxy_srv.requests))
 
@@ -171,9 +170,8 @@ server ${server_ip}:8000;
         await deproxy_cl.wait_for_response(timeout=5)
 
         deproxy_cl.make_requests(request2, pipelined=True)
-        resp = await deproxy_cl.wait_for_response(timeout=5)
+        await deproxy_cl.wait_for_response(timeout=5)
 
-        self.assertTrue(resp, "Response not received")
         self.assertEqual(6, len(deproxy_cl.responses))
         self.assertEqual(6, len(deproxy_srv.requests))
 

--- a/tests/reconf/test_reconf_base.py
+++ b/tests/reconf/test_reconf_base.py
@@ -5,7 +5,6 @@ __license__ = "GPL2"
 import asyncio
 import time
 
-
 from framework.helpers import analyzer, dmesg, error, port_checks, remote
 from framework.helpers.analyzer import PSH, TCP
 from framework.helpers.cert_generator_x509 import CertGenerator
@@ -246,17 +245,17 @@ frang_limits {{http_strict_host_checking false;}}
                 name="add_listen",
                 first_config="listen 443 proto={0};\n",
                 second_config="listen 443 proto={0};\nlisten 444 proto={0};\n",
-                expected_response_on_444_port=True,
+                client_wait_method_for_444_port="wait_for_response",
             ),
             marks.Param(
                 name="remove_listen",
                 first_config="listen 443 proto={0};\nlisten 444 proto={0};\n",
                 second_config="listen 443 proto={0};\n",
-                expected_response_on_444_port=False,
+                client_wait_method_for_444_port="wait_for_connection_close",
             ),
         ]
     )
-    async def test_reconf(self, name, first_config, second_config, expected_response_on_444_port):
+    async def test_reconf(self, name, first_config, second_config, client_wait_method_for_444_port):
         await self._start_all_services_and_reload_tempesta(
             first_config.format(self.proto),
             second_config.format(self.proto),
@@ -271,7 +270,7 @@ frang_limits {{http_strict_host_checking false;}}
         client.port = 444
         client.restart()
         client.make_request(request)
-        await client.wait_for_response(strict=expected_response_on_444_port, timeout=1)
+        await getattr(client, client_wait_method_for_444_port)()
 
 
 class TestListenStartFail(tester.TempestaTest):
@@ -490,9 +489,8 @@ http_chain {{
         server.conns_n = conns_n_2
 
         tempesta.reload()
-        self.assertTrue(
-            await server.wait_for_connections(),
-            "Tempesta did not change number of connections with server after reload.",
+        await server.wait_for_connections(
+            msg="Tempesta did not change number of connections with server after reload."
         )
 
         client.start()
@@ -544,9 +542,8 @@ http_chain {{
         server.conns_n = conns_n_2
 
         tempesta.reload()
-        self.assertTrue(
-            await server.wait_for_connections(),
-            "Tempesta did not change number of connections with server after reload.",
+        await server.wait_for_connections(
+            msg="Tempesta did not change number of connections with server after reload."
         )
 
         client.start()
@@ -581,11 +578,13 @@ http_chain {{
         second_config(self)
 
         self.get_tempesta().reload()
-        self.assertTrue(
-            await server_1.wait_for_connections(),
-            "Tempesta removed connections to a server/srv_group after reload. "
-            + "But this server/srv_group was not removed.",
+        await server_1.wait_for_connections(
+            msg=(
+                "Tempesta removed connections to a server/srv_group after reload. "
+                + "But this server/srv_group was not removed."
+            )
         )
+
         self.assertEqual(
             len(server_2.connections),
             0,
@@ -639,14 +638,15 @@ http_chain {{
 
         self.get_tempesta().reload()
         server_2.start()
-        self.assertTrue(
-            await server_1.wait_for_connections(),
-            "Tempesta removed connections to a old server/srv_group after reload. "
-            + "But this server/srv_group was not removed.",
+        await server_1.wait_for_connections(
+            msg=(
+                "Tempesta removed connections to a old server/srv_group after reload. "
+                + "But this server/srv_group was not removed."
+            )
         )
-        self.assertTrue(
-            await server_2.wait_for_connections(),
-            "Tempesta did not create connections to a new server/srv_group after reload.",
+
+        await server_2.wait_for_connections(
+            msg="Tempesta did not create connections to a new server/srv_group after reload."
         )
 
         for authority in ["grp1", "grp2"] * 5:
@@ -909,11 +909,11 @@ srv_group default {{
         client = self.get_client("deproxy")
         client.make_request(client.create_request(method="GET", headers=[]))
 
-        self.assertTrue(await server.wait_for_requests(1))
+        await server.wait_for_requests(1)
         server.reset_new_connections()
         server.drop_conn_when_request_received = False
 
-        self.assertTrue(await client.wait_for_response(15))
+        await client.wait_for_response(15)
         self.assertEqual(client.last_response.status, "200")
 
         self.loggers.dmesg.update()
@@ -1017,12 +1017,12 @@ srv_group default {{
         self.get_tempesta().reload()
 
         client.make_request(client.create_request(method="GET", headers=[]))
-        await client.wait_for_response(timeout=2, strict=expect_response)
 
         self.assertTrue(
             await self.dmesg.find("request evicted: timed out, status", cond=dmesg_cond),
             DMESG_WARNING,
         )
+        self.assertEqual(client.last_response is not None, expect_response)
 
     @marks.Parameterize.expand(
         [
@@ -1083,7 +1083,7 @@ srv_group default {{
 
         request = client.create_request(method="GET", headers=[], uri="/status/")
         client.make_requests(requests=[request] * 6)  # server_failover_http 502 5 10
-        await client.wait_for_response(strict=True)
+        await client.wait_for_response()
 
         self.assertTrue(
             await self.dmesg.find(
@@ -1124,7 +1124,7 @@ srv_group default {{
 
         request = client.create_request(method="GET", headers=[], uri="/")
         client.make_requests(requests=[request] * 5)
-        await client.wait_for_response(strict=True, timeout=10)
+        await client.wait_for_response(timeout=10)
 
         tempesta = self.get_tempesta()
         tempesta.get_stats()
@@ -1232,16 +1232,18 @@ class TestVhostReconf(tester.TempestaTest):
                 first_config=_set_tempesta_config_with_1_vhost,
                 second_config=_set_tempesta_config_with_2_vhost,
                 server_headers=("grp1", "grp2"),
+                srv2_wait_method="wait_for_connections",
             ),
             marks.Param(
                 name="remove_vhost",
                 first_config=_set_tempesta_config_with_2_vhost,
                 second_config=_set_tempesta_config_with_1_vhost,
                 server_headers=("grp1", "grp1"),
+                srv2_wait_method="wait_for_connections_closed",
             ),
         ]
     )
-    async def test(self, name, first_config, second_config, server_headers):
+    async def test(self, name, first_config, second_config, server_headers, srv2_wait_method):
         tempesta = self.get_tempesta()
         client = self.get_client("deproxy")
         srv1 = self.get_server("deproxy-1")
@@ -1256,7 +1258,7 @@ class TestVhostReconf(tester.TempestaTest):
         second_config(self)
         tempesta.reload()
         await srv1.wait_for_connections()
-        await srv2.wait_for_connections()
+        await getattr(srv2, srv2_wait_method)()
 
         for authority, server_header in zip(["grp1", "grp2"], server_headers):
             client.restart()
@@ -2030,13 +2032,13 @@ class TestCtrlFrameMultiplier(tester.TempestaTest):
         client = self.get_client("deproxy")
         client.update_initial_settings()
         client.send_bytes(client.h2_connection.data_to_send())
-        self.assertTrue(await client.wait_for_ack_settings())
+        await client.wait_for_ack_settings()
 
         for _ in range(0, 10000):
             client.send_ping()
 
         tempesta.config.set_defconfig(old_config)
         tempesta.reload()
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
         tempesta.get_stats()
         self.assertEqual(tempesta.stats.cl_ping_frame_exceeded, 1)

--- a/tests/sched/test_reconnection_logic.py
+++ b/tests/sched/test_reconnection_logic.py
@@ -98,33 +98,30 @@ http_chain {
         await self.start_all_services()
 
         await client.send_request(request, "200")
-        self.assertTrue(
-            await primary_server.wait_for_requests(1),
-            "TempestaFW first send a request to the backup server.",
+        await primary_server.wait_for_requests(
+            1, msg="TempestaFW first send a request to the backup server."
         )
 
         primary_server.stop()
 
         await client.send_request(request, "200")
-        self.assertTrue(
-            await backup_server.wait_for_requests(1),
-            "TempestaFW doesn't send a request to the backup server when the primary server is down.",
+        await backup_server.wait_for_requests(
+            1,
+            msg="TempestaFW doesn't send a request to the backup server when the primary server is down.",
         )
 
         primary_server.start()
-        self.assertTrue(
-            await primary_server.wait_for_connections(),
-            "TempestaFW doesn't reconnect to the primary server.",
+        await primary_server.wait_for_connections(
+            msg="TempestaFW doesn't reconnect to the primary server."
         )
         self.assertEqual(
             len(primary_server.requests), 0, "Server must remove the old requests after restart."
         )
 
         await client.send_request(request, "200")
-        self.assertTrue(
-            await primary_server.wait_for_requests(1),
-            "TempestaFW doesn't send a request to the primary server "
-            "when it has restored operation.",
+        await primary_server.wait_for_requests(
+            1,
+            msg="TempestaFW doesn't send a request to the primary server when it has restored operation.",
         )
         self.assertLess(
             len(backup_server.requests), 2, "TempestaFW duplicated the request to the backup server"

--- a/tests/selftests/test_deproxy.py
+++ b/tests/selftests/test_deproxy.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from h2.exceptions import ProtocolError
 
 from framework.deproxy import deproxy_client, deproxy_message
@@ -57,7 +59,7 @@ class DeproxyTestH2(tester.TempestaTest):
         deproxy_cl.parsing = True
         deproxy_cl.make_request(head)
 
-        self.assertTrue(await deproxy_cl.wait_for_response(timeout=0.5))
+        await deproxy_cl.wait_for_response(timeout=0.5)
         self.assertEqual(deproxy_cl.last_response.status, "200")
 
     async def test_duplicate_headers(self):
@@ -170,7 +172,7 @@ class DeproxyTestH2(tester.TempestaTest):
         deproxy_cl.parsing = False
         deproxy_cl.make_request(head)
 
-        self.assertTrue(await deproxy_cl.wait_for_response(timeout=2))
+        await deproxy_cl.wait_for_response(timeout=2)
         # TODO: decide between 400 or 403 response code later
         self.assertEqual(int(int(deproxy_cl.last_response.status) / 100), 4)
 
@@ -210,7 +212,7 @@ class DeproxyTestH2(tester.TempestaTest):
         # disable sending WINDOW frames from client
         client.auto_flow_control = False
         client.make_request(client.create_request(method="GET", headers=[], uri="/large.txt"))
-        self.assertTrue(await client.wait_for_headers_frame(stream_id=1))
+        await client.wait_for_headers_frame(stream_id=1)
         self.assertIsNotNone(
             client._active_responses.get(1, None),
             "`wait_for_headers_frame` returned True, "
@@ -224,7 +226,7 @@ class DeproxyTestH2(tester.TempestaTest):
         )
 
         client.increment_flow_control_window(stream_id=1, flow_controlled_length=body_size)
-        self.assertTrue(await client.wait_for_response())
+        await client.wait_for_response()
         self.assertEqual(client.last_response.status, "200")
 
 
@@ -326,8 +328,7 @@ server ${server_ip}:8000;
         await client.wait_for_connection_close(timeout=2)
         # Connect one more time during block duration.
         client.restart()
-        if timeout > 0:
-            await client.wait_for_connection_open(timeout=timeout)
+        await asyncio.sleep(timeout)
         # If wait less than block_duration time thus expected not established connection.
         expected_connected = True if timeout > block_duration else False
         self.assertEqual(client._connected, expected_connected)
@@ -393,7 +394,7 @@ server ${server_ip}:8000;
         messages = 5
         for _ in range(0, messages):
             client.make_request("GET / HTTP/1.1\r\nHost: local<host\r\n\r\n")
-            await client.wait_for_response(timeout=0.5)
+            await client.wait_for_response(timeout=0.5, n=1)
 
         self.assertEqual(client.last_response.status, "400")
         self.assertEqual(len(client.responses), 1)

--- a/tests/selftests/test_docker_server.py
+++ b/tests/selftests/test_docker_server.py
@@ -4,6 +4,8 @@ __author__ = "Tempesta Technologies, Inc."
 __copyright__ = "Copyright (C) 2024 Tempesta Technologies, Inc."
 __license__ = "GPL2"
 
+import asyncio
+
 from framework.test_suite import tester
 
 
@@ -127,8 +129,9 @@ class TestHealthCheck(tester.TempestaTest):
 
         await self.start_tempesta()
 
-        self.assertFalse(await server.wait_for_connections(timeout=1))
-        self.assertTrue(await server.wait_for_connections(timeout=3))
+        with self.assertRaises(AssertionError):
+            await server.wait_for_connections(timeout=1)
+        await server.wait_for_connections(timeout=3)
         self.assertEqual(server.health_status, "healthy")
 
     async def test_unhealthy_server(self):
@@ -138,7 +141,8 @@ class TestHealthCheck(tester.TempestaTest):
         server.start()
 
         self.assertEqual(server.health_status, "starting")
-        self.assertFalse(await server.wait_for_connections(timeout=7))
+        with self.assertRaises(AssertionError):
+            await server.wait_for_connections(timeout=7)
         self.assertEqual(server.health_status, "unhealthy")
 
     async def test_override_default_healthcheck(self):
@@ -148,5 +152,4 @@ class TestHealthCheck(tester.TempestaTest):
 
         server.start()
 
-        await server.wait_for_connections(timeout=1)
-        self.assertEqual(server.health_status, "healthy")
+        await self.assertWaitUntilEqual(lambda: server.health_status, "healthy")

--- a/tests/server_connections/test_close_dead_connections.py
+++ b/tests/server_connections/test_close_dead_connections.py
@@ -2,8 +2,6 @@ __author__ = "Tempesta Technologies, Inc."
 __copyright__ = "Copyright (C) 2026 Tempesta Technologies, Inc."
 __license__ = "GPL2"
 
-from h2.errors import ErrorCodes
-
 from framework.deproxy import deproxy_message
 from framework.test_suite import marks, tester
 
@@ -89,7 +87,7 @@ class TestFinishH2StreamsByClient(FinishByClientBase):
         for _ in range(CONNS_N):
             client.make_request(request)
 
-        await server.wait_for_requests(strict=True, n=CONNS_N)
+        await server.wait_for_requests(n=CONNS_N, timeout=10)
 
         for i in range(CONNS_N):
             client.send_reset_stream(stream_id=i * 2 + 1)
@@ -98,9 +96,8 @@ class TestFinishH2StreamsByClient(FinishByClientBase):
             lambda: set(server_conn_list_before).isdisjoint(set(server.connections)),
             f"Tempesta FW must close dead connections.",
         )
-        self.assertTrue(
-            await server.wait_for_connections(timeout=5),
-            f"Tempesta FW must recreate dead connections.",
+        await server.wait_for_connections(
+            timeout=5, msg=f"Tempesta FW must recreate dead connections."
         )
 
 
@@ -156,7 +153,7 @@ class TestFinishTCPConnectionByClient(FinishByClientBase):
                 client.set_rst_tcp_to_closing_connection()
         for client in self.get_clients():
             client.make_request(request)
-        await server.wait_for_requests(strict=True, n=CONNS_N)
+        await server.wait_for_requests(n=CONNS_N)
         for client in self.get_clients():
             client.stop()
 
@@ -164,7 +161,6 @@ class TestFinishTCPConnectionByClient(FinishByClientBase):
             lambda: set(server_conn_list_before).isdisjoint(set(server.connections)),
             f"Tempesta FW must close dead connections.",
         )
-        self.assertTrue(
-            await server.wait_for_connections(timeout=5),
-            f"Tempesta FW must recreate dead connections.",
+        await server.wait_for_connections(
+            timeout=5, msg=f"Tempesta FW must recreate dead connections."
         )

--- a/tests/server_connections/test_established_connections.py
+++ b/tests/server_connections/test_established_connections.py
@@ -175,9 +175,8 @@ srv_group default {{
 
         await client.send_request(client.create_request(method="GET", headers=[]), "504")
 
-        self.assertTrue(
-            await server.wait_for_connections(),
-            "Tempesta FW must recreate all connections to server.",
+        await server.wait_for_connections(
+            msg="Tempesta FW must recreate all connections to server."
         )
         tfw.get_stats()
 
@@ -253,7 +252,7 @@ srv_group default {{
         self.assertGreaterEqual(tfw.stats.srv_established_connections, 0, msg)
 
         msg = "Tempesta FW don't recreate connections to server after unblock firewall"
-        self.assertTrue(await server.wait_for_connections(), msg)
+        await server.wait_for_connections(msg=msg)
 
         tfw.get_stats()
         self.assertEqual(len(server.connections), self.conns_n, msg)

--- a/tests/server_options/test_server_options.py
+++ b/tests/server_options/test_server_options.py
@@ -102,7 +102,7 @@ class TestRescheduling(TestServerOptionsBase):
             b"HTTP/1.1 200 OK\r\nContent-Length: 10\r\nConnection: close\r\n\r\nxxxxxxxxxx"
         )
         server.start()
-        self.assertTrue(await client.wait_for_response())
+        await client.wait_for_response()
         self.assertEqual(client.last_response.status, "200")
         self.assertEqual(client.last_response.body, "xxxxxxxxxx")
 
@@ -131,15 +131,15 @@ class TestRescheduling(TestServerOptionsBase):
         client = self.get_client("deproxy-1")
         for _ in range(0, 3):
             client.make_request(client.create_request(method="GET", headers=[]))
-        await server.wait_for_requests(3, strict=True)
+        await server.wait_for_requests(3)
         server.stop()
 
         server.start()
-        await server.wait_for_requests(1, strict=True)
+        await server.wait_for_requests(1)
         server.stop()
 
         server.start()
-        await server.wait_for_requests(1, strict=True)
+        await server.wait_for_requests(1)
         server.stop()
 
         server.pipelined = 0
@@ -183,11 +183,11 @@ class TestRescheduling(TestServerOptionsBase):
         client_1 = self.get_client("deproxy-1")
         for _ in range(0, 3):
             client_1.make_request(client_1.create_request(method="GET", headers=[]))
-        await server.wait_for_requests(3, strict=True)
+        await server.wait_for_requests(3)
         server.stop()
         server.pipelined = 2
         server.start()
-        await server.wait_for_requests(1, strict=True)
+        await server.wait_for_requests(1)
 
         client_2 = self.get_client("deproxy-2")
         await client_2.send_request(client_2.create_request(method="GET", headers=[]), "502")
@@ -219,7 +219,7 @@ class TestRescheduling(TestServerOptionsBase):
         client_1 = self.get_client("deproxy-1")
         for _ in range(0, 4):
             client_1.make_request(client_1.create_request(method="GET", headers=[]))
-        await server.wait_for_requests(3, strict=True)
+        await server.wait_for_requests(3)
         server.stop()
         server.pipelined = 2
         server.send_after_conn_established = True
@@ -304,7 +304,7 @@ class TestServerOptions(TestServerOptionsBase):
         client.make_request(client.create_request(method="GET", headers=[]))
         await asyncio.sleep(1)
         server.drop_conn_when_request_received = False
-        await client.wait_for_response(timeout=5, strict=True)
+        await client.wait_for_response(timeout=5)
 
         self.assertEqual(client.last_response.status, "200")
         self.assertTrue(
@@ -390,9 +390,9 @@ class TestServerOptions(TestServerOptionsBase):
 
         client = self.get_client("deproxy")
         client.make_request(client.create_request(method="GET", headers=[]))
-        await server.wait_for_requests(50, strict=True)
+        await server.wait_for_requests(50)
         server.drop_conn_when_request_received = False
-        await client.wait_for_response(timeout=5, strict=True)
+        await client.wait_for_response(timeout=5)
 
         self.assertTrue(
             await self.loggers.dmesg.find(
@@ -433,12 +433,12 @@ class TestServerOptions(TestServerOptionsBase):
         await self.start_all_services()
         client = self.get_client("deproxy")
         client.make_request(client.create_request(method="POST", headers=[]))
-        await server.wait_for_requests(1, strict=True)  # it's necessary for stability
+        await server.wait_for_requests(1)  # it's necessary for stability
 
         request = client.create_request(method="GET", headers=[])
         client.make_requests([request] * 5)
 
-        await client.wait_for_connection_close(strict=True)
+        await client.wait_for_connection_close()
         self.assertIsNone(client.last_response)
 
     async def test_requests_after_nonidempotent_request_conn_n_2(self):
@@ -465,14 +465,14 @@ class TestServerOptions(TestServerOptionsBase):
         client = self.get_client("deproxy")
         client.make_request(client.create_request(method="POST", headers=[]))
 
-        await server.wait_for_requests(1, strict=True)  # it's necessary for stability
+        await server.wait_for_requests(1)  # it's necessary for stability
         server.set_response("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
 
         request = client.create_request(method="GET", headers=[])
         idempotent_req_n = 5
         client.make_requests([request] * idempotent_req_n)
 
-        await client.wait_for_response(n=idempotent_req_n, strict=True)
+        await client.wait_for_response(n=idempotent_req_n)
         self.assertEqual(
             {1, idempotent_req_n},
             set(con.nrreq for con in server.connections),
@@ -516,9 +516,9 @@ class TestServerOptions(TestServerOptionsBase):
         client = self.get_client("deproxy")
         request = client.create_request(method="GET", headers=[])
         client.make_requests([request] * server_queue_size)
-        await server.wait_for_requests(server_queue_size, strict=True)
+        await server.wait_for_requests(server_queue_size)
         client.make_requests([request] * 10)
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
 
         self.assertEqual(client.statuses, {502: 10})
         self.assertTrue(
@@ -561,8 +561,8 @@ class TestServerOptions(TestServerOptionsBase):
         client = self.get_client("deproxy")
         request = client.create_request(method="GET", headers=[])
         client.make_requests([request] * server_queue_size)
-        await server.wait_for_requests(3, strict=True)
-        self.assertTrue(await client.wait_for_connection_close())
+        await server.wait_for_requests(3)
+        await client.wait_for_connection_close()
 
         self.assertEqual(client.statuses, {})
         self.assertTrue(
@@ -604,8 +604,8 @@ class TestServerOptions(TestServerOptionsBase):
         client = self.get_client("deproxy-1")
         request = client.create_request(method="GET", headers=[])
         client.make_requests([request] * 5)
-        await server.wait_for_requests(server_queue_size, strict=True)
-        self.assertTrue(await client.wait_for_connection_close())
+        await server.wait_for_requests(server_queue_size)
+        await client.wait_for_connection_close()
 
         self.assertTrue(
             await self.loggers.dmesg.find("request evicted:", cond=dmesg.amount_zero),
@@ -710,10 +710,10 @@ class TestServerOptions(TestServerOptionsBase):
         client = self.get_client("deproxy")
         client.make_request(client.create_request(method="GET", headers=[]))
 
-        self.assertTrue(await server.wait_for_requests(n=1))
+        await server.wait_for_requests(n=1)
         server.reset_new_connections()
 
-        self.assertTrue(await client.wait_for_response(timeout=15))
+        await client.wait_for_response(timeout=15)
         self.assertEqual(client.last_response.status, "502")
 
         sniffer.stop()
@@ -763,11 +763,11 @@ class TestServerOptions(TestServerOptionsBase):
         client = self.get_client("deproxy")
         client.make_request(client.create_request(method="GET", headers=[]))
 
-        self.assertTrue(await server.wait_for_requests(1))
+        await server.wait_for_requests(1)
         server.reset_new_connections()
         server.drop_conn_when_request_received = False
 
-        self.assertTrue(await client.wait_for_response(15))
+        await client.wait_for_response(15)
         self.assertEqual(client.last_response.status, "200")
 
         sniffer.stop()
@@ -817,7 +817,7 @@ class TestServerOptions(TestServerOptionsBase):
         client = self.get_client("deproxy")
         client.make_request(client.create_request(method="GET", headers=[]))
 
-        self.assertTrue(await server.wait_for_requests(1))
+        await server.wait_for_requests(1)
         server.reset_new_connections()
         server.drop_conn_when_request_received = False
 
@@ -825,7 +825,7 @@ class TestServerOptions(TestServerOptionsBase):
         # Do not call the start method here because it reset all variables
         server.run_start()
 
-        self.assertTrue(await client.wait_for_response(5))
+        await client.wait_for_response(5)
         self.assertEqual(client.last_response.status, "200")
         self.assertEqual(len(server.connections), 2)
         self.assertTrue(

--- a/tests/sessions/test_cookies.py
+++ b/tests/sessions/test_cookies.py
@@ -270,7 +270,7 @@ class CookiesMaxMisses(tester.TempestaTest):
             await client.send_request(request)
 
         self.assertEqual(client.last_response.status, "403")
-        self.assertTrue(await client.wait_for_connection_close())
+        await client.wait_for_connection_close()
 
 
 class VhostCookies(CookiesNotEnabled):

--- a/tests/sessions/test_js_challenge.py
+++ b/tests/sessions/test_js_challenge.py
@@ -45,9 +45,9 @@ class BaseJSChallenge(tester.TempestaTest):
         remote.tempesta.run_cmd(f"cp {srcdir}/etc/js_challenge.tpl {workdir}/js1.tpl")
 
     @staticmethod
-    async def client_send_pipelined_requests(client, reqs, error_expected) -> list:
+    async def client_send_pipelined_requests(client, reqs: list, error_expected: bool) -> list:
         client.make_requests(reqs, pipelined=True)
-        await client.wait_for_response(strict=True)
+        await client.wait_for_response()
 
         return client.responses[-len(reqs) :] if not error_expected else client.responses[-1:]
 
@@ -211,7 +211,7 @@ class JSChallenge(BaseJSChallenge):
                 f"accept header - {accept}",
             )
         if conn_is_closed:
-            self.assertTrue(await client.wait_for_connection_close())
+            await client.wait_for_connection_close()
         else:
             self.assertFalse(client.connection_is_closed)
 
@@ -353,7 +353,7 @@ class JSChallenge(BaseJSChallenge):
 
         # make third request without cookie, request misses = 3
         await client.send_request(self.prepare_first_req(client), expected_status_code="403")
-        await client.wait_for_connection_close(strict=True)
+        await client.wait_for_connection_close()
 
     async def test_disable_challenge_on_reload(self):
         """
@@ -481,16 +481,14 @@ class JSChallenge(BaseJSChallenge):
             await asyncio.sleep(sleep_time)
 
         requests = [self.prepare_second_req(client, cookie) for cookie in cookies]
-        responses = await self.client_send_pipelined_requests(
-            client, requests, True if conn_is_closed else False
-        )
+        client.make_requests(requests, pipelined=True)
 
         if conn_is_closed:
+            await client.wait_for_connection_close()
             self.assertEqual(client.last_response.status, "403", "unexpected response status code")
-            self.assertEqual(len(responses), 1)
         else:
-            self.assertEqual(len(responses), 2)
-            for resp in responses:
+            await client.wait_for_response()
+            for resp in client.responses[-len(requests) :]:
                 self.assertEqual(resp.status, "200", "unexpected response status code")
         self.assertEqual(client.connection_is_closed, conn_is_closed)
 

--- a/tests/sessions/test_learn.py
+++ b/tests/sessions/test_learn.py
@@ -189,13 +189,13 @@ class LearnSessions(LearnSessionsBase):
             )
             client.make_request(req)
 
-        self.assertTrue(await client.wait_for_response(20))
+        await client.wait_for_response(20)
 
         self.assertEqual(len(client.responses), ATTEMPTS + 1)
         for resp in client.responses[1:]:
             self.assertEqual(resp.status, "502", "unexpected response status code")
         srv.start()
-        self.assertTrue(await srv.wait_for_connections(timeout=3), "Can't restart backend server")
+        await srv.wait_for_connections(timeout=3, msg="Can't restart backend server")
         for _ in range(ATTEMPTS):
             new_s_id = await self.client_send_next_req(client, cookie)
             self.assertEqual(s_id, new_s_id, "Sticky session was forwarded to not-pinned server")
@@ -269,7 +269,7 @@ class LearnSessionsMultipleSameSetCookie(LearnSessionsBase):
         self.assertEqual(response.status, "200", "unexpected response status code")
 
         self.assertTrue(
-            self.klog.find(
+            await self.klog.find(
                 "Multiple sticky cookies found in response: 2", cond=dmesg.amount_equals(1)
             ),
             1,

--- a/tests/sessions/test_sessions.py
+++ b/tests/sessions/test_sessions.py
@@ -248,7 +248,7 @@ class StickySessionsPersistense(StickySessions):
         for _ in range(ATTEMPTS):
             await client.send_request(req, "502")
         srv.start()
-        self.assertTrue(await srv.wait_for_connections(timeout=3), "Can't restart backend server")
+        await srv.wait_for_connections(timeout=3, msg="Can't restart backend server")
         for _ in range(ATTEMPTS):
             new_s_id = await self.client_send_next_req(client, cookie)
             self.assertEqual(s_id, new_s_id, "Sticky session was forwarded to not-pinned server")
@@ -400,7 +400,7 @@ class StickySessionsFailover(StickySessions):
         )
 
         srv.start()
-        self.assertTrue(await srv.wait_for_connections(timeout=3), "Can't restart backend server")
+        await srv.wait_for_connections(timeout=3, msg="Can't restart backend server")
         for _ in range(ATTEMPTS):
             new_s_id = await self.client_send_next_req(client, cookie)
             self.assertEqual(
@@ -436,8 +436,8 @@ class StickySessionsFailover(StickySessions):
 
         srv1.start()
         srv2.start()
-        self.assertTrue(await srv1.wait_for_connections(timeout=3), "Can't restart backend server")
-        self.assertTrue(await srv2.wait_for_connections(timeout=3), "Can't restart backend server")
+        await srv1.wait_for_connections(timeout=3, msg="Can't restart backend server")
+        await srv2.wait_for_connections(timeout=3, msg="Can't restart backend server")
         for _ in range(ATTEMPTS):
             new_s_id = await self.client_send_next_req(client, cookie)
             self.assertEqual(

--- a/tests/stress/test_ddos.py
+++ b/tests/stress/test_ddos.py
@@ -324,7 +324,7 @@ http_chain {{
         # TODO: https://github.com/tempesta-tech/tempesta-test/issues/38
         #  issue - add checks to receiving a response from upstream
 
-        self.assertTrue(await client.wait_for_finish(timeout=DURATION + 5))
+        await client.wait_for_finish(timeout=DURATION + 5)
         client.stop()
 
         tempesta.get_stats()

--- a/tests/tf/test_tf.py
+++ b/tests/tf/test_tf.py
@@ -174,9 +174,9 @@ class TestTFt(tester.TempestaTest):
 
         client.make_request(request)
         if expected_block:
-            self.assertTrue(await client.wait_for_connection_close())
+            await client.wait_for_connection_close()
         else:
-            self.assertTrue(await client.wait_for_response())
+            await client.wait_for_response()
             self.assertTrue(client.last_response.status, "200")
 
 

--- a/tests/tls/test_tls_basic.py
+++ b/tests/tls/test_tls_basic.py
@@ -43,17 +43,11 @@ class TlsBasic(tester.TempestaTest):
     async def test_bad_request(self):
         await self.start_all_services()
         client = self.get_client("deproxy")
-        client.make_request("GET / HTxTP/1.1\nHost: localhost\n\n")
-        res = await client.wait_for_response(timeout=1)
-        self.assertTrue(res, "Cannot process request")
-        status = client.last_response.status
-        self.assertEqual(status, "400", "Wrong response status: %s" % status)
+        await client.send_request("GET / HTxTP/1.1\nHost: localhost\n\n", "400")
 
     async def test_connection_close(self):
         await self.start_all_services()
         client = self.get_client("deproxy")
-        client.make_request("GET / HTTP/1.1\r\n" "Host: localhost\r\n" "Connection: close\r\n\r\n")
-        res = await client.wait_for_response(timeout=1)
-        self.assertTrue(res, "Cannot process request")
-        status = client.last_response.status
-        self.assertEqual(status, "200", "Wrong response status: %s" % status)
+        await client.send_request(
+            "GET / HTTP/1.1\r\n" "Host: localhost\r\n" "Connection: close\r\n\r\n", "200"
+        )

--- a/tests/tls/test_tls_cert.py
+++ b/tests/tls/test_tls_cert.py
@@ -20,7 +20,7 @@ from framework.test_suite import tester
 from .handshake import TlsHandshake, x509_check_cn
 
 __author__ = "Tempesta Technologies, Inc."
-__copyright__ = "Copyright (C) 2022-2024 Tempesta Technologies, Inc."
+__copyright__ = "Copyright (C) 2022-2026 Tempesta Technologies, Inc."
 __license__ = "GPL2"
 
 
@@ -92,11 +92,9 @@ class X509(tester.TempestaTest):
 
         await self.start_all_services()
         client = self.get_client("deproxy")
-        client.make_request("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
-        res = await client.wait_for_response(timeout=X509.TIMEOUT)
-        self.assertTrue(res, "Cannot process request")
-        status = client.last_response.status
-        self.assertEqual(status, "200", "Bad response status: %s" % status)
+        await client.send_request(
+            "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n", "200", timeout=X509.TIMEOUT
+        )
 
     @dmesg.unlimited_rate_on_tempesta_node
     async def check_bad_alg(self, msg):
@@ -115,9 +113,7 @@ class X509(tester.TempestaTest):
         # Collect warnings before start w/ a bad certificate.
         self.start_all_clients()
         self.deproxy_manager.start()
-        self.assertTrue(
-            await deproxy_srv.wait_for_connections(timeout=X509.TIMEOUT), "Cannot start Tempesta"
-        )
+        await deproxy_srv.wait_for_connections(timeout=X509.TIMEOUT, msg="Cannot start Tempesta")
         client = self.get_client("deproxy")
         client.make_request("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
         res = await client.wait_for_response(timeout=X509.TIMEOUT)
@@ -443,7 +439,7 @@ class TlsCertSelect(tester.TempestaTest):
         deproxy_srv.start()
         await self.start_tempesta()
         self.deproxy_manager.start()
-        self.assertTrue(await deproxy_srv.wait_for_connections(timeout=1), "Cannot start Tempesta")
+        await deproxy_srv.wait_for_connections(timeout=1, msg="Cannot start Tempesta")
         # TlsHandshake proposes EC only cipher suite and it must successfully
         # request Tempesta.
         res = self.get_tls_handshake().do_12()
@@ -1048,22 +1044,15 @@ class BaseTlsSniWithHttpTable(tester.TempestaTest, base=True):
         self.tempesta = {"config": self.tempesta_tmpl % (self.frang_limits), "custom_cert": True}
         await tester.TempestaTest.asyncSetUp(self)
 
-    async def make_request(self, host):
-        """Make request with the specified `host` header and
-        return the body of response."""
-        client = self.get_client("deproxy")
-        client.make_request(f"GET / HTTP/1.1\r\nHost: {host}\r\n\r\n")
-        return await client.wait_for_response(timeout=X509.TIMEOUT)
-
     async def expect_request_processed(self, host, expected_server):
-        self.assertTrue(await self.make_request(host))
         client = self.get_client("deproxy")
-        status = client.last_response.status
-        self.assertEqual(status, "200", f"Bad response status: {status}")
+        await client.send_request(f"GET / HTTP/1.1\r\nHost: {host}\r\n\r\n", "200")
         self.assertEqual(client.last_response.body, expected_server)
 
     async def expect_request_fail(self, host):
-        self.assertFalse(await self.make_request(host))
+        client = self.get_client("deproxy")
+        client.make_request(f"GET / HTTP/1.1\r\nHost: {host}\r\n\r\n")
+        await client.wait_for_connection_close()
 
     async def test_valid(self):
         """
@@ -1209,6 +1198,7 @@ class BaseTlsMultiTest(tester.TempestaTest, base=True):
 
     async def run_alterative_access(self):
         """Try to access multiple hosts in alterating order."""
+        self.disable_deproxy_auto_parser()
         generate_certificate(san=["example.com", "*.example.com"])
         REQ_NUM = 4
         self.assertFalse(REQ_NUM % 2, "REQ_NUM should be even")
@@ -1222,10 +1212,11 @@ class BaseTlsMultiTest(tester.TempestaTest, base=True):
 
         for request in self.build_requests(hosts=islice(host_iter, REQ_NUM)):
             client.make_request(request)
-            await client.wait_for_response()
+        await client.wait_for_connection_close()
 
         self.assertLess(len(client.responses), 2)
         # server1 received requests
+        await server1.wait_for_requests(n=1)
         self.assertGreater(len(server1.requests), 0)
         # server2 did not receive requests
         self.assertEqual(len(server2.requests), 0)

--- a/tests/tls/test_tls_handshake.py
+++ b/tests/tls/test_tls_handshake.py
@@ -539,7 +539,7 @@ class TlsCertReconfig(tester.TempestaTest):
         deproxy_srv.start()
         await self.start_tempesta()
         self.deproxy_manager.start()
-        self.assertTrue(await deproxy_srv.wait_for_connections(timeout=1), "Cannot start Tempesta")
+        await deproxy_srv.wait_for_connections(timeout=1, msg="Cannot start Tempesta")
 
         vhs = TlsHandshake()
         res = vhs.do_12()

--- a/tests/tls/test_tls_integrity.py
+++ b/tests/tls/test_tls_integrity.py
@@ -76,13 +76,9 @@ class TlsIntegrityTester(tester.TempestaTest):
         for clnt in self.clients:
             client = self.get_client(clnt["id"])
             client.make_request(self.make_req(req_len))
-            res = await client.wait_for_response(timeout=5)
-            self.assertTrue(
-                res, "Cannot process request (len=%d) or response" " (len=%d)" % (req_len, resp_len)
-            )
-            resp = client.responses[-1].body
-            hash2 = hashlib.md5(resp.encode()).digest()
-            self.assertTrue(hash1 == hash2, "Bad response checksum")
+            await client.wait_for_response(timeout=5)
+            hash2 = hashlib.md5(client.last_response.body.encode()).digest()
+            self.assertEqual(hash1, hash2, "Bad response checksum")
 
     @contextmanager
     async def tcp_flow_check(self, resp_len, mtu=1500):
@@ -302,9 +298,9 @@ class ManyClients(Cache):
             client.make_request(reqeust)
 
         for client in clients:
-            self.assertTrue(
-                await client.wait_for_response(timeout=25),
-                "Cannot process request (len=%d) or response" " (len=%d)" % (req_len, resp_len),
+            await client.wait_for_response(
+                timeout=25,
+                msg="Cannot process request (len=%d) or response" " (len=%d)" % (req_len, resp_len),
             )
 
         for client in clients:
@@ -401,13 +397,11 @@ class CloseConnection(tester.TempestaTest):
 
         client = self.get_client(self.clients[0]["id"])
         client.make_request(self.make_req(req_len))
-        res = await client.wait_for_response(timeout=5)
-        self.assertTrue(
-            res, "Cannot process request (len=%d) or response" " (len=%d)" % (req_len, resp_len)
+        await client.wait_for_response(
+            msg="Cannot process request (len=%d) or response" " (len=%d)" % (req_len, resp_len)
         )
-        resp = client.responses[-1].body
-        hash2 = hashlib.md5(resp.encode()).digest()
-        self.assertTrue(hash1 == hash2, "Bad response checksum")
+        hash2 = hashlib.md5(client.last_response.body.encode()).digest()
+        self.assertEqual(hash1, hash2, "Bad response checksum")
 
     async def test1(self):
         await self.start_all_services()

--- a/tests/tls/test_tls_limits.py
+++ b/tests/tls/test_tls_limits.py
@@ -80,18 +80,17 @@ class TLSMatchHostSni(tester.TempestaTest):
 
         # case 1.1 (sni match)
         deproxy_cl.make_request("GET / HTTP/1.1\r\nHost: tempesta-tech.com\r\n\r\n")
-        self.assertTrue(await deproxy_cl.wait_for_response())
+        await deproxy_cl.wait_for_response()
         self.assertEqual(1, len(deproxy_cl.responses))
 
         # case 1.2 (sni match with port)
         deproxy_cl.make_request("GET / HTTP/1.1\r\nHost: tempesta-tech.com:443\r\n\r\n")
-        self.assertTrue(await deproxy_cl.wait_for_response())
+        await deproxy_cl.wait_for_response()
         self.assertEqual(2, len(deproxy_cl.responses))
 
         # case 2 (sni mismatch)
         deproxy_cl.make_request("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
-        self.assertFalse(await deproxy_cl.wait_for_response())
-        self.assertEqual(2, len(deproxy_cl.responses))
 
-        self.assertTrue(await deproxy_cl.wait_for_connection_close())
+        await deproxy_cl.wait_for_connection_close()
+        self.assertEqual(2, len(deproxy_cl.responses))
         self.assertTrue(await klog.find(self.TLS_WARN), "Frang limits warning is not shown")

--- a/tests/wrong_body_length/test_request_wrong_length.py
+++ b/tests/wrong_body_length/test_request_wrong_length.py
@@ -345,7 +345,7 @@ class RequestLongBodyLength(TempestaTest):
             + "\r\n"
             + "body\r\n"
         )
-        await client.wait_for_response(timeout=3)
+        await client.wait_for_connection_close()
 
         self.assertIsNone(
             client.last_response,

--- a/tests/ws/test_ws_ping.py
+++ b/tests/ws/test_ws_ping.py
@@ -487,7 +487,7 @@ class TestWssPipelining(BaseWsPing):
         await self.wait_for_connections(conns_n=32)
         deproxy_cl = self.get_client("deproxy")
         deproxy_cl.make_requests(self.request, pipelined=True)
-        await deproxy_cl.wait_for_connection_close(timeout=5, strict=True)
+        await deproxy_cl.wait_for_connection_close(timeout=5)
 
         self.assertTrue(
             await self.loggers.dmesg.find(


### PR DESCRIPTION
The main problem in the old version - different results and multiple use cases. As a result, some methods were used incorrectly, often `wait_for_response` should have been used instead of `wait_for_connections_case`, etc.