### PR TITLE
prepare service lifecycle for async support

### DIFF
--- a/framework/deproxy/deproxy_base.py
+++ b/framework/deproxy/deproxy_base.py
@@ -86,7 +86,7 @@ class BaseDeproxy(asyncore.DeproxyAsyncore, Stateful, ABC):
             self._tcp_logger.error(os_err_msg, exc_info=True)
             raise OSError(os_err_msg) from os_exc
 
-    def run_start(self):
+    async def run_start(self):
         self.__acquire()
 
         try:

--- a/framework/deproxy/deproxy_client.py
+++ b/framework/deproxy/deproxy_client.py
@@ -555,8 +555,8 @@ class ReqBodyBuffer:
 
 
 class DeproxyClientH2(BaseDeproxyClient):
-    def run_start(self):
-        super(DeproxyClientH2, self).run_start()
+    async def run_start(self):
+        await super(DeproxyClientH2, self).run_start()
         self.update_initial_settings()
 
     def reinit_hpack_encoder(self):

--- a/framework/deproxy/deproxy_manager.py
+++ b/framework/deproxy/deproxy_manager.py
@@ -36,7 +36,7 @@ class DeproxyManager(stateful.Stateful):
         client.set_lock(self._lock)
         self.clients.append(client)
 
-    def run_start(self):
+    async def run_start(self):
         self._exit_event.clear()
         self._proc = threading.Thread(
             target=self.__run_deproxy_manager,

--- a/framework/services/base_client.py
+++ b/framework/services/base_client.py
@@ -119,7 +119,7 @@ class BaseClient(stateful.Stateful, metaclass=abc.ABCMeta):
                 + "Queue is empty and timeout is over."
             )
 
-    def run_start(self):
+    async def run_start(self):
         """Run client"""
         self.prepare()
         self.proc = multiprocessing.Process(target=_run_client, args=(self, self.resq))

--- a/framework/services/base_server.py
+++ b/framework/services/base_server.py
@@ -41,7 +41,6 @@ class BaseServer(stateful.Stateful, abc.ABC):
 
         timeout_not_exceeded = await util.wait_until(
             self._wait_for_connections,
-            abort_cond=lambda: self.state != stateful.STATE_STARTED,
             timeout=timeout,
         )
 

--- a/framework/services/docker_server.py
+++ b/framework/services/docker_server.py
@@ -118,7 +118,7 @@ class DockerServer(DockerServerArguments, base_server.BaseServer):
             self._logger.info(f"Status is unhealthy.")
         return status
 
-    def run_start(self):
+    async def run_start(self):
         self._logger.info(f"Start with {self.image} image")
         self.port_checker.check_ports_status()
         self._build_image()

--- a/framework/services/nginx_server.py
+++ b/framework/services/nginx_server.py
@@ -63,7 +63,7 @@ class Nginx(base_server.BaseServer):
         self.get_stats()
         return self.active_conns < self.conns_n
 
-    def run_start(self):
+    async def run_start(self):
         self.clear_stats()
         self.port_checker.check_ports_status()
         # Copy nginx config to working directory on 'server' host.

--- a/framework/services/stateful.py
+++ b/framework/services/stateful.py
@@ -1,10 +1,11 @@
 import abc
+import asyncio
 import logging
 import traceback
 import typing
 
 __author__ = "Tempesta Technologies, Inc."
-__copyright__ = "Copyright (C) 2018-2025 Tempesta Technologies, Inc."
+__copyright__ = "Copyright (C) 2018-2026 Tempesta Technologies, Inc."
 __license__ = "GPL2"
 
 STATE_BEGIN_START = "begin_start"
@@ -61,47 +62,50 @@ class Stateful(abc.ABC):
         self.state = STATE_ERROR
 
     @abc.abstractmethod
-    def run_start(self): ...
+    async def run_start(self): ...
 
     @abc.abstractmethod
     def clear_stats(self) -> None:
         """All counters or dynamic variables for the service should be reset here."""
 
-    def restart(self):
-        self.stop()
-        self.start()
+    async def restart(self):
+        await self.stop()
+        await self.start()
 
-    def start(self):
+    async def start(self):
         """Try to start object"""
         self._logger.info("Starting...")
         if self.state != STATE_STOPPED:
             self._logger.warning(f"Not stopped")
             return
         self.state = STATE_BEGIN_START
-        self.run_start()
+        await self.run_start()
         self.state = STATE_STARTED
         self._logger.info("Start completed")
 
-    def force_stop(self):
+    async def force_stop(self):
         """Stop object"""
         procedures_names = [procedure.__name__ for procedure in self._stop_procedures()]
         self._logger.info(f"Stop procedures list: {procedures_names}")
         for stop_proc in self._stop_procedures():
             try:
-                stop_proc()
+                if asyncio.iscoroutinefunction(stop_proc):
+                    await stop_proc()
+                else:
+                    stop_proc()
                 self.state = STATE_STOPPED
             except Exception as exc:
                 tb_msg = traceback.format_exc()
                 self._logger.error("Exception in stopping process: %s", exc, exc_info=True)
                 self.append_exception(tb_msg)
 
-    def stop(self):
+    async def stop(self):
         """Try to stop object"""
         self._logger.info("Stopping...")
         if self.state != STATE_STARTED and self.state != STATE_BEGIN_START:
             self._logger.warning(f"Not started")
             return
-        self.force_stop()
+        await self.force_stop()
         self._logger.info("Stop completed")
 
     def is_running(self):

--- a/framework/services/tempesta.py
+++ b/framework/services/tempesta.py
@@ -459,7 +459,7 @@ class Tempesta(stateful.Stateful):
     def load_module(self, path, module_name):
         remote.tempesta.run_cmd(f"insmod {self.srcdir}/{path}/{module_name}.ko")
 
-    def run_start(self):
+    async def run_start(self):
         self.clear_stats()
         self._do_run(f"{self.srcdir}/scripts/tempesta.sh --time-output --start")
 
@@ -534,7 +534,7 @@ class TempestaFI(Tempesta):
         if self.module_stap:
             self.node.run_cmd("rm -r %s" % self.modules_dir)
 
-    def run_start(self):
-        Tempesta.run_start(self)
+    async def run_start(self):
+        await Tempesta.run_start(self)
         self.inject_prepare()
         self.inject()

--- a/framework/test_suite/tester.py
+++ b/framework/test_suite/tester.py
@@ -292,8 +292,8 @@ class TempestaTest(WaitUntilAsserts, unittest.IsolatedAsyncioTestCase):
             raise error.ServerNotFound(sid) from None
         return server
 
-    def get_servers(self):
-        return self.__servers.values()
+    def get_servers(self) -> list:
+        return list(self.__servers.values())
 
     def get_servers_id(self):
         """Return list of registered servers id"""
@@ -350,12 +350,9 @@ class TempestaTest(WaitUntilAsserts, unittest.IsolatedAsyncioTestCase):
             tfw_config=config.get("tfw_config", None),
         )
 
-    def start_all_servers(self):
-        for sid in self.__servers:
-            srv = self.__servers[sid]
-            srv.start()
-            if not srv.is_running():
-                raise Exception("Can not start server %s" % sid)
+    async def start_all_servers(self, servers: list[Stateful] = None) -> None:
+        servers = servers or self.get_servers()
+        await asyncio.gather(*[asyncio.create_task(srv.start()) for srv in servers])
 
     async def start_tempesta(self):
         """Start Tempesta and wait until the initialization process finish."""
@@ -365,16 +362,13 @@ class TempestaTest(WaitUntilAsserts, unittest.IsolatedAsyncioTestCase):
         async with dmesg.wait_for_msg(
             re.escape("[tempesta fw] Tempesta FW is ready"), strict=False
         ):
-            self.__tempesta.start()
+            await self.__tempesta.start()
             if not self.__tempesta.is_running():
                 raise Exception("Can not start Tempesta")
 
-    def start_all_clients(self):
-        for cid in self.__clients:
-            client = self.__clients[cid]
-            client.start()
-            if not client.is_running():
-                raise Exception("Can not start client %s" % cid)
+    async def start_all_clients(self, clients: list[Stateful] = None) -> None:
+        clients = clients or self.get_clients()
+        await asyncio.gather(*[asyncio.create_task(client.start()) for client in clients])
 
     def create_task(self, func):
         stop_event = threading.Event()
@@ -437,8 +431,12 @@ class TempestaTest(WaitUntilAsserts, unittest.IsolatedAsyncioTestCase):
     async def cleanup_services(self):
         test_logger.info("Cleanup: stopping all services...")
 
+        tasks = []
         for service in self.get_all_services():
-            service.stop()
+            tasks.append(asyncio.create_task(service.stop()))
+        await asyncio.gather(*tasks)
+
+        for service in self.get_all_services():
             service.clear_stats()
             if service.exceptions:
                 self.__exceptions.update({str(service): "\n".join(service.exceptions)})
@@ -522,21 +520,23 @@ class TempestaTest(WaitUntilAsserts, unittest.IsolatedAsyncioTestCase):
 
     async def start_all_services(self, client: bool = True) -> None:
         """Start all services."""
-        self.start_all_servers()
-        await self.start_tempesta()
+        tasks = [
+            asyncio.create_task(self.start_all_servers()),
+            asyncio.create_task(self.start_tempesta()),
+        ]
 
         if "deproxy" or "deproxy_h2" in [
             element["type"] for element in (self.clients + self.backends)
         ]:
-            self.deproxy_manager.start()
+            tasks.append(asyncio.create_task(self.deproxy_manager.start()))
 
         conn_task = asyncio.create_task(self.wait_all_connections())
         tfw_logger_task = asyncio.create_task(self.__tempesta.wait_while_logger_start())
 
-        await asyncio.gather(conn_task, tfw_logger_task)
+        await asyncio.gather(conn_task, tfw_logger_task, *tasks)
 
         if client:
-            self.start_all_clients()
+            await self.start_all_clients()
 
     def __run_tcpdump(self) -> None:
         """

--- a/tests/access_log/test_access_log.py
+++ b/tests/access_log/test_access_log.py
@@ -100,7 +100,7 @@ class CheckedResponses(tester.TempestaTest):
     async def send_request_and_get_dmesg(self, klog, request_as_str, response_as_str=HTTP_200_OK):
         self.get_server("0").response = response_as_str
         deproxy_cl = self.get_client("client")
-        deproxy_cl.start()
+        await deproxy_cl.start()
         deproxy_cl.make_request(request_as_str)
         await deproxy_cl.wait_for_response()
         return AccessLogLine.from_dmesg(klog)
@@ -116,7 +116,7 @@ class CheckedResponses(tester.TempestaTest):
         self.set_response(status, body)
 
         deproxy_cl = self.get_client("client")
-        deproxy_cl.start()
+        await deproxy_cl.start()
         deproxy_cl.make_request(request)
         await deproxy_cl.wait_for_response()
         self.assertEqual(int(deproxy_cl.last_response.status), status)

--- a/tests/cache/test_cache.py
+++ b/tests/cache/test_cache.py
@@ -1677,9 +1677,9 @@ class TestChunkedResponse(tester.TempestaTest):
     ]
 
     async def get_response(self, client) -> CurlResponse:
-        client.start()
+        await client.start()
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
         return client.last_response
 
     async def test_h2_cached_data_equal_to_original(self):
@@ -1800,9 +1800,9 @@ class TestCacheVhost(tester.TempestaTest):
     }
 
     async def get_response(self, client) -> CurlResponse:
-        client.start()
+        await client.start()
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
         return client.response_msg
 
     @marks.Parameterize.expand(
@@ -2149,7 +2149,7 @@ http_chain {
         # Expected response to HEAD from upstream
         self.assertIsNone(client.last_response.headers.get("age"))
 
-        client.restart()
+        await client.restart()
         second_request = client.create_request(method="GET", headers=[])
         await client.send_request(second_request, "200")
         # Expected response to GET from upstream

--- a/tests/cache/test_cache_stale.py
+++ b/tests/cache/test_cache_stale.py
@@ -70,7 +70,7 @@ cache_fulfill * *;
         )
 
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
         await client.send_request(
             client.create_request(
                 method="GET",
@@ -299,7 +299,7 @@ class TestCacheUseStale(TestCacheUseStaleBase):
         )
 
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
         await client.send_request(
             client.create_request(
                 method="GET",
@@ -389,7 +389,7 @@ class TestCacheUseStale(TestCacheUseStaleBase):
         )
 
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
         await client.send_request(
             client.create_request(
                 method="GET",
@@ -478,7 +478,7 @@ class TestCacheUseStale(TestCacheUseStaleBase):
         )
 
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
         await client.send_request(
             client.create_request(
                 method="GET",
@@ -563,7 +563,7 @@ class TestCacheUseStale(TestCacheUseStaleBase):
         )
 
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
         await client.send_request(
             client.create_request(
                 method="GET",

--- a/tests/cache/test_purge.py
+++ b/tests/cache/test_purge.py
@@ -183,7 +183,7 @@ frang_limits {
             msg="TempestaFW reloads with wrong config",
         ):
             self.oops_ignore = ["ERROR"]
-            self.get_tempesta().start()
+            await self.get_tempesta().start()
 
 
 @marks.parameterize_class(
@@ -746,9 +746,9 @@ class TestPurgeGet(TempestaTest):
             with self.subTest("PURGE+GET", uri=uri):
                 client.set_uri(uri)
 
-                client.start()
+                await client.start()
                 await self.wait_while_busy(client)
-                client.stop()
+                await client.stop()
                 response = client.last_response
 
                 self.assertEqual(response.status, 200, response)
@@ -765,9 +765,9 @@ class TestPurgeGet(TempestaTest):
         client = self.get_client("purge")
         client.set_uri("/server1")
 
-        client.start()
+        await client.start()
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
         response = client.last_response
 
         self.assertEqual(response.status, 200, response)

--- a/tests/clickhouse/test_clickhouse_logs.py
+++ b/tests/clickhouse/test_clickhouse_logs.py
@@ -111,7 +111,7 @@ class TestClickhouseLogsBufferConfiguration(tester.TempestaTest):
             expected_exception=error.ProcessBadExitStatusException,
             msg="Tempesta FW started with mmap_log_buffer_size > 128 MB or < 4 KB.",
         ):
-            self.get_tempesta().start()
+            await self.get_tempesta().start()
         self.assertTrue(
             await self.loggers.dmesg.find(fail_pattern), "Not found ERROR msg in dmesg."
         )
@@ -151,7 +151,7 @@ class TestClickhouseLogsOnly(TestClickhouseLogsBaseTest):
         Toggle off the dmesg logs sending
         """
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
 
         await self.send_simple_request(client)
         await self.assertWaitUntilEqual(self.loggers.clickhouse.access_log_records_count, 1)
@@ -191,7 +191,7 @@ class TestNoLogs(TestClickhouseLogsBaseTest):
         Turn off all the logs
         """
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
 
         await self.send_simple_request(client)
         await self.assertWaitUntilEqual(self.loggers.dmesg.access_log_records_count, 0)
@@ -215,7 +215,7 @@ class TestDmesgLogsOnly(TestClickhouseLogsBaseTest):
         Turn on the only dmesg logging
         """
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
 
         await self.send_simple_request(client)
         await self.assertWaitUntilEqual(self.loggers.dmesg.access_log_records_count, 1)
@@ -289,7 +289,7 @@ class TestClickHouseLogsCorrectnessData(TestClickhouseLogsBaseTest):
         deproxy_server.set_response(response)
 
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
 
         await self.send_simple_request(
             client,
@@ -352,7 +352,7 @@ class TestClickHouseLogsCorrectnessDataPostRequest(TestClickhouseLogsBaseTest):
         Verify the clickhouse log record data
         """
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
 
         await self.send_simple_request(
             client, client.create_request(uri="/", method="POST", headers=[]), expected_status="500"
@@ -376,7 +376,7 @@ class TestClickHouseLogsDelay(TestClickhouseLogsBaseTest):
         server.delay_before_sending_response = 2
 
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
 
         time_before = datetime.now(tz=timezone.utc)
 
@@ -428,13 +428,13 @@ class TestClickhouseLogTiming(tester.TempestaTest):
         """
         This test demonstrates the original problem
         """
-        self.get_tempesta().start()
+        await self.get_tempesta().start()
 
         client = self.get_client("curl")
 
-        client.start()
+        await client.start()
         await client.wait_for_finish()
-        client.stop()
+        await client.stop()
 
         await self.assertWaitUntilEqual(
             func=self.loggers.clickhouse.access_log_records_count, second=1
@@ -444,13 +444,13 @@ class TestClickhouseLogTiming(tester.TempestaTest):
         """
         Test that multiple requests are send
         """
-        self.get_tempesta().start()
+        await self.get_tempesta().start()
 
         client = self.get_client("parallel")
 
-        client.start()
+        await client.start()
         await client.wait_for_finish()
-        client.stop()
+        await client.stop()
 
         await self.assertWaitUntilEqual(
             func=self.loggers.clickhouse.access_log_records_count, second=5

--- a/tests/client_mem/test_client_mem.py
+++ b/tests/client_mem/test_client_mem.py
@@ -80,7 +80,7 @@ listen 80;
         self.update_tempesta_config(client_mem_config)
         self.oops_ignore = ["ERROR"]
         with self.assertRaises(error.ProcessBadExitStatusException):
-            tempesta.start()
+            await tempesta.start()
 
 
 class TestBlockByMemExceededBase(TestClientMemBase):
@@ -229,9 +229,9 @@ tls_match_any_server_name;
         client = self.get_client("gflood")
         task = self.create_task(self.__do_reload)
         task.start()
-        client.start()
+        await client.start()
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
 
 
 @marks.parameterize_class(
@@ -373,7 +373,7 @@ tls_match_any_server_name;
 
         i = 0
         for client in self.get_clients():
-            client.start()
+            await client.start()
             request = client.create_request(method="GET", uri="/", headers=[])
             client.make_requests([request] * 10)
             await server.wait_for_requests((i + 1) * 10)

--- a/tests/cve/test_cve.py
+++ b/tests/cve/test_cve.py
@@ -271,7 +271,7 @@ class TestHttp2FrameFlood(tester.TempestaTest):
 
         request = client.create_request(uri="/", method="GET", headers=[])
 
-        client.start()
+        await client.start()
         client.make_request(request)
         for stream_id in range(3, 200, 2):
             client.make_request(
@@ -307,9 +307,9 @@ class TestHttp2FrameFlood(tester.TempestaTest):
 
         client = self.get_client("gflood")
 
-        client.start()
+        await client.start()
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
 
         self.assertEqual(0, client.returncode)
 
@@ -416,9 +416,9 @@ class TestHttp2FrameFlood(tester.TempestaTest):
         await self.start_all_services(client=False)
 
         flood_client.options = flood_client.options + [cmd_args]
-        flood_client.start()
+        await flood_client.start()
         await self.wait_while_busy(flood_client)
-        flood_client.stop()
+        await flood_client.stop()
 
         self.assertEqual(0, flood_client.returncode)
         tempesta.get_stats()

--- a/tests/deadtime/test_deadtime_1M.py
+++ b/tests/deadtime/test_deadtime_1M.py
@@ -137,11 +137,11 @@ class TestModifyServerGroup(tester.TempestaTest):
         tfw = self.get_tempesta()
         server = self.get_server("nginx")
 
-        client.start()
+        await client.start()
         await server.wait_for_requests(n=self.requests_n // 3)
         tfw.reload()
         await client.wait_for_finish()
-        client.stop()
+        await client.stop()
 
         self.assertGreater(
             client.statuses.get(200, 0), 0, "Tempesta FW doesn't forward requests to server."
@@ -161,12 +161,12 @@ class TestModifyServerGroup(tester.TempestaTest):
         tfw = self.get_tempesta()
         server = self.get_server("nginx")
 
-        client.start()
+        await client.start()
         await server.wait_for_requests(n=self.requests_n // 3)
         self._generate_tempesta_config_with_multiple_srv_group(server_listeners)
         tfw.reload()
         await client.wait_for_finish()
-        client.stop()
+        await client.stop()
 
         self.assertGreater(
             client.statuses.get(200, 0), 0, "Tempesta FW doesn't forward requests to server."
@@ -186,12 +186,12 @@ class TestModifyServerGroup(tester.TempestaTest):
         tfw = self.get_tempesta()
         server = self.get_server("nginx")
 
-        client.start()
+        await client.start()
         await server.wait_for_requests(n=self.requests_n // 3)
         self._generate_tempesta_config_with_multiple_srv_group(first_part)
         tfw.reload()
         await client.wait_for_finish()
-        client.stop()
+        await client.stop()
 
         self.assertGreater(
             client.statuses.get(200, 0), 0, "Tempesta FW doesn't forward requests to server."

--- a/tests/fault_injection/test_fault_injection_base.py
+++ b/tests/fault_injection/test_fault_injection_base.py
@@ -242,9 +242,9 @@ class TestStress(TestFailFunctionBaseStress):
         client = self.get_client(client_id)
 
         self.oops_ignore = ["ERROR"]
-        client.start()
+        await client.start()
         await self.wait_while_busy(client, timeout=50)
-        client.stop()
+        await client.stop()
 
 
 class TestSchedConfig(TestFailFunctionBase):
@@ -515,7 +515,7 @@ sched hash;
     )
     async def test(self, name, func_name, extra_config, space, retval):
         self.get_tempesta().config.set_defconfig(self.base_tempesta_config)
-        self.get_tempesta().start()
+        await self.get_tempesta().start()
         TestFailFunctionBaseStress.setup_fail_function_test(func_name, 100, -1, space, retval)
 
         self.oops_ignore = ["ERROR"]
@@ -962,12 +962,12 @@ srv_group test {{
                 self.get_tempesta().load_module(module_path, module_name_preload)
             TestFailFunctionBaseStress.setup_fail_function_test(func_name, 100, -1, space, retval)
             try:
-                self.get_tempesta().start()
+                await self.get_tempesta().start()
             except error.ProcessBadExitStatusException:
                 pass
             else:
                 need_stop = True
-            self.get_tempesta().stop()
+            await self.get_tempesta().stop()
             """
             Because we setup fail function in the loop we should call teardown here
             at the end of the each loop iteration. If test fails teardown will be
@@ -1014,7 +1014,7 @@ http_chain {{
 }}
 """
         )
-        self.get_tempesta().start()
+        await self.get_tempesta().start()
         TestFailFunctionBaseStress.setup_fail_function_test("__tfw_wq_push", 100, -1, 0, -12)
         for server in self.get_servers():
             server.conns_n = 10
@@ -1026,9 +1026,9 @@ http_chain {{
                 )
             )
 
-            server.start()
+            await server.start()
 
-        self.deproxy_manager.start()
+        await self.deproxy_manager.start()
         for srv_name in ["deproxy_3", "deproxy_4", "deproxy_5"]:
             server = self.get_server(srv_name)
             await server.wait_for_connections(timeout=5)
@@ -1086,7 +1086,7 @@ http_chain {{
 }}
 """
         )
-        self.get_tempesta().start()
+        await self.get_tempesta().start()
         TestFailFunctionBaseStress.setup_fail_function_test("__tfw_wq_push", 100, -1, 0, -12)
         for server in self.get_servers():
             server.conns_n = 10
@@ -1098,9 +1098,9 @@ http_chain {{
                 )
             )
 
-            server.start()
+            await server.start()
 
-        self.deproxy_manager.start()
+        await self.deproxy_manager.start()
         for srv_name in ["deproxy_3", "deproxy_4", "deproxy_5"]:
             server = self.get_server(srv_name)
             await server.wait_for_connections(timeout=5)
@@ -1138,7 +1138,7 @@ http_chain {{
 }}
 """
         )
-        self.get_tempesta().start()
+        await self.get_tempesta().start()
         TestFailFunctionBaseStress.setup_fail_function_test("__tfw_wq_push", 100, 50, 7, -12)
         server = self.get_server("deproxy_1")
         server.conns_n = 10
@@ -1149,14 +1149,14 @@ http_chain {{
                 date=deproxy_message.HttpMessage.date_time_string(),
             )
         )
-        server.start()
-        self.deproxy_manager.start()
+        await server.start()
+        await self.deproxy_manager.start()
         await server.wait_for_connections(timeout=5)
 
         client = self.get_client("deproxy_h2")
-        client.start()
+        await client.start()
         await client.send_request(client.create_request(method="GET", headers=[]), "200")
-        self.get_tempesta().stop()
+        await self.get_tempesta().stop()
 
     @marks.Parameterize.expand(
         [
@@ -1194,7 +1194,7 @@ server {SERVER_IP}:8000 conns_n=10;
     )
     async def test_tls(self, name, func_name, base_config, new_config, space, retval):
         self.get_tempesta().config.set_defconfig(base_config)
-        self.get_tempesta().start()
+        await self.get_tempesta().start()
         TestFailFunctionBaseStress.setup_fail_function_test(func_name, 100, -1, space, retval)
 
         self.oops_ignore = ["ERROR"]
@@ -1256,7 +1256,7 @@ grace_shutdown_time 5;
     )
     async def test_learn(self, name, func_name, extra_config_1, extra_config_2, space, retval):
         self.get_tempesta().config.set_defconfig(self.base_tempesta_config + extra_config_1)
-        self.get_tempesta().start()
+        await self.get_tempesta().start()
         TestFailFunctionBaseStress.setup_fail_function_test(func_name, 100, -1, space, retval)
 
         server = self.get_server("deproxy_1")
@@ -1272,13 +1272,13 @@ grace_shutdown_time 5;
             )
         )
 
-        server.start()
-        self.deproxy_manager.start()
+        await server.start()
+        await self.deproxy_manager.start()
         await server.wait_for_connections(timeout=5)
 
         client = self.get_client("deproxy")
         request = client.create_request(method="GET", headers=[])
-        client.start()
+        await client.start()
 
         cookie = await self.client_send_first_req(client)
         request = (
@@ -1362,9 +1362,9 @@ class TestSched(TestFailFunctionBaseStress):
         client = self.get_client("h2load")
 
         self.oops_ignore = ["ERROR"]
-        client.start()
+        await client.start()
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
 
 
 class TestFailFunction(TestFailFunctionBase):
@@ -1827,7 +1827,7 @@ class TestFailFunction(TestFailFunctionBase):
         TestFailFunctionBaseStress.setup_fail_function_test(func_name, 100, times, space, retval)
         client = self.get_client(id)
         request = client.create_request(method="GET", headers=[])
-        client.start()
+        await client.start()
 
         self.oops_ignore = ["ERROR"]
         client.make_request(request)
@@ -1871,7 +1871,7 @@ class TestFailFunctionPrepareResp(TestFailFunctionBase):
         client = self.get_client("deproxy_h2")
         request1 = client.create_request(method="GET", headers=[])
         request2 = client.create_request(method="GET", headers=[("Content-Type", "!!!!")])
-        client.start()
+        await client.start()
 
         client.update_initial_settings(max_header_list_size=1600000)
         client.send_bytes(client.h2_connection.data_to_send())
@@ -1924,7 +1924,7 @@ class TestFailFunctionPrepareResp(TestFailFunctionBase):
         )
         client = self.get_client("deproxy_h2")
         request = client.create_request(method="GET", headers=[("accept", "text/html")])
-        client.start()
+        await client.start()
 
         self.oops_ignore = ["ERROR"]
         client.make_request(request)
@@ -1978,7 +1978,7 @@ class TestFailFunctionPipelinedResponses(TestFailFunctionBase):
             i = i + 1
             client = self.get_client(id)
             request = client.create_request(method="GET", headers=[])
-            client.start()
+            await client.start()
             client.make_request(request)
             await srv.wait_for_requests(i)
 

--- a/tests/forwarding/test_forwarded_hdr.py
+++ b/tests/forwarding/test_forwarded_hdr.py
@@ -49,7 +49,7 @@ class TestForwardedBase(tester.TempestaTest, base=True):
                     request=client.create_request(method="GET", headers=[("Forwarded", param)]),
                     expected_status_code=self.response_status,
                 )
-                client.restart()
+                await client.restart()
 
 
 class TestForwardedBaseAllowed(TestForwardedBase):
@@ -149,4 +149,4 @@ class TestForwardedBaseMalicious(TestForwardedBase):
                         ),
                         expected_status_code=self.response_status,
                     )
-                    client.restart()
+                    await client.restart()

--- a/tests/frang/frang_test_case.py
+++ b/tests/frang/frang_test_case.py
@@ -101,7 +101,7 @@ block_action attack reply;
 
         client = self.get_client("deproxy-1")
         client.parsing = False
-        client.start()
+        await client.start()
         for request in requests:
             if isinstance(client, DeproxyClientH2):
                 client.make_request(request, huffman=huffman)
@@ -181,9 +181,9 @@ block_action attack reply;
         client.options = [
             f" -address {tempesta_ip}:443 -connections {conn_n} -sni tempesta-tech.com -conn_type {ctype}"
         ]
-        client.start()
+        await client.start()
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
         self.assertEqual(0, client.returncode)
 
 

--- a/tests/frang/test_client_body_and_header_timeout.py
+++ b/tests/frang/test_client_body_and_header_timeout.py
@@ -14,8 +14,8 @@ TIMEOUT = 1
 
 
 class TestTimeoutBase(FrangTestCase):
-    request_segment_1: str or list
-    request_segment_2: str or list
+    request_segment_1: str | list
+    request_segment_2: str | list
     error: str
     frang_config: str
 
@@ -23,7 +23,7 @@ class TestTimeoutBase(FrangTestCase):
         self.disable_deproxy_auto_parser()
         client = self.get_client("deproxy-1")
         client.parsing = False
-        client.start()
+        await client.start()
 
         client.make_request(request=self.request_segment_1, end_stream=False)
         await asyncio.sleep(sleep)
@@ -95,7 +95,7 @@ class ClientHeaderTimeoutH2(H2Config, ClientHeaderTimeout):
     async def send_request_with_sleep(self, sleep: float, timeout_before_send=False):
         self.disable_deproxy_auto_parser()
         client = self.get_client("deproxy-1")
-        client.start()
+        await client.start()
         client.parsing = False
 
         self.__setup_connection(client)

--- a/tests/frang/test_concurrent_connections.py
+++ b/tests/frang/test_concurrent_connections.py
@@ -75,16 +75,16 @@ frang_limits {
         server = self.get_server("deproxy")
         server.bind_addr = ip
 
-        self.start_all_servers()
+        await self.start_all_servers()
         await self.start_tempesta()
-        self.deproxy_manager.start()
+        await self.deproxy_manager.start()
         for client in self.get_clients():
             """
             Set the same address as for standalone deproxy server.
             Try to connect to this server directly avoid Tempesta.
             """
             client.conn_addr = ip
-            client.start()
+            await client.start()
             """
             We need to be sure that previous client is establish or fail
             to establish connection because of limit exceeded. Otherwise
@@ -140,7 +140,7 @@ frang_limits {
     async def _base_scenario(self, clients: list, responses: int):
         self.disable_deproxy_auto_parser()
         for client in clients:
-            client.start()
+            await client.start()
             """
             We need to be sure that previous client is establish or fail
             to establish connection because of limit exceeded. Otherwise
@@ -245,11 +245,11 @@ frang_limits {
 
         for n in [warning_n, warning_n * 2]:
             for client in non_blocked_clients:
-                client.start()
+                await client.start()
                 await client.wait_for_connection_open()
 
             for client in blocked_clients:  # establish 2 or more connections
-                client.start()
+                await client.start()
                 await client.wait_for_connection_close(
                     msg="Tempesta did not block concurrent TCP connections."
                 )
@@ -260,6 +260,6 @@ frang_limits {
             await self.assertFrangWarning(warning=ERROR, expected=n)
 
             for client in non_blocked_clients + blocked_clients:
-                client.stop()
+                await client.stop()
 
             await self.assertWaitUntilEqual(self._get_num_active_conns, 0, timeout=3)

--- a/tests/frang/test_config.py
+++ b/tests/frang/test_config.py
@@ -78,7 +78,7 @@ block_action error reply;
         await self.start_all_services(client=False)
         client = self.get_client("deproxy-1")
 
-        client.start()
+        await client.start()
         client.make_request(client.create_request(method="POST", headers=[]), end_stream=False)
 
         default_size = 1073741824  # 1 GB
@@ -105,7 +105,7 @@ block_action error reply;
         client = self.get_client("deproxy-1")
         client.parsing = False
 
-        client.start()
+        await client.start()
         await client.send_request(
             request=client.create_request(
                 method="GET", headers=[("host", "otherhost")], authority="localhost"
@@ -125,7 +125,7 @@ block_action error reply;
         await self.start_all_services(client=False)
         client = self.get_client("deproxy-1")
 
-        client.start()
+        await client.start()
         await client.send_request(
             request=client.create_request(method="POST", headers=[]),
             expected_status_code="200",
@@ -141,7 +141,7 @@ block_action error reply;
         await self.start_all_services(client=False)
         client = self.get_client("deproxy-1")
 
-        client.start()
+        await client.start()
         client.make_request(
             request=client.create_request(
                 method="POST", headers=[("trailer", "x-my-hdr"), ("x-my-hdr", "value")]
@@ -171,7 +171,7 @@ block_action error reply;
         await self.start_all_services(client=False)
         client = self.get_client("deproxy-1")
 
-        client.start()
+        await client.start()
         await client.send_request(
             request=client.create_request(method="PUT", headers=[]),
             expected_status_code="403",
@@ -189,9 +189,9 @@ block_action error reply;
         client.connections = 1010
         client.options.append(f"--header 'Host: tempesta-tech.com'")
 
-        client.start()
+        await client.start()
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
 
         self.assertTrue(
             await self.loggers.dmesg.find(
@@ -209,7 +209,7 @@ block_action error reply;
         await self.start_all_services(client=False)
         client = self.get_client("deproxy-1")
 
-        client.start()
+        await client.start()
         await client.send_request(
             request=client.create_request(
                 method="POST", headers=[("x-my-hdr", "value") for _ in range(60)]
@@ -229,13 +229,13 @@ block_action error reply;
         client_1 = self.get_client("deproxy-1")
         client_2 = self.get_client("deproxy-2")
 
-        client_1.start()
+        await client_1.start()
         await client_1.send_request(
             request=client_1.create_request(method="PUT", headers=[]),
             expected_status_code="403",
         )
 
-        client_2.start()
+        await client_2.start()
         await client_2.send_request(
             request=client_2.create_request(method="POST", headers=[]),
             expected_status_code="200",
@@ -422,7 +422,7 @@ block_action error reply;
         self.assertTrue(await self.loggers.dmesg.find("frang: HTTP header length exceeded for"))
         self.assertTrue(await self.loggers.dmesg.find("Warning: block client"))
         await asyncio.sleep(2)
-        client.restart()
+        await client.restart()
         await client.send_request(
             client.create_request(authority="vh1", method="GET", headers=[("x-my-xdr", "a")]), "200"
         )
@@ -728,7 +728,7 @@ block_action error reply;
 
     async def _test_not_override_http_methods(self):
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
         await client.send_request(client.create_request(method="GET", headers=[]), "403")
         self.assertTrue(await self.loggers.dmesg.find("frang: restricted HTTP method for"))
 
@@ -737,8 +737,8 @@ block_action error reply;
         client_1 = self.get_client("deproxy_1")
         server = self.get_server("deproxy")
 
-        client.start()
-        client_1.start()
+        await client.start()
+        await client_1.start()
 
         client.make_request(client.create_request(method="GET", headers=[]))
         await server.wait_for_requests(n=1)
@@ -752,7 +752,7 @@ block_action error reply;
 
     async def _test_not_override_http_body_len_0(self):
         client = self.get_client("deproxy_http")
-        client.start()
+        await client.start()
         request = (
             f"POST /1234 HTTP/1.1\r\nHost: localhost\r\nContent-Length: 1000\r\n\r\n{'x' * 1000}"
         )
@@ -761,21 +761,21 @@ block_action error reply;
 
     async def _test_not_override_http_body_len_1(self):
         client = self.get_client("deproxy_http")
-        client.start()
+        await client.start()
         request = f"POST /1234 HTTP/1.1\r\nHost: localhost\r\nContent-Length: 2\r\n\r\n{'x' * 2}"
         await client.send_request(request, "403")
         self.assertTrue(await self.loggers.dmesg.find("frang: HTTP body length exceeded for"))
 
     async def _test_not_override_http_body_len_2(self):
         client = self.get_client("deproxy_http")
-        client.start()
+        await client.start()
         request = f"POST /1234 HTTP/1.1\r\nHost: localhost\r\nContent-Length: 2\r\n\r\n{'x' * 2}"
         await client.send_request(request, "200")
         self.assertFalse(await self.loggers.dmesg.find("frang: HTTP body length exceeded for"))
 
     async def _test_not_override_http_resp_code_block_1(self):
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
         client.make_request(client.create_request(method="GET", headers=[]))
         client.make_request(client.create_request(method="GET", headers=[]))
         client.make_request(client.create_request(method="GET", headers=[]))
@@ -786,7 +786,7 @@ block_action error reply;
 
     async def _test_not_override_http_resp_code_block_2(self):
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
         client.make_request(client.create_request(method="GET", headers=[]))
         client.make_request(client.create_request(method="GET", headers=[]))
         await client.wait_for_response(5)
@@ -926,13 +926,13 @@ block_action error reply;
 
     async def _test_override_http_methods_after_reload(self):
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
         await client.send_request(client.create_request(method="GET", headers=[]), "200")
         self.assertFalse(await self.loggers.dmesg.find("frang: restricted HTTP method for"))
 
     async def _test_override_ct_vals_after_reload(self):
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
         await client.send_request(
             client.create_request(method="POST", headers=[("content-type", "text/html")]), "200"
         )

--- a/tests/frang/test_header_cnt.py
+++ b/tests/frang/test_header_cnt.py
@@ -201,7 +201,7 @@ class FrangHttpHeaderCountH2(H2Config, FrangHttpHeaderCountTestCase):
 
         client = self.get_client("deproxy-1")
         client.parsing = False
-        client.start()
+        await client.start()
         client.make_request(
             request=self.post_request + [HeaderTuple(b"a", b"a" * 4000)],
             end_stream=False,

--- a/tests/frang/test_http_body_and_header_chunk_cnt.py
+++ b/tests/frang/test_http_body_and_header_chunk_cnt.py
@@ -30,7 +30,7 @@ class HttpHeaderChunkCnt(FrangTestCase):
 
         client = self.get_client("deproxy-1")
         client.parsing = False
-        client.start()
+        await client.start()
         for data in requests:
             client.make_request(data)
         await client.wait_for_response(n=1)
@@ -112,7 +112,7 @@ class HttpHeaderChunkCntH2Base(H2Config, FrangTestCase, base=True):
 
         client = self.get_client("deproxy-1")
         client.parsing = False
-        client.start()
+        await client.start()
 
         client.update_initial_settings()
         client.send_bytes(client.h2_connection.data_to_send())

--- a/tests/frang/test_http_resp_code_block.py
+++ b/tests/frang/test_http_resp_code_block.py
@@ -95,7 +95,7 @@ class TestRespCodeBlockOneClient(FrangTestCase):
         client = self.get_client("deproxy-1")
 
         await self.set_frang_config("http_resp_code_block 404 405 6 2;")
-        client.start()
+        await client.start()
 
         for rps, requests in [
             (2.8, [client.create_request(method="GET", uri=self.uri_404, headers=[]).msg] * 7),
@@ -117,7 +117,7 @@ class TestRespCodeBlockOneClient(FrangTestCase):
         await self.set_frang_config_no_shc("http_resp_code_block 404 405 6 2;")
 
         client = self.get_client("deproxy-1")
-        client.start()
+        await client.start()
         client.make_requests(
             [client.create_request(method="GET", uri=self.uri_405, headers=[]).msg] * 3
             + [client.create_request(method="GET", uri=self.uri_404, headers=[]).msg] * 4
@@ -135,7 +135,7 @@ class TestRespCodeBlockOneClient(FrangTestCase):
         await self.set_frang_config("http_resp_code_block 404 405 5 2;")
 
         client = self.get_client("deproxy-1")
-        client.start()
+        await client.start()
         client.make_requests(
             [client.create_request(method="GET", uri=self.uri_200, headers=[]).msg]
             + [client.create_request(method="GET", uri=self.uri_404, headers=[]).msg] * 4
@@ -233,10 +233,10 @@ tls_match_any_server_name;
         await self.start_all_services(client=False)
 
         deproxy_cl = self.get_client("deproxy3")
-        deproxy_cl.start()
+        await deproxy_cl.start()
 
         deproxy_cl2 = self.get_client("deproxy4")
-        deproxy_cl2.start()
+        await deproxy_cl2.start()
 
         request_1 = deproxy_cl.create_request(method="GET", uri="/uri1", headers=[])
         request_2 = deproxy_cl.create_request(method="GET", uri="/uri2", headers=[])
@@ -267,10 +267,10 @@ tls_match_any_server_name;
         await self.start_all_services(client=False)
 
         deproxy_cl = self.get_client("deproxy")
-        deproxy_cl.start()
+        await deproxy_cl.start()
 
         deproxy_cl2 = self.get_client("deproxy2")
-        deproxy_cl2.start()
+        await deproxy_cl2.start()
 
         request_1 = deproxy_cl.create_request(method="GET", uri="/uri1", headers=[])
         request_2 = deproxy_cl.create_request(method="GET", uri="/uri2", headers=[])

--- a/tests/frang/test_http_strict_host_checking.py
+++ b/tests/frang/test_http_strict_host_checking.py
@@ -129,7 +129,7 @@ class FrangHostRequiredTestCase(FrangTestCase):
         await self.set_frang_config(frang_config="http_strict_host_checking true;")
 
         client = self.get_client("deproxy-2")
-        client.start()
+        await client.start()
         client.make_request("GET / HTTP/1.1\r\nHost: tempesta-tech.com\r\n\r\n")
         await client.wait_for_response()
         await self.check_response(client, status_code="403", warning_msg=WARN_PORT)
@@ -142,7 +142,7 @@ class FrangHostRequiredTestCase(FrangTestCase):
         await self.set_frang_config(frang_config="http_strict_host_checking true;")
 
         client = self.get_client("deproxy-2")
-        client.start()
+        await client.start()
         client.make_request(
             "GET http://tempesta-tech.com:80/ HTTP/1.1\r\nHost: tempesta-tech.com\r\n\r\n"
         )
@@ -230,7 +230,7 @@ block_action error reply;
         """Test with header `host`, success."""
         await self.set_frang_config(frang_config="http_strict_host_checking true;")
         client = self.get_client("deproxy-1")
-        client.start()
+        await client.start()
         client.parsing = False
 
         first_headers = [(":authority", "localhost"), (":path", "/")]
@@ -318,7 +318,7 @@ block_action error reply;
         await self.set_frang_config(frang_config="http_strict_host_checking true;")
 
         client = self.get_client("deproxy-2")
-        client.start()
+        await client.start()
         client.make_request(
             [
                 (":scheme", "https"),

--- a/tests/frang/test_http_trailer_split_allowed.py
+++ b/tests/frang/test_http_trailer_split_allowed.py
@@ -85,7 +85,7 @@ class TestFrangHttpTrailerSplitAllowedH2(H2Config, FrangTestCase):
         await self.set_frang_config(f"{config}http_strict_host_checking false;")
 
         client = self.get_client("deproxy-1")
-        client.start()
+        await client.start()
         client.make_request(
             request=client.create_request(
                 method="POST", headers=[("trailer", "x-my-hdr"), ("x-my-hdr", "value")]

--- a/tests/frang/test_ip_block.py
+++ b/tests/frang/test_ip_block.py
@@ -90,7 +90,7 @@ block_action attack drop;
 
         await self.sniffer.start()
         await self.start_all_services(client=False)
-        four.start()
+        await four.start()
 
         # Good request: all is good
         await four.send_request(self.GOOD_REQ, "200")
@@ -104,7 +104,7 @@ block_action attack drop;
         self.assertTrue(c4.conn_is_active)
         await c4.send_request(self.GOOD_REQ, "200")
         # New clients with blocked IP won't be accepted
-        c5.start()
+        await c5.start()
         # don't adjust timeout. At this moment Tempesta doesn't accepts SYN from blocked client
         # and network not heavy loaded, thus doesn't make sense to wait 60 seconds on tcp
         # segmentation, 5 sec must be enough
@@ -129,7 +129,7 @@ block_action attack drop;
 
         await self.sniffer.start()
         await self.start_all_services(client=False)
-        three.start()
+        await three.start()
 
         # Good request: all is good
         await three.send_request(self.GOOD_REQ, "200")
@@ -146,14 +146,14 @@ block_action attack drop;
         await c2.wait_for_connection_close(timeout=2)
         # New clients with blocked IP won't be accepted
         # wait 3 seconds timeout - client is blocked
-        c2.restart()
+        await c2.restart()
         await c2.wait_for_connection_close(timeout=3, adjust_timeout=False)
         self.assertFalse(c2.conn_is_active)
         # Wait 12 seconds to have in most fastest case atleast 12 seconds wait that greater
         # than block duration
         await asyncio.sleep(12)
 
-        c2.restart()
+        await c2.restart()
         # block duration is 2 seconds, thus expect successful connection
         await c2.send_request(self.GOOD_REQ, "200")
 
@@ -173,8 +173,8 @@ block_action attack drop;
 
         await self.sniffer.start()
         await self.start_all_services(client=False)
-        c1.start()
-        c2.start()
+        await c1.start()
+        await c2.start()
 
         # Blocking is off: clients with the same IPs
         # handled separately
@@ -224,12 +224,12 @@ block_action attack drop;
         await self.sniffer.start()
         await self.start_all_services(client=False)
         for cl in [c1, c2, c3]:
-            cl.start()
+            await cl.start()
             await cl.wait_for_connection_open()
 
         await c2.send_request(self.REQ, "200")
         # On connection to c4 client - block expected
-        c4.start()
+        await c4.start()
         await c4.wait_for_connection_close(timeout=2)
         self.assertFalse(c4.conn_is_active)
 
@@ -240,7 +240,7 @@ block_action attack drop;
         self.assertTrue(c3.conn_is_active)
 
         # New clients with blocked IP won't be accepted
-        c5.start()
+        await c5.start()
         # don't adjust timeout. At this moment Tempesta doesn't accepts SYN from blocked client
         # and network not heavy loaded, thus doesn't make sense to wait 60 seconds on tcp
         # segmentation, 5 sec must be enough
@@ -266,14 +266,14 @@ block_action attack drop;
         await self.sniffer.start()
         await self.start_all_services(client=False)
         for cl in [c1, c2, c3]:
-            cl.start()
+            await cl.start()
             await cl.wait_for_connection_open()
 
         # Reset all current clients with the same IPs
         # New clients with blocked IP won't be accepted
-        c4.start()
+        await c4.start()
         for cl in [c1, c2, c4]:
-            cl.start()
+            await cl.start()
             await cl.wait_for_connection_close()
 
         # Client with different IP wasn't blocked
@@ -285,7 +285,7 @@ block_action attack drop;
         # ip will be blocked. But we can't be sure that it being blocked or it just disconnected, to
         # be sure that ip is blocked we do this connection attempt. At this moment connection will
         # not be established and SYN from client "c5" will be dropped
-        c5.start()
+        await c5.start()
         await c5.wait_for_connection_close(
             timeout=3, adjust_timeout=False, msg="Client has not been blocked"
         )
@@ -294,7 +294,7 @@ block_action attack drop;
         # than block duration
         await asyncio.sleep(11)
 
-        c4.restart()
+        await c4.restart()
         await c4.send_request(self.REQ, "200")
 
         self.sniffer.stop()
@@ -315,7 +315,7 @@ block_action attack drop;
         await asyncio.sleep(self.timeout)
         await self.start_all_services(client=False)
         for cl in [c1, c2, c3]:
-            cl.start()
+            await cl.start()
 
         # The last connection triggers block by concurrent_tcp_connections.
         await c1.wait_for_connection_open()

--- a/tests/frang/test_request_rate_burst.py
+++ b/tests/frang/test_request_rate_burst.py
@@ -132,8 +132,8 @@ tls_certificate_key ${tempesta_workdir}/tempesta.key;
     async def arrange(self, c1, c2):
         await self.sniffer.start()
         await self.set_frang_config(self.frang_config)
-        c1.start()
-        c2.start()
+        await c1.start()
+        await c2.start()
 
     def do_requests(self, c1, c2, request_cnt_1: int, request_cnt_2: int):
         for _ in range(request_cnt_1):
@@ -266,7 +266,7 @@ class TestFrangRequestRateBurst(FrangTestCase):
         await self.start_all_services(client=False)
 
         client = self.get_client(self.client_name)
-        client.start()
+        await client.start()
 
         start_time = time.monotonic()
         for _ in range(req_n):
@@ -314,7 +314,7 @@ class TestFrangRequestRateBurst(FrangTestCase):
         await self.start_all_services(client=False)
 
         client = self.get_client(self.client_name)
-        client.start()
+        await client.start()
 
         start_time = time.monotonic()
         for _ in range(req_n):

--- a/tests/frang/test_tls_incomplete.py
+++ b/tests/frang/test_tls_incomplete.py
@@ -2,8 +2,8 @@
 
 import asyncio
 
-from framework.test_suite import marks
 from framework.helpers import dmesg
+from framework.test_suite import marks
 from tests.frang.frang_test_case import FrangTestCase
 
 __author__ = "Tempesta Technologies, Inc."
@@ -69,9 +69,9 @@ class FrangTlsIncompleteTestCase(FrangTestCase):
 
         await self.start_all_services(client=False)
 
-        curl.start()
+        await curl.start()
         await self.wait_while_busy(curl)
-        curl.stop()
+        await curl.stop()
 
         await asyncio.sleep(self.timeout)
 

--- a/tests/frang/test_whitelist_mark.py
+++ b/tests/frang/test_whitelist_mark.py
@@ -93,7 +93,7 @@ class FrangWhitelistMarkTestCase(NetfilterMarkMixin, tester.TempestaTest):
         await self.start_all_services(client=False)
 
         client: deproxy_client.DeproxyClient = self.get_client("deproxy-cl")
-        client.start()
+        await client.start()
         await client.send_request(
             client.create_request(uri="/", method="GET", headers=[]),
             expected_status_code="200",
@@ -104,7 +104,7 @@ class FrangWhitelistMarkTestCase(NetfilterMarkMixin, tester.TempestaTest):
         await self.start_all_services(client=False)
 
         client: deproxy_client.DeproxyClient = self.get_client("deproxy-cl")
-        client.start()
+        await client.start()
         await client.send_request(
             client.create_request(uri="/", method="GET", headers=[("x-forwarded-for", "1.2.3.4")]),
             expected_status_code="200",
@@ -115,7 +115,7 @@ class FrangWhitelistMarkTestCase(NetfilterMarkMixin, tester.TempestaTest):
         await self.start_all_services(client=False)
 
         client: deproxy_client.DeproxyClient = self.get_client("deproxy-cl")
-        client.start()
+        await client.start()
         await client.send_request(
             # very long uri
             client.create_request(uri="/" + "a" * 25, method="GET", headers=[]),
@@ -127,7 +127,7 @@ class FrangWhitelistMarkTestCase(NetfilterMarkMixin, tester.TempestaTest):
         await self.start_all_services(client=False)
 
         client: deproxy_client.DeproxyClient = self.get_client("deproxy-cl")
-        client.start()
+        await client.start()
         await client.send_request(
             # very long uri
             client.create_request(
@@ -147,9 +147,9 @@ class FrangWhitelistMarkTestCase(NetfilterMarkMixin, tester.TempestaTest):
 
         await self.start_all_services()
 
-        curl.start()
+        await curl.start()
         await self.wait_while_busy(curl)
-        curl.stop()
+        await curl.stop()
         # we expect all requests to receive 200
         self.assertEqual(
             curl.statuses,
@@ -161,7 +161,7 @@ class FrangWhitelistMarkTestCase(NetfilterMarkMixin, tester.TempestaTest):
         await self.start_all_services(client=False)
 
         client: deproxy_client.DeproxyClient = self.get_client("deproxy-cl")
-        client.start()
+        await client.start()
         await client.send_request(
             client.create_request(uri="/", method="GET", headers=[]),
             expected_status_code="403",

--- a/tests/health_monitoring/test_health_monitor.py
+++ b/tests/health_monitoring/test_health_monitor.py
@@ -168,19 +168,13 @@ return 200;
         },
     ]
 
-    def wait_for_server(self, srv):
-        srv.start()
-        while srv.state != "started":
-            pass
-        srv.wait_for_connections()
-
-    def run_curl(self, n=1):
+    async def run_curl(self, n=1):
         res = defaultdict(int)
         for _ in range(n):
             curl = self.get_client("curl")
-            curl.start()
+            await curl.start()
             curl.wait_for_finish()
-            curl.stop()
+            await curl.stop()
             res[curl.response_msg[:-1]] += 1
         return res
 
@@ -192,7 +186,7 @@ return 200;
         back1 = self.get_server("nginx1")
         back2 = self.get_server("nginx2")
         back3 = self.get_server("nginx3")
-        res = self.run_curl(REQ_COUNT)
+        res = await self.run_curl(REQ_COUNT)
         self.assertEqual(
             list(res.keys()),
             ["502"],
@@ -201,9 +195,9 @@ return 200;
         )
 
         # 2
-        self.wait_for_server(back1)
-        self.wait_for_server(back2)
-        res = self.run_curl(REQ_COUNT)
+        await back1.wait_for_connections()
+        await back2.wait_for_connections()
+        res = await self.run_curl(REQ_COUNT)
         self.assertEqual(
             list(res.values()),
             [50, 50],
@@ -211,8 +205,8 @@ return 200;
         )
 
         # 3
-        self.wait_for_server(back3)
-        res = self.run_curl(REQ_COUNT)
+        await back3.wait_for_connections()
+        res = await self.run_curl(REQ_COUNT)
         self.assertGreater(
             res["200"],
             res["502"],
@@ -220,13 +214,13 @@ return 200;
         )
 
         # 4
-        res = self.run_curl(REQ_COUNT)
+        res = await self.run_curl(REQ_COUNT)
         self.assertGreater(
             res["200"],
             res["502"],
             f"TempestaFW or server are not stable. Response statuses - {res.items()}",
         )
-        back3.stop()
+        await back3.stop()
 
 
 DEPROXY_CLIENT = {

--- a/tests/http2_general/test_h2_headers.py
+++ b/tests/http2_general/test_h2_headers.py
@@ -889,7 +889,7 @@ class TestTrailers(H2Base):
             ("user-agent", "Mozilla/5.0 (Windows NT 6.1;) Gecko/20100101 Firefox/47.0"),
         ]:
             with self.subTest(msg=f"The request with trailer - `{header[0]}: {header[1]}`"):
-                client.restart()
+                await client.restart()
                 await self.initiate_h2_connection(client)
                 client.init_stream_for_send(1)
                 self.__send_headers_and_data_frames(client)
@@ -1070,17 +1070,17 @@ class CurlTestBase(tester.TempestaTest):
     async def run_test(self, served_from_cache=False):
         curl = self.get_client("curl")
 
-        self.start_all_servers()
+        await self.start_all_servers()
         await self.start_tempesta()
 
-        self.start_all_clients()
+        await self.start_all_clients()
         await self.wait_while_busy(curl)
-        curl.stop()
+        await curl.stop()
         self.assertIn("200", curl.response_msg)
 
-        self.start_all_clients()
+        await self.start_all_clients()
         await self.wait_while_busy(curl)
-        curl.stop()
+        await curl.stop()
         self.assertIn("200", curl.response_msg)
 
         nginx = self.get_server("nginx")
@@ -1096,12 +1096,12 @@ class CurlTestBase(tester.TempestaTest):
 
         await self.start_all_services()
         await self.wait_while_busy(curl)
-        curl.stop()
+        await curl.stop()
         self.assertIn("200", curl.response_msg)
 
-        self.start_all_clients()
+        await self.start_all_clients()
         await self.wait_while_busy(curl)
-        curl.stop()
+        await curl.stop()
         self.assertIn("200", curl.response_msg)
 
         srv = self.get_server("deproxy")
@@ -1184,15 +1184,15 @@ return 200;
     async def test(self, served_from_cache=True):
         curl = self.get_client("curl")
 
-        self.start_all_servers()
+        await self.start_all_servers()
         await self.start_tempesta()
 
-        self.start_all_clients()
+        await self.start_all_clients()
         await self.wait_while_busy(curl)
         self.assertEqual(
             0, curl.returncode, msg=("Curl return code is not 0 (%d)." % (curl.returncode))
         )
-        curl.stop()
+        await curl.stop()
 
         setcookie_count = 0
         lines = curl.stderr.decode().split("\n")
@@ -1202,7 +1202,7 @@ return 200;
                 self.assertEqual(len(line.split(",")), 1, "Wrong separator")
         self.assertEqual(setcookie_count, 3, "Set-Cookie headers quantity mismatch")
 
-        self.start_all_clients()
+        await self.start_all_clients()
         await self.wait_while_busy(curl)
         self.assertEqual(
             0, curl.returncode, msg=("Curl return code is not 0 (%d)." % (curl.returncode))
@@ -1713,7 +1713,7 @@ class TestNoContentLengthInMethod(tester.TempestaTest):
 
         server = self.get_server("deproxy")
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
 
         for status in self.statuses:
             with self.subTest(status=status):

--- a/tests/http2_general/test_h2_hpack.py
+++ b/tests/http2_general/test_h2_hpack.py
@@ -860,9 +860,9 @@ class TestHpackCache(TestHpackBase):
         await self.initiate_h2_connection(client)
 
         await client.send_request(self.get_request, "200")
-        client.stop()
+        await client.stop()
 
-        client.start()
+        await client.start()
         await client.send_request(self.get_request, "200")
 
         self.assertEqual(1, len(server.requests))
@@ -1118,8 +1118,8 @@ class TestHpackBomb(TestHpackBase):
         # Max table size 4096 bytes, see RFC 7540 6.5.2
         for bomb_size in [(2**8), (2**14 - 9)]:
             with self.subTest(bomb_size=bomb_size):
-                client.stop()
-                client.start()
+                await client.stop()
+                await client.start()
                 client.make_request(
                     request=self.post_request + [HeaderTuple(b"a", b"a" * 4063)],
                     end_stream=False,
@@ -1592,7 +1592,7 @@ class TestLoadingHeadersFromHpackDynamicTable(H2Base):
         # Cookie was reloaded from hpack table, count is 6 blocked.
         await self.__send_add_check_req_with_huffman(client, second_request, huffman, "403")
 
-        client.restart()
+        await client.restart()
         await self.initiate_h2_connection(client)
 
         # Request which was previously successful is blocked.

--- a/tests/http2_general/test_h2_perf.py
+++ b/tests/http2_general/test_h2_perf.py
@@ -95,10 +95,8 @@ class TLSPerf(tester.TempestaTest):
     async def test(self):
         tls_perf = self.get_client("tls-perf")
 
-        self.start_all_servers()
-        await self.start_tempesta()
-        tls_perf.start()
+        await self.start_all_services()
         await self.wait_while_busy(tls_perf)
-        tls_perf.stop()
+        await tls_perf.stop()
 
         self.assertFalse(tls_perf.stderr)

--- a/tests/http2_general/test_h2_responses.py
+++ b/tests/http2_general/test_h2_responses.py
@@ -88,15 +88,15 @@ class TestH2Responses(tester.TempestaTest):
 
     async def __setup_h2_responses_test(self):
         curl = self.get_client("curl")
-        self.start_all_servers()
+        await self.start_all_servers()
         await self.start_tempesta()
         return curl
 
     async def __test_h2_response(self, curl, header_name, header_value, status):
         curl.headers[header_name] = header_value
-        curl.start()
+        await curl.start()
         await self.wait_while_busy(curl)
-        curl.stop()
+        await curl.stop()
         response = curl.last_response
         self.assertEqual(response.status, status)
 

--- a/tests/http2_general/test_h2_specs.py
+++ b/tests/http2_general/test_h2_specs.py
@@ -100,6 +100,6 @@ class H2Spec(tester.TempestaTest):
 
         h2spec = self.get_client("h2spec")
         await self.wait_while_busy(h2spec)
-        h2spec.stop()
+        await h2spec.stop()
         self.assertEqual(0, h2spec.returncode)
         assert "0 failed" in h2spec.response_msg, h2spec.response_msg

--- a/tests/http2_general/test_h2_sticky_cookie.py
+++ b/tests/http2_general/test_h2_sticky_cookie.py
@@ -91,12 +91,12 @@ class H2StickyCookieBaseTestCase(tester.TempestaTest):
         """Check for presents `set-cookie` header."""
         curl = self.get_client("curl-1")
 
-        self.start_all_servers()
+        await self.start_all_servers()
         await self.start_tempesta()
 
-        curl.start()
+        await curl.start()
         await self.wait_while_busy(curl)
-        curl.stop()
+        await curl.stop()
 
         response = curl.response_msg
         self.assertIn(
@@ -165,12 +165,12 @@ class H2StickyCookieTestCase(tester.TempestaTest):
         """Send request with many `Cookie` headers and enforced option."""
         curl = self.get_client("curl-2")
 
-        self.start_all_servers()
+        await self.start_all_servers()
         await self.start_tempesta()
 
-        curl.start()
+        await curl.start()
         await self.wait_while_busy(curl)
-        curl.stop()
+        await curl.stop()
 
         response = curl.response_msg
         self.assertIn(
@@ -199,12 +199,12 @@ class H2StickyCookieTestCase(tester.TempestaTest):
         """Send request with no `Cookie` headers and enforced option."""
         curl = self.get_client("curl-3")
 
-        self.start_all_servers()
+        await self.start_all_servers()
         await self.start_tempesta()
 
-        curl.start()
+        await curl.start()
         await self.wait_while_busy(curl)
-        curl.stop()
+        await curl.stop()
 
         response = curl.response_msg
         self.assertIn(

--- a/tests/http2_general/test_h2_streams.py
+++ b/tests/http2_general/test_h2_streams.py
@@ -287,10 +287,10 @@ class TestMultiplexing(tester.TempestaTest):
             step += 1
 
         for client in clients:
-            client.start()
+            await client.start()
         await self.wait_while_busy(*clients)
         for client in clients:
-            client.stop()
+            await client.stop()
 
         step = 1
         for client, server in list(zip(clients, servers)):

--- a/tests/http_general/test_block_action.py
+++ b/tests/http_general/test_block_action.py
@@ -4,8 +4,6 @@ __author__ = "Tempesta Technologies, Inc."
 __copyright__ = "Copyright (C) 2023-2025 Tempesta Technologies, Inc."
 __license__ = "GPL2"
 
-import asyncio
-
 import run_config
 from framework.deproxy import deproxy_message
 from framework.deproxy.deproxy_client import BaseDeproxyClient

--- a/tests/http_general/test_expect_100_continue.py
+++ b/tests/http_general/test_expect_100_continue.py
@@ -50,7 +50,7 @@ class TestExpect100ContinueBehavior(tester.TempestaTest):
         await self.start_all_services(client=False)
 
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
 
         await client.send_request(
             request=client.create_request(
@@ -77,7 +77,7 @@ class TestExpect100ContinueBehavior(tester.TempestaTest):
         await self.start_all_services(client=False)
 
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
 
         await client.send_request(
             request=client.create_request(
@@ -114,7 +114,7 @@ class TestExpect100ContinueBehavior(tester.TempestaTest):
         server.delay_before_sending_response = 2
 
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
 
         client.make_requests(
             requests=[
@@ -172,7 +172,7 @@ class TestExpect100ContinueBehavior(tester.TempestaTest):
         server.delay_before_sending_response = 2
 
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
 
         client.make_requests(
             requests=[
@@ -219,7 +219,7 @@ class TestExpect100ContinueBehavior(tester.TempestaTest):
         server.delay_before_sending_response = 2
 
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
 
         client.make_requests(
             requests=[
@@ -279,7 +279,7 @@ class TestExpect100ContinueBehavior(tester.TempestaTest):
         server.delay_before_sending_response = 2
 
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
 
         client.make_requests(
             requests=[
@@ -326,7 +326,7 @@ class TestExpect100ContinueBehavior(tester.TempestaTest):
         await self.start_all_services(client=False)
 
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
 
         client.make_requests(
             requests=[
@@ -374,7 +374,7 @@ class TestExpect100ContinueBehavior(tester.TempestaTest):
         await self.start_all_services(client=False)
 
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
 
         client.make_requests(
             requests=[

--- a/tests/http_general/test_headers.py
+++ b/tests/http_general/test_headers.py
@@ -193,12 +193,12 @@ class TestSmallHeader(tester.TempestaTest):
 
         for length in range(1, 5):
             header = "X" * length
-            client.start()
+            await client.start()
             with self.subTest(header=header):
                 client.make_request(f"GET / HTTP/1.1\r\nHost: deproxy\r\n{header}: test\r\n\r\n")
                 await client.wait_for_response(timeout=1)
                 self.assertEqual(client.last_response.status, "200")
-            client.stop()
+            await client.stop()
 
 
 class TestHostBase(tester.TempestaTest):
@@ -1048,7 +1048,7 @@ class TestNoContentLengthInMethod(tester.TempestaTest):
 
         server = self.get_server("deproxy")
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
 
         for status in self.statuses:
             with self.subTest(status=status):

--- a/tests/http_rules/test_backup_servers.py
+++ b/tests/http_rules/test_backup_servers.py
@@ -97,13 +97,13 @@ http_chain {
         await client.send_request(request, "200")
         got_requests = len(primary_server.requests)
 
-        primary_server.stop()
+        await primary_server.stop()
         # Sleep to be shure that server is stopped and connection
         # is closed (Remove after #2111 in Tempesta)
         await asyncio.sleep(1)
         await client.send_request(request, "200")
 
-        primary_server.start()
+        await primary_server.start()
         await primary_server.wait_for_connections(3)
         await client.send_request(request, "200")
         got_requests += len(primary_server.requests)

--- a/tests/http_rules/test_http_rules.py
+++ b/tests/http_rules/test_http_rules.py
@@ -204,7 +204,7 @@ class TestHostBase(tester.TempestaTest):
         for step in range(3)
     ]
 
-    async def send_request_and_check_server_request(self, request: str or list, server_id: int):
+    async def send_request_and_check_server_request(self, request: str | list, server_id: int):
         await self.start_all_services()
         client = self.get_client("deproxy")
         client.parsing = False

--- a/tests/http_rules/test_http_tables.py
+++ b/tests/http_rules/test_http_tables.py
@@ -336,7 +336,7 @@ class HttpTablesTestBase(tester.TempestaTest, base=True):
 
         deproxy_cl = self.get_client("client")
         deproxy_cl.server_hostname = "tempesta-tech.com"
-        deproxy_cl.start()
+        await deproxy_cl.start()
         deproxy_cl.make_request(self.requests)
         if self.resp_status:
             await deproxy_cl.wait_for_response()
@@ -925,7 +925,7 @@ class TestHttpTablesPatternTrimming(tester.TempestaTest):
             (("r", "v"), "vh2"),
         ):
             with self.subTest(headers=headers, expected_vhost=expected_vhost):
-                client.restart()
+                await client.restart()
                 await client.send_request(
                     request=client.create_request(method="GET", uri="/", headers=[headers]),
                     expected_status_code="200",

--- a/tests/leaks/test_leak.py
+++ b/tests/leaks/test_leak.py
@@ -179,11 +179,11 @@ frang_limits {http_strict_host_checking false;}
         tempesta = self.get_tempesta()
         await self.start_all_services()
         await self.wait_while_busy(client)
-        client.stop()
-        tempesta.stop()
+        await client.stop()
+        await tempesta.stop()
         backend.get_stats()
         self.assertGreater(backend.requests, 0)
-        backend.stop()
+        await backend.stop()
 
     async def test_kmemleak(self):
         """Detecting leaks with kmemleak"""

--- a/tests/long_body/test_long_request.py
+++ b/tests/long_body/test_long_request.py
@@ -123,9 +123,9 @@ class LongBodyInRequest(tester.TempestaTest):
 
         client = self.get_client(client_id)
         client.options = [f" --data-binary @'{self.abs_path}' -H '{header}' -H 'Expect: '"]
-        client.start()
+        await client.start()
         await client.wait_for_finish()
-        client.stop()
+        await client.stop()
 
         self.assertIsNotNone(client.last_response)
         self.assertEqual(client.last_response.status, 200)

--- a/tests/long_body/test_long_response.py
+++ b/tests/long_body/test_long_response.py
@@ -86,9 +86,9 @@ cache 0;
 
         client: curl_client.CurlClient = self.get_client(client_id)
         client.options = [" --raw"]
-        client.start()
+        await client.start()
         await client.wait_for_finish(timeout=100)
-        client.stop()
+        await client.stop()
 
         self.assertIsNotNone(client.last_response)
         if client.http2:

--- a/tests/malformed/test_h2_field_validity.py
+++ b/tests/malformed/test_h2_field_validity.py
@@ -69,7 +69,7 @@ block_action error reply;
         self.assertEqual("400", client.last_response.status)
 
         await client.wait_for_connection_close()
-        client.stop()
+        await client.stop()
 
     async def test_ascii_uppercase_in_header_name(self):
         """

--- a/tests/mixed_requests/test_mixed.py
+++ b/tests/mixed_requests/test_mixed.py
@@ -275,9 +275,9 @@ frang_limits {
 
         wrk = self.get_client("wrk")
         wrk.set_script("wrk", lua)
-        wrk.start()
+        await wrk.start()
         await self.wait_while_busy(wrk)
-        wrk.stop()
+        await wrk.stop()
 
         self.assertIn(405, wrk.statuses)
         self.assertNotIn(403, wrk.statuses)
@@ -335,9 +335,9 @@ frang_limits {
         wrk = self.get_client("wrk")
         wrk.set_script("wrk", lua_trace)
 
-        wrk.start()
+        await wrk.start()
         await self.wait_while_busy(wrk)
-        wrk.stop()
+        await wrk.stop()
         self.assertNotIn(200, wrk.statuses)
         self.assertIn(405, wrk.statuses)
         self.assertGreater(wrk.statuses[405], 0)

--- a/tests/modify_http_headers/test_logic.py
+++ b/tests/modify_http_headers/test_logic.py
@@ -43,7 +43,7 @@ def generate_h2_request(optional_headers=[]) -> list:
 
 def get_expected_response(
     optional_headers: list, expected_headers: list, client, cache: bool, directive: str
-) -> Response or H2Response:
+) -> Response | H2Response:
     if client.is_http2:
         tempesta_headers = [
             ("via", f"2.0 tempesta_fw (Tempesta FW {tempesta.version()})"),

--- a/tests/msg_sequence/test_pairing.py
+++ b/tests/msg_sequence/test_pairing.py
@@ -73,11 +73,11 @@ tls_match_any_server_name;
             client.make_request(request)
 
         await server.wait_for_requests(n=chain_size)
-        client.stop()
+        await client.stop()
 
         server.set_response("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
 
-        client.start()
+        await client.start()
         await client.send_request(request, "200")
 
         self.assertTrue(

--- a/tests/multiple_clients/test_multiple_clients.py
+++ b/tests/multiple_clients/test_multiple_clients.py
@@ -78,7 +78,7 @@ server ${server_ip}:8000;
         FW stopping.
         """
         await self.disable_close_connection_and_send_requests()
-        self.get_tempesta().stop()
+        await self.get_tempesta().stop()
 
     async def test_tcp_fin_timeout(self):
         """
@@ -91,11 +91,11 @@ server ${server_ip}:8000;
         await asyncio.sleep(tcp_fin_timeout + 1)
 
         t = time.time()
-        self.get_tempesta().stop()
+        await self.get_tempesta().stop()
         self.assertLess(time.time() - t, 5)
 
         for client in self.get_clients():
-            client.stop()
+            await client.stop()
             self.assertTrue(
                 client.is_rst_received, "Client don't receive TCP RST when Tempesta FW closes."
             )
@@ -111,6 +111,6 @@ server ${server_ip}:8000;
         request = self.get_client("deproxy-0").create_request(method="GET", headers=[])
 
         for client in self.get_clients():
-            client.start()
+            await client.start()
             await client.send_request(request, "200")
-            client.stop()
+            await client.stop()

--- a/tests/multiple_listeners/test_mixed.py
+++ b/tests/multiple_listeners/test_mixed.py
@@ -170,9 +170,9 @@ class TestMixedListeners(tester.TempestaTest):
             str: server response to the request as string
         """
         client: ExternalTester = self.get_client(curl_client_id)
-        client.start()
+        await client.start()
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
         return client.response_msg
 
     def check_curl_response(self, response: str, fail=False):

--- a/tests/multiple_listeners/test_multiple_listening.py
+++ b/tests/multiple_listeners/test_multiple_listening.py
@@ -1435,7 +1435,7 @@ class TestMultipleListening(tester.TempestaTest):
                     cli[ID],
                 )
                 await self.wait_while_busy(h2spec)
-                h2spec.stop()
+                await h2spec.stop()
                 self.assertIn(
                     H2SPEC_OK,
                     h2spec.response_msg,
@@ -1446,9 +1446,9 @@ class TestMultipleListening(tester.TempestaTest):
                 curl = self.get_client(
                     cli[ID],
                 )
-                curl.start()
+                await curl.start()
                 await self.wait_while_busy(curl)
-                curl.stop()
+                await curl.stop()
                 self.assertIn(
                     STATUS_OK,
                     curl.response_msg,

--- a/tests/reconf/reconf_stress.py
+++ b/tests/reconf/reconf_stress.py
@@ -49,14 +49,14 @@ class LiveReconfStressTestBase(tester.TempestaTest, base=True):
             str: server response to the request as string
         """
         client = self.get_client(curl_client_id)
-        client.start()
+        await client.start()
         await self.wait_while_busy(client)
         self.assertEqual(
             0,
             client.returncode,
             msg=(f"Curl return code is not 0. Received - {client.returncode}."),
         )
-        client.stop()
+        await client.stop()
         return client.response_msg
 
     async def make_curl_client_request(
@@ -84,14 +84,14 @@ class LiveReconfStressTestBase(tester.TempestaTest, base=True):
             for key, val in headers.items():
                 curl.headers[key] = val
 
-        curl.start()
+        await curl.start()
         await self.wait_while_busy(curl)
         self.assertEqual(
             0,
             curl.returncode,
             msg=(f"Curl return code is not 0. Received - {curl.returncode}."),
         )
-        curl.stop()
+        await curl.stop()
         return curl.last_response
 
     def reload_tfw_config(

--- a/tests/reconf/test_reconf_base.py
+++ b/tests/reconf/test_reconf_base.py
@@ -48,14 +48,14 @@ class TestListenCommonReconf(tester.TempestaTest):
         await self.start_tempesta()
 
         remote.tempesta.run_cmd("sysctl -e -w net.tempesta.state=stop")
-        tempesta.run_start()
+        await tempesta.run_start()
 
     async def test_reconf_busy_socks(self):
         """The user is trying to add listen to a busy port by another service."""
         tempesta = self.get_tempesta()
         port_checker = port_checks.FreePortsChecker()
 
-        self.start_all_servers()
+        await self.start_all_servers()
 
         # Tempesta listen 443 port and Nginx listen 8000 port
         tempesta.config.set_defconfig(self.tempesta_orig["config"])
@@ -164,7 +164,7 @@ frang_limits {{http_strict_host_checking false;}}
 
         client = self.get_client(proto)
         request = client.create_request(method="GET", headers=[])
-        client.start()
+        await client.start()
 
         with self.subTest(msg=f"Tempesta did not change listening proto after reload."):
             await client.send_request(request, "200")
@@ -178,13 +178,13 @@ frang_limits {{http_strict_host_checking false;}}
         client = self.get_client(self.proto)
         request = client.create_request(method="GET", headers=[])
         client.port = 4433
-        client.start()
+        await client.start()
 
         with self.subTest(msg=f"Tempesta did not change listening port after reload."):
             await client.send_request(request, "200")
 
         client.port = 443
-        client.restart()
+        await client.restart()
 
         with self.subTest(msg=f"Tempesta continued listening to the old port."):
             with self.assertRaises(AssertionError):
@@ -227,13 +227,13 @@ frang_limits {{http_strict_host_checking false;}}
         request = client.create_request(method="GET", headers=[])
         client.conn_addr = new_ip
         client.port = port
-        client.start()
+        await client.start()
 
         with self.subTest(msg=f"Tempesta did not change listening IP after reload."):
             await client.send_request(request, "200")
 
         client.conn_addr = old_ip
-        client.restart()
+        await client.restart()
 
         with self.subTest(msg=f"Tempesta continued listening to old IP after reload."):
             with self.assertRaises(AssertionError):
@@ -264,11 +264,11 @@ frang_limits {{http_strict_host_checking false;}}
         client = self.get_client(self.proto)
         request = client.create_request(method="GET", headers=[])
 
-        client.start()
+        await client.start()
         await client.send_request(request, "200")
 
         client.port = 444
-        client.restart()
+        await client.restart()
         client.make_request(request)
         await getattr(client, client_wait_method_for_444_port)()
 
@@ -294,13 +294,13 @@ class TestListenStartFail(tester.TempestaTest):
         },
     ]
 
-    def __heavy_load(self, stop_event):
+    async def __heavy_load(self, stop_event):
         curl = self.get_client("curl")
 
         while not stop_event.is_set():
-            curl.start()
-            time.sleep(0.1)
-            curl.stop()
+            await curl.start()
+            await asyncio.sleep(0.1)
+            await curl.stop()
 
     async def asyncSetUp(self):
         await super().asyncSetUp()
@@ -316,8 +316,8 @@ class TestListenStartFail(tester.TempestaTest):
         unsuccessful start.
         """
         server = self.get_server("deproxy")
-        server.start()
-        self.deproxy_manager.start()
+        await server.start()
+        await self.deproxy_manager.start()
 
         task = self.create_task(self.__heavy_load)
         task.start()
@@ -337,7 +337,7 @@ class TestListenStartFail(tester.TempestaTest):
             error.ProcessBadExitStatusException,
             msg="Tempesta FW successfully start, although one of the port is already listened by deproxy server",
         ):
-            self.get_tempesta().start()
+            await self.get_tempesta().start()
 
 
 class TestServerReconf(tester.TempestaTest):
@@ -369,11 +369,11 @@ class TestServerReconf(tester.TempestaTest):
 
     async def _start_all(self, servers: list, client: bool):
         for server in servers:
-            server.start()
+            await server.start()
         await self.start_tempesta()
         if client:
-            self.start_all_clients()
-        self.deproxy_manager.start()
+            await self.start_all_clients()
+        await self.deproxy_manager.start()
 
         for server in servers:
             await server.wait_for_connections()
@@ -493,7 +493,7 @@ http_chain {{
             msg="Tempesta did not change number of connections with server after reload."
         )
 
-        client.start()
+        await client.start()
         await client.send_request(client.create_request(method="GET", headers=[]), "200")
 
     @marks.Parameterize.expand(
@@ -546,7 +546,7 @@ http_chain {{
             msg="Tempesta did not change number of connections with server after reload."
         )
 
-        client.start()
+        await client.start()
         await client.send_request(client.create_request(method="GET", headers=[]), "200")
 
     @marks.Parameterize.expand(
@@ -594,7 +594,7 @@ http_chain {{
 
         request = client.create_request(method="GET", headers=[], authority="grp1")
         for _ in range(10):
-            client.restart()
+            await client.restart()
             await client.send_request(request, "200")
 
         self.assertIsNotNone(
@@ -637,7 +637,7 @@ http_chain {{
         second_config(self)
 
         self.get_tempesta().reload()
-        server_2.start()
+        await server_2.start()
         await server_1.wait_for_connections(
             msg=(
                 "Tempesta removed connections to a old server/srv_group after reload. "
@@ -650,7 +650,7 @@ http_chain {{
         )
 
         for authority in ["grp1", "grp2"] * 5:
-            client.restart()
+            await client.restart()
             await client.send_request(
                 client.create_request(method="GET", headers=[], authority=authority), "200"
             )
@@ -1249,19 +1249,19 @@ class TestVhostReconf(tester.TempestaTest):
         srv1 = self.get_server("deproxy-1")
         srv2 = self.get_server("deproxy-2")
 
-        srv1.start()
-        srv2.start()
-        self.deproxy_manager.start()
+        await srv1.start()
+        await srv2.start()
+        await self.deproxy_manager.start()
 
         first_config(self)
-        tempesta.start()
+        await tempesta.start()
         second_config(self)
         tempesta.reload()
         await srv1.wait_for_connections()
         await getattr(srv2, srv2_wait_method)()
 
         for authority, server_header in zip(["grp1", "grp2"], server_headers):
-            client.restart()
+            await client.restart()
             await client.send_request(
                 client.create_request(method="GET", headers=[], authority=authority), "200"
             )
@@ -1293,11 +1293,11 @@ http_chain {{
 }}
 """
         )
-        server.start()
-        tempesta.start()
-        self.deproxy_manager.start()
+        await server.start()
+        await tempesta.start()
+        await self.deproxy_manager.start()
         await server.wait_for_connections()
-        client.start()
+        await client.start()
 
         tempesta.config.set_defconfig(
             f"""
@@ -1442,7 +1442,7 @@ http_chain {{
         self._set_tempesta_config_with_backup_group(backup_group="default")
         self.get_tempesta().reload()
 
-        server_grp1.stop()
+        await server_grp1.stop()
         # Remove after #2111 in Tempesta
         await asyncio.sleep(1)
 
@@ -1564,7 +1564,7 @@ class TestLocationReconf(tester.TempestaTest):
 
         client = self.get_client("deproxy")
         for uri, expected_header in zip(["/static/", "/dynamic/"], expected_headers):
-            client.restart()
+            await client.restart()
             await client.send_request(
                 client.create_request(method="GET", headers=[], uri=uri), "200"
             )
@@ -1955,7 +1955,7 @@ http_chain {{
         self.oops_ignore = ["ERROR"]
 
         tempesta.config.set_defconfig(self.base_tempesta_config + valid_config)
-        tempesta.start()
+        await tempesta.start()
         tempesta.config.set_defconfig(self.base_tempesta_config + invalid_config)
         with self.assertRaises(error.ProcessBadExitStatusException):
             tempesta.reload()

--- a/tests/reconf/test_stress_grace_shutdown.py
+++ b/tests/reconf/test_stress_grace_shutdown.py
@@ -154,7 +154,7 @@ class TestGraceShutdownLiveReconf(LiveReconfStressTestBase):
 
         # launch h2load
         client.options[0] += ' --header ":authority: app.com"'
-        client.start()
+        await client.start()
 
         # 2
         # config Tempesta change,
@@ -171,4 +171,4 @@ class TestGraceShutdownLiveReconf(LiveReconfStressTestBase):
 
         # h2load stop
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()

--- a/tests/reconf/test_stress_health_monitor.py
+++ b/tests/reconf/test_stress_health_monitor.py
@@ -133,7 +133,7 @@ class TestHealthMonitorLiveReconf(LiveReconfStressTestBase):
 
         # launch H2Load
         client = self.get_client("h2load")
-        client.start()
+        await client.start()
 
         stats_srvs: list[ServerStats] = [
             ServerStats(tempesta, "main", cfg.get("Server", "ip"), port) for port in (8000, 8001)
@@ -152,7 +152,7 @@ class TestHealthMonitorLiveReconf(LiveReconfStressTestBase):
 
         # H2Load stop
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
         self.assertNotIn(" 0 2xx, ", client.response_msg)
 
     def check_servers_stats(

--- a/tests/reconf/test_stress_reconf.py
+++ b/tests/reconf/test_stress_reconf.py
@@ -79,7 +79,7 @@ class TestLiveReconf(LiveReconfStressTestBase):
 
         # launch h2load
         client = self.get_client("h2load")
-        client.start()
+        await client.start()
 
         # sending curl requests before reconfig Tempesta
         response = await self.make_curl_request("curl-0")
@@ -104,7 +104,7 @@ class TestLiveReconf(LiveReconfStressTestBase):
 
         # h2load stop
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
         self.assertNotIn(" 0 2xx, ", client.response_msg)
 
     async def check_non_working_socket(

--- a/tests/reconf/test_stress_sched_dynamic.py
+++ b/tests/reconf/test_stress_sched_dynamic.py
@@ -108,7 +108,7 @@ class TestSchedRatioDynamicLiveReconf(LiveReconfStressTestBase):
 
         # launch h2load
         client = self.get_client("h2load")
-        client.start()
+        await client.start()
         await self.wait_while_busy(client)
 
         self.check_servers_weights()
@@ -121,12 +121,12 @@ class TestSchedRatioDynamicLiveReconf(LiveReconfStressTestBase):
         )
 
         # stop h2load
-        client.stop()
+        await client.stop()
 
         # launch h2load after Tempesta reload
-        client.start()
+        await client.start()
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
 
         self.check_servers_weights()
 

--- a/tests/reconf/test_stress_sched_hash.py
+++ b/tests/reconf/test_stress_sched_hash.py
@@ -119,7 +119,7 @@ class TestSchedHashLiveReconf(LiveReconfStressTestBase):
         # launch H2Load
         client = self.get_client("h2load")
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
         self.assertNotIn(" 0 2xx, ", client.response_msg)
 
         self.assertAlmostEqual(
@@ -137,9 +137,9 @@ class TestSchedHashLiveReconf(LiveReconfStressTestBase):
         )
 
         # launch h2load after Tempesta reload
-        client.start()
+        await client.start()
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
         self.assertNotIn(" 0 2xx, ", client.response_msg)
 
         self.assertNotAlmostEqual(

--- a/tests/reconf/test_stress_sched_http.py
+++ b/tests/reconf/test_stress_sched_http.py
@@ -121,7 +121,7 @@ class TestSchedHttpLiveReconf(LiveReconfStressTestBase):
         # launch H2Load
         client_h2 = self.get_client("h2load")
         client_h2.options[0] = self._change_uri_cmd_opt(client_h2, VHOSTS[0])
-        client_h2.start()
+        await client_h2.start()
 
         # sending curl requests before reconfig Tempesta
         response = await self.make_curl_request("curl-origin-h2")
@@ -147,7 +147,7 @@ class TestSchedHttpLiveReconf(LiveReconfStressTestBase):
 
         # H2Load stop
         await self.wait_while_busy(client_h2)
-        client_h2.stop()
+        await client_h2.stop()
 
     def _change_uri_cmd_opt(self, client: ExternalTester, path: str = None) -> str:
         """Changing the uri option in the options list of client.

--- a/tests/reconf/test_stress_sched_ratio.py
+++ b/tests/reconf/test_stress_sched_ratio.py
@@ -109,7 +109,7 @@ class TestSchedRatioLiveReconf(LiveReconfStressTestBase):
 
         # launch h2load
         client = self.get_client("h2load")
-        client.start()
+        await client.start()
         await self.wait_while_busy(client)
 
         # get statistics on expected requests
@@ -137,10 +137,10 @@ class TestSchedRatioLiveReconf(LiveReconfStressTestBase):
         )
 
         # h2load stop
-        client.stop()
+        await client.stop()
 
         # launch h2load after Tempesta reload
-        client.start()
+        await client.start()
         await self.wait_while_busy(client)
 
         # get statistics on expected requests
@@ -161,7 +161,7 @@ class TestSchedRatioLiveReconf(LiveReconfStressTestBase):
             )
 
         # h2load stop
-        client.stop()
+        await client.stop()
 
     def get_n_expected_reqs(self, servers) -> float:
         tempesta = self.get_tempesta()

--- a/tests/reconf/test_stress_sticky.py
+++ b/tests/reconf/test_stress_sticky.py
@@ -130,7 +130,7 @@ class TestGraceShutdownLiveReconf(LiveReconfStressTestBase):
 
         # launch h2load
         client.options[0] += ' --header ":authority: app.com"'
-        client.start()
+        await client.start()
 
         # get statistics
         stats_srvs: list[ServerStats] = [
@@ -166,4 +166,4 @@ class TestGraceShutdownLiveReconf(LiveReconfStressTestBase):
 
         # # h2load stop
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()

--- a/tests/regress/test_reboot_under_load.py
+++ b/tests/regress/test_reboot_under_load.py
@@ -134,10 +134,10 @@ class TestRebootUnderLoad(tester.TempestaTest):
         await asyncio.sleep(self.warm_timeout)
         for i in range(self.restart_cycles):
             await asyncio.sleep(self.restart_timeout)
-            tempesta.stop()
+            await tempesta.stop()
             # Run random command on remote node to see if it is still alive.
             remote.tempesta.run_cmd("uname")
-            tempesta.start()
+            await tempesta.start()
             self._check_tfw_log()
 
     async def make_curl_request(self, curl_client_id: str) -> str:
@@ -151,14 +151,14 @@ class TestRebootUnderLoad(tester.TempestaTest):
             str: server response to the request as string
         """
         client = self.get_client(curl_client_id)
-        client.start()
+        await client.start()
         await self.wait_while_busy(client)
         self.assertEqual(
             0,
             client.returncode,
             msg=f"Curl return code is not 0. Received - {client.returncode}.",
         )
-        client.stop()
+        await client.stop()
         return client.response_msg
 
     async def test_reboot_under_load(self) -> None:
@@ -167,7 +167,7 @@ class TestRebootUnderLoad(tester.TempestaTest):
 
         # launch h2load
         client = self.get_client("h2load")
-        client.start()
+        await client.start()
 
         # sending curl requests before reboot Tempesta
         response = await self.make_curl_request("curl")
@@ -181,7 +181,7 @@ class TestRebootUnderLoad(tester.TempestaTest):
 
         # h2load stop
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
         self.assertNotIn(" 0 2xx, ", client.response_msg)
 
     def _check_tfw_log(self) -> None:

--- a/tests/regress/test_stress_pipeline.py
+++ b/tests/regress/test_stress_pipeline.py
@@ -113,9 +113,9 @@ class TestStressPipeline(tester.TempestaTest):
 
         await self.start_all_services(client=False)
 
-        wrk.start()
+        await wrk.start()
         await self.wait_while_busy(wrk)
-        wrk.stop()
+        await wrk.stop()
         return wrk
 
     def assert_client(self, req, err, statuses) -> None:

--- a/tests/sched/test_hash_stress.py
+++ b/tests/sched/test_hash_stress.py
@@ -126,7 +126,7 @@ class BindToServer(tester.TempestaTest):
 
         await self.start_all_services()
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
 
         self.__check_load_distribution_between_servers()
 

--- a/tests/sched/test_per_group_lb.py
+++ b/tests/sched/test_per_group_lb.py
@@ -313,9 +313,9 @@ class AllDefaults(tester.TempestaTest):
         else:
             client_1.options[0] += ' -H "Host: example.com"'
 
-        self.start_all_servers()
+        await self.start_all_servers()
         await self.start_tempesta()
-        self.start_all_clients()
+        await self.start_all_clients()
         await self.wait_while_busy(client_1, client_2)
 
         servers = self.get_servers()

--- a/tests/sched/test_ratio_dynamic.py
+++ b/tests/sched/test_ratio_dynamic.py
@@ -223,12 +223,12 @@ class RatioDynamic(tester.TempestaTest):
         else:
             client.options[0] += f" --duration {self.min_duration}"
 
-        self.start_all_servers()
+        await self.start_all_servers()
         await self.start_tempesta()
-        self.start_all_clients()
+        await self.start_all_clients()
 
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
 
         tempesta = self.get_tempesta()
         servers = self.get_servers()

--- a/tests/sched/test_ratio_dynamic_recalc.py
+++ b/tests/sched/test_ratio_dynamic_recalc.py
@@ -148,9 +148,9 @@ class RatioDynamic(tester.TempestaTest):
         configuration.
         """
         if new_server_name:
-            srv_dyn.stop()
+            await srv_dyn.stop()
             srv_dyn = self.get_server(new_server_name)
-            srv_dyn.start()
+            await srv_dyn.start()
 
         client = self.get_client("client")
         if isinstance(client, Wrk):
@@ -158,9 +158,9 @@ class RatioDynamic(tester.TempestaTest):
         else:
             client.options[0] += f" --duration {self.min_duration}"
 
-        client.start()
+        await client.start()
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
 
         return (srv_const, srv_dyn)
 
@@ -198,8 +198,8 @@ class RatioDynamic(tester.TempestaTest):
         """
         srv_const = self.get_server("nginx_constant")
         srv_dyn = self.get_server("nginx_dynamic")
-        srv_const.start()
-        srv_dyn.start()
+        await srv_const.start()
+        await srv_dyn.start()
         await self.start_tempesta()
 
         perfstat = {

--- a/tests/sched/test_ratio_static.py
+++ b/tests/sched/test_ratio_static.py
@@ -208,9 +208,9 @@ class Ratio(tester.TempestaTest):
         """All servers must receive almost the same number of requests."""
         client = self.get_client("client")
 
-        self.start_all_servers()
+        await self.start_all_servers()
         await self.start_tempesta()
-        self.start_all_clients()
+        await self.start_all_clients()
         await self.wait_while_busy(client)
 
         tempesta = self.get_tempesta()

--- a/tests/sched/test_ratio_weight.py
+++ b/tests/sched/test_ratio_weight.py
@@ -229,9 +229,9 @@ class Ratio(tester.TempestaTest):
         """
         client = self.get_client("client")
 
-        self.start_all_servers()
+        await self.start_all_servers()
         await self.start_tempesta()
-        self.start_all_clients()
+        await self.start_all_clients()
 
         await self.wait_while_busy(client)
 

--- a/tests/sched/test_reconnection_logic.py
+++ b/tests/sched/test_reconnection_logic.py
@@ -102,7 +102,7 @@ http_chain {
             1, msg="TempestaFW first send a request to the backup server."
         )
 
-        primary_server.stop()
+        await primary_server.stop()
 
         await client.send_request(request, "200")
         await backup_server.wait_for_requests(
@@ -110,7 +110,7 @@ http_chain {
             msg="TempestaFW doesn't send a request to the backup server when the primary server is down.",
         )
 
-        primary_server.start()
+        await primary_server.start()
         await primary_server.wait_for_connections(
             msg="TempestaFW doesn't reconnect to the primary server."
         )

--- a/tests/selftests/test_clickhouse.py
+++ b/tests/selftests/test_clickhouse.py
@@ -37,13 +37,13 @@ class TestClickhouse(tester.TempestaTest):
         Test that documents issue #2314 - logs missing during first second of startup.
         This test verifies that logs are not lost in clickhouse immediately after startup.
         """
-        self.deproxy_manager.start()
+        await self.deproxy_manager.start()
 
         await self.start_tempesta()
         await self.get_tempesta().wait_while_logger_start()
 
         client = self.get_client("deproxy")
-        client.start()
+        await client.start()
 
         await client.send_request(client.create_request(method="GET", headers=[]), "502")
 

--- a/tests/selftests/test_curl_client.py
+++ b/tests/selftests/test_curl_client.py
@@ -177,9 +177,9 @@ class TestCurlClient(tester.TempestaTest):
         await self.start_all_services(client=False)
 
     async def get_response(self, client) -> CurlResponse:
-        client.start()
+        await client.start()
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
         return client.last_response
 
     async def test_check_curl_binary_version(self):

--- a/tests/selftests/test_deproxy.py
+++ b/tests/selftests/test_deproxy.py
@@ -322,12 +322,12 @@ server ${server_ip}:8000;
         remote.client.run_cmd("sysctl -w net.ipv4.tcp_syn_linear_timeouts=4")
 
         client: deproxy_client.DeproxyClient = self.get_client("deproxy-interface")
-        client.start()
+        await client.start()
         await client.wait_for_connection_open(timeout=2)
         client.make_request("GET /qwerty HTTP/1.1\r\nHost: localhost\r\n\r\n")
         await client.wait_for_connection_close(timeout=2)
         # Connect one more time during block duration.
-        client.restart()
+        await client.restart()
         await asyncio.sleep(timeout)
         # If wait less than block_duration time thus expected not established connection.
         expected_connected = True if timeout > block_duration else False
@@ -447,13 +447,11 @@ server ${server_ip}:8000;
 
         await self.start_all_services(client=False)
 
+        request = client.create_request(method="GET", uri="/", headers=[])
         for _ in range(5):
-            try:
-                client.start()
-                client.make_request("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
-                client.stop()
-            except OSError:
-                raise AssertionError("Deproxy client launch: IP address is not available.")
+            await client.start()
+            await client.send_request(request, "200")
+            await client.stop()
 
     async def test_pipeline_request(self):
         await self.start_all_services()

--- a/tests/selftests/test_docker_server.py
+++ b/tests/selftests/test_docker_server.py
@@ -75,9 +75,9 @@ class TestDockerServer(tester.TempestaTest):
         client = self.get_client("default")
         client.headers["Host"] = host
         client.set_uri(uri)
-        client.start()
+        await client.start()
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
         return client.last_response
 
     async def test_request_to_server_completed(self):
@@ -124,7 +124,7 @@ class TestHealthCheck(tester.TempestaTest):
         server = self.get_server("default")
         server.cmd_args = "-c 'import time ; time.sleep(3); import hello'"
 
-        server.start()
+        await server.start()
         self.assertEqual(server.health_status, "starting")
 
         await self.start_tempesta()
@@ -138,7 +138,7 @@ class TestHealthCheck(tester.TempestaTest):
         server = self.get_server("default")
         server.cmd_args = "-c 'import time ; time.sleep(10)'"
 
-        server.start()
+        await server.start()
 
         self.assertEqual(server.health_status, "starting")
         with self.assertRaises(AssertionError):
@@ -150,6 +150,6 @@ class TestHealthCheck(tester.TempestaTest):
         server.options = "--health-interval 0.1s --health-cmd 'exit 0'"
         server.cmd_args = "-c 'import time ; time.sleep(10)'"
 
-        server.start()
+        await server.start()
 
         await self.assertWaitUntilEqual(lambda: server.health_status, "healthy")

--- a/tests/server_connections/test_close_dead_connections.py
+++ b/tests/server_connections/test_close_dead_connections.py
@@ -80,7 +80,7 @@ class TestFinishH2StreamsByClient(FinishByClientBase):
         self.configure_deproxy_server()
         self.disable_deproxy_auto_parser()
         await self.start_all_services(client=False)
-        client.start()
+        await client.start()
 
         server_conn_list_before = set(server.connections)
         request = client.create_request(method="GET", headers=[])
@@ -146,7 +146,7 @@ class TestFinishTCPConnectionByClient(FinishByClientBase):
 
         request = self.get_client(0).create_request(method="GET", headers=[])
         for client in self.get_clients():
-            client.start()
+            await client.start()
 
         if close_with_rst:
             for client in self.get_clients():
@@ -155,7 +155,7 @@ class TestFinishTCPConnectionByClient(FinishByClientBase):
             client.make_request(request)
         await server.wait_for_requests(n=CONNS_N)
         for client in self.get_clients():
-            client.stop()
+            await client.stop()
 
         await self.assertWaitUntilTrue(
             lambda: set(server_conn_list_before).isdisjoint(set(server.connections)),

--- a/tests/server_connections/test_established_connections.py
+++ b/tests/server_connections/test_established_connections.py
@@ -114,7 +114,7 @@ srv_group default {{
             server_ip_and_port=self.get_server_ip_and_port(server), expected_n=self.conns_n, msg=msg
         )
 
-        tfw.stop()
+        await tfw.stop()
         msg = "Tempesta FW must close all connections after stop."
         self.assertEqual(len(server.connections), 0, msg)
         await self.check_total_sockets(
@@ -138,8 +138,8 @@ srv_group default {{
             ],
             node=remote.server,
         ):
-            server.start()
-            tfw.start()
+            await server.start()
+            await tfw.start()
             tfw.get_stats()
             await self.check_total_sockets(
                 server_ip_and_port=self.get_server_ip_and_port(server),
@@ -204,7 +204,7 @@ srv_group default {{
         server = self.get_server("deproxy")
         server.conns_n = self.conns_n
         tfw = self.get_tempesta()
-        tfw.start()
+        await tfw.start()
         tfw.get_stats()
 
         msg = "Tempesta must not open connections to server."
@@ -223,8 +223,8 @@ srv_group default {{
         server = self.get_server("deproxy")
         server.conns_n = self.conns_n
         tfw = self.get_tempesta()
-        server.start()
-        self.deproxy_manager.start()
+        await server.start()
+        await self.deproxy_manager.start()
 
         with netfilter.block_ports_on_node(
             blocked_ports=[
@@ -232,7 +232,7 @@ srv_group default {{
             ],
             node=remote.server,
         ):
-            tfw.start()
+            await tfw.start()
             tfw.get_stats()
             await self.check_total_sockets(
                 server_ip_and_port=self.get_server_ip_and_port(server),

--- a/tests/server_options/test_server_options.py
+++ b/tests/server_options/test_server_options.py
@@ -97,11 +97,11 @@ class TestRescheduling(TestServerOptionsBase):
         client.make_request(client.create_request(method="GET", headers=[]))
         # Sleep until Tempesta FW received response.
         await asyncio.sleep(3)
-        server.stop()
+        await server.stop()
         server.set_response(
             b"HTTP/1.1 200 OK\r\nContent-Length: 10\r\nConnection: close\r\n\r\nxxxxxxxxxx"
         )
-        server.start()
+        await server.start()
         await client.wait_for_response()
         self.assertEqual(client.last_response.status, "200")
         self.assertEqual(client.last_response.body, "xxxxxxxxxx")
@@ -132,22 +132,22 @@ class TestRescheduling(TestServerOptionsBase):
         for _ in range(0, 3):
             client.make_request(client.create_request(method="GET", headers=[]))
         await server.wait_for_requests(3)
-        server.stop()
+        await server.stop()
 
-        server.start()
+        await server.start()
         await server.wait_for_requests(1)
-        server.stop()
+        await server.stop()
 
-        server.start()
+        await server.start()
         await server.wait_for_requests(1)
-        server.stop()
+        await server.stop()
 
         server.pipelined = 0
         server.set_response(
             b"HTTP/1.1 200 OK\r\nContent-Length: 10\r\nConnection: close\r\n\r\nxxxxxxxxxx"
             + b"HTTP/1.1 200 OK\r\nContent-Length: 10\r\nConnection: close\r\n\r\nxxxxxxxxxx"
         )
-        server.start()
+        await server.start()
 
         self.assertTrue(
             await self.loggers.dmesg.find(
@@ -184,9 +184,9 @@ class TestRescheduling(TestServerOptionsBase):
         for _ in range(0, 3):
             client_1.make_request(client_1.create_request(method="GET", headers=[]))
         await server.wait_for_requests(3)
-        server.stop()
+        await server.stop()
         server.pipelined = 2
-        server.start()
+        await server.start()
         await server.wait_for_requests(1)
 
         client_2 = self.get_client("deproxy-2")
@@ -220,10 +220,10 @@ class TestRescheduling(TestServerOptionsBase):
         for _ in range(0, 4):
             client_1.make_request(client_1.create_request(method="GET", headers=[]))
         await server.wait_for_requests(3)
-        server.stop()
+        await server.stop()
         server.pipelined = 2
         server.send_after_conn_established = True
-        server.start()
+        await server.start()
 
         self.assertTrue(
             await self.loggers.dmesg.find(
@@ -823,7 +823,7 @@ class TestServerOptions(TestServerOptionsBase):
 
         await asyncio.sleep(2)
         # Do not call the start method here because it reset all variables
-        server.run_start()
+        await server.run_start()
 
         await client.wait_for_response(5)
         self.assertEqual(client.last_response.status, "200")

--- a/tests/sessions/test_h2_sticky_scheduler.py
+++ b/tests/sessions/test_h2_sticky_scheduler.py
@@ -109,14 +109,14 @@ class H2StickySchedulerTestCase(tester.TempestaTest):
         """
         curl = self.get_client("curl")
 
-        self.start_all_servers()
+        await self.start_all_servers()
         await self.start_tempesta()
 
         # perform `init` request
         curl.headers = {"Host": "good.com"}
-        curl.start()
+        await curl.start()
         await self.wait_while_busy(curl)
-        curl.stop()
+        await curl.stop()
         response = curl.last_response
         self.assertEqual(response.status, http.HTTPStatus.FOUND)
         self.assertIn("__tfw", response.headers["set-cookie"])
@@ -127,18 +127,18 @@ class H2StickySchedulerTestCase(tester.TempestaTest):
             "Cookie": response.headers["set-cookie"],
         }
 
-        curl.start()
+        await curl.start()
         await self.wait_while_busy(curl)
-        curl.stop()
+        await curl.stop()
 
         response = curl.last_response
         self.assertEqual(response.status, http.HTTPStatus.OK)
 
         # perform `bad` request
         curl.headers["Host"] = "bad.com"
-        curl.start()
+        await curl.start()
         await self.wait_while_busy(curl)
-        curl.stop()
+        await curl.stop()
         response = curl.last_response
         self.assertEqual(response.status, http.HTTPStatus.FORBIDDEN)
 

--- a/tests/sessions/test_js_challenge.py
+++ b/tests/sessions/test_js_challenge.py
@@ -414,14 +414,14 @@ class JSChallenge(BaseJSChallenge):
         await client.send_request(
             self.prepare_second_req(client, cookie_1), expected_status_code="200"
         )
-        client.stop()
+        await client.stop()
 
-        self.get_tempesta().restart()
+        await self.get_tempesta().restart()
 
         # browser create a new session with an existing cookie.
         # This cookie valid for browser, but invalid for Tempesta
         # because it has other timestamp after reboot
-        client.start()
+        await client.start()
         await client.send_request(
             self.prepare_second_req(client, cookie_1), expected_status_code="503"
         )
@@ -443,7 +443,7 @@ class JSChallenge(BaseJSChallenge):
         await client.send_request(
             self.prepare_second_req(client, cookie_1), expected_status_code="200"
         )
-        client.restart()
+        await client.restart()
         await client.send_request(
             self.prepare_second_req(client, cookie_1), expected_status_code="200"
         )

--- a/tests/sessions/test_learn.py
+++ b/tests/sessions/test_learn.py
@@ -177,7 +177,7 @@ class LearnSessions(LearnSessionsBase):
         s_id, cookie = await self.client_send_first_req(client)
         srv = self.get_server(s_id)
         self.assertIsNotNone(srv, "Backend server is not known")
-        srv.stop()
+        await srv.stop()
         # Remove after 2111 in Tempesta will be implemented
         await asyncio.sleep(1)
         for _ in range(ATTEMPTS):
@@ -194,7 +194,7 @@ class LearnSessions(LearnSessionsBase):
         self.assertEqual(len(client.responses), ATTEMPTS + 1)
         for resp in client.responses[1:]:
             self.assertEqual(resp.status, "502", "unexpected response status code")
-        srv.start()
+        await srv.start()
         await srv.wait_for_connections(timeout=3, msg="Can't restart backend server")
         for _ in range(ATTEMPTS):
             new_s_id = await self.client_send_next_req(client, cookie)

--- a/tests/sessions/test_sessions.py
+++ b/tests/sessions/test_sessions.py
@@ -241,13 +241,13 @@ class StickySessionsPersistense(StickySessions):
         # session.
         srv = self.get_server(s_id)
         self.assertIsNotNone(srv, "Backend server is not known")
-        srv.stop()
+        await srv.stop()
         # Remove after 2111 in Tempesta will be implemented
         await asyncio.sleep(1)
         req = client.create_request(method="GET", headers=[("cookie", f"{cookie[0]}={cookie[1]}")])
         for _ in range(ATTEMPTS):
             await client.send_request(req, "502")
-        srv.start()
+        await srv.start()
         await srv.wait_for_connections(timeout=3, msg="Can't restart backend server")
         for _ in range(ATTEMPTS):
             new_s_id = await self.client_send_next_req(client, cookie)
@@ -390,7 +390,7 @@ class StickySessionsFailover(StickySessions):
 
         srv = self.get_server(s_id)
         self.assertIsNotNone(srv, "Backend server is not known")
-        srv.stop()
+        await srv.stop()
         # Remove after 2111 in Tempesta will be implemented
         await asyncio.sleep(1)
 
@@ -399,7 +399,7 @@ class StickySessionsFailover(StickySessions):
             failovered_s_id, ["server-1", "server-2"], "session is pinned to unexpected server"
         )
 
-        srv.start()
+        await srv.start()
         await srv.wait_for_connections(timeout=3, msg="Can't restart backend server")
         for _ in range(ATTEMPTS):
             new_s_id = await self.client_send_next_req(client, cookie)
@@ -420,9 +420,9 @@ class StickySessionsFailover(StickySessions):
         await self.client_send_next_req(client, cookie)
 
         srv1 = self.get_server("server-1")
-        srv1.stop()
+        await srv1.stop()
         srv2 = self.get_server("server-2")
-        srv2.stop()
+        await srv2.stop()
 
         # We need this sleep to be shure that srv1 and srv2 is
         # really stopped and all connections is closed.
@@ -434,8 +434,8 @@ class StickySessionsFailover(StickySessions):
             failovered_s_id, ["server-3", "server-4"], "session is pinned to unexpected server"
         )
 
-        srv1.start()
-        srv2.start()
+        await srv1.start()
+        await srv2.start()
         await srv1.wait_for_connections(timeout=3, msg="Can't restart backend server")
         await srv2.wait_for_connections(timeout=3, msg="Can't restart backend server")
         for _ in range(ATTEMPTS):

--- a/tests/sessions/test_sticky_sess_stress.py
+++ b/tests/sessions/test_sticky_sess_stress.py
@@ -96,9 +96,9 @@ frang_limits {http_strict_host_checking false;}
         wrk.set_script("cookie-one-client")
         wrk.threads = 1
 
-        wrk.start()
+        await wrk.start()
         await self.wait_while_busy(wrk)
-        wrk.stop()
+        await wrk.stop()
         self.assertIsNotNone(wrk.statuses.get(200))
 
         for server in self.get_servers():
@@ -129,9 +129,9 @@ frang_limits {http_strict_host_checking false;}
         wrk.set_script("cookie-many-clients")
         wrk.threads = wrk.connections
 
-        wrk.start()
+        await wrk.start()
         await self.wait_while_busy(wrk)
-        wrk.stop()
+        await wrk.stop()
         self.assertIsNotNone(wrk.statuses.get(200))
 
         for server in self.get_servers():

--- a/tests/stress/test_clickhouse.py
+++ b/tests/stress/test_clickhouse.py
@@ -67,13 +67,13 @@ class TestClickHouseLogsUnderLoad(tester.TempestaTest):
 
     async def test_all_logs_under_load(self):
         client = self.get_client("h2load")
-        client.start()
+        await client.start()
 
         half_of_duration = run_config.DURATION / 2
         await asyncio.sleep(int(half_of_duration))
 
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
 
         h2_total_requests = self.h2load_total_requests(client.stdout.decode())
         self.assertTrue(h2_total_requests)
@@ -87,7 +87,7 @@ class TestClickHouseLogsUnderLoad(tester.TempestaTest):
 
     async def test_all_logs_with_reload(self):
         client = self.get_client("h2load")
-        client.start()
+        await client.start()
 
         tempesta = self.get_tempesta()
 
@@ -96,7 +96,7 @@ class TestClickHouseLogsUnderLoad(tester.TempestaTest):
         tempesta.reload()
 
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
 
         h2_total_requests = self.h2load_total_requests(client.stdout.decode())
         self.assertTrue(h2_total_requests)
@@ -110,7 +110,7 @@ class TestClickHouseLogsUnderLoad(tester.TempestaTest):
 
     async def test_tfw_logger_stop_cont(self):
         client = self.get_client("h2load")
-        client.start()
+        await client.start()
 
         half_of_duration = run_config.DURATION / 2
         await asyncio.sleep(int(half_of_duration))
@@ -119,7 +119,7 @@ class TestClickHouseLogsUnderLoad(tester.TempestaTest):
         self.get_tempesta().tfw_logger_signal("CONT")
 
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
 
         h2_total_requests = self.h2load_total_requests(client.stdout.decode())
         self.assertTrue(h2_total_requests)

--- a/tests/stress/test_ddos.py
+++ b/tests/stress/test_ddos.py
@@ -186,9 +186,9 @@ http_chain {{
     async def make_response(self, curl, uri: str) -> None:
         curl.headers["Host"] = "tempesta-tech.com"
         curl.set_uri(uri)
-        curl.start()
+        await curl.start()
         await self.wait_while_busy(curl)
-        curl.stop()
+        await curl.stop()
 
     @classmethod
     def setUpClass(cls):
@@ -305,7 +305,7 @@ http_chain {{
             + f"--rpc {RPC} "
             + f"--duration {DURATION} "
         ]
-        client.start()
+        await client.start()
 
         await asyncio.sleep(DURATION / 2)
         # Get a response from the cache after the attack started.
@@ -325,7 +325,7 @@ http_chain {{
         #  issue - add checks to receiving a response from upstream
 
         await client.wait_for_finish(timeout=DURATION + 5)
-        client.stop()
+        await client.stop()
 
         tempesta.get_stats()
         self.assertGreater(tempesta.stats.cl_msg_received, 3, "DDoS tool doesn't work.")

--- a/tests/stress/test_nginx.py
+++ b/tests/stress/test_nginx.py
@@ -88,15 +88,15 @@ class NginxStressBase(NginxProxyMixin, tester.TempestaTest, base=True):
     async def test(self):
         # Start servers, but not Tempesta
         self.create_cert()
-        self.start_all_servers()
-        self.deproxy_manager.start()
+        await self.start_all_servers()
+        await self.deproxy_manager.start()
         wrk = self.get_client("wrk")
         wrk.set_script("foo", content='wrk.method="GET"')
         wrk.timeout = 0
 
-        wrk.start()
+        await wrk.start()
         await self.wait_while_busy(wrk, timeout=20)
-        wrk.stop()
+        await wrk.stop()
 
         self.assertGreater(wrk.statuses[200], 0)
 

--- a/tests/stress/test_stress.py
+++ b/tests/stress/test_stress.py
@@ -359,11 +359,11 @@ max_concurrent_streams 10000;
                     f"--max-concurrent-streams {REQUESTS_COUNT} --duration {DURATION}"
                 ]
 
-                client.start()
+                await client.start()
                 await self.wait_while_busy(
                     client, timeout=DURATION * 10
                 )  # The MTU80 tests require more time
-                client.stop()
+                await client.stop()
 
                 self.assertEqual(client.returncode, 0)
                 self.assertNotIn(" 0 2xx, ", client.response_msg, client.response_msg)
@@ -422,9 +422,9 @@ class TlsWrkStressDocker(tester.TempestaTest):
         wrk.threads = THREADS
         wrk.timeout = 0
 
-        wrk.start()
+        await wrk.start()
         await self.wait_while_busy(wrk, timeout=20)
-        wrk.stop()
+        await wrk.stop()
 
         self.assertGreater(wrk.statuses.get(200, 0), 0)
 
@@ -496,9 +496,9 @@ class BaseCurlStress(LargePageNginxBackendMixin, tester.TempestaTest, base=True)
     async def make_requests(self, client_id):
         client = self.get_client(client_id)
         await self.start_all_services(client=False)
-        client.start()
+        await client.start()
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
         self.assertEqual(client.statuses[200], REQUESTS_COUNT)
         if client.last_response:
             self.assertFalse(client.last_response.stderr)
@@ -513,9 +513,9 @@ class BaseCurlStress(LargePageNginxBackendMixin, tester.TempestaTest, base=True)
         for i in range(1, REQUESTS_COUNT + 1):
             delta = time.time() - started
             client.set_uri("/" if uri_is_same else f"/{i}")
-            client.start()
+            await client.start()
             await self.wait_while_busy(client)
-            client.stop()
+            await client.stop()
 
             response = client.last_response
             self.assertFalse(response.stderr, f"Error after {delta} seconds and {i} requests.")
@@ -622,16 +622,16 @@ class TestTdbStress(LargePageNginxBackendMixin, tester.TempestaTest):
 
         for step in range(20):
             client.set_uri(f"/{step}/[1-256]")
-            client.start()
+            await client.start()
             await self.wait_while_busy(client)
-            client.stop()
+            await client.stop()
             tempesta.get_stats()
             self.assertGreater(tempesta.stats.cache_objects, 0)
 
             client_purge.set_uri(f"/{step}/[1-256]")
-            client_purge.start()
+            await client_purge.start()
             await self.wait_while_busy(client_purge)
-            client_purge.stop()
+            await client_purge.stop()
             tempesta.get_stats()
             self.assertEqual(tempesta.stats.cache_objects, 0)
 
@@ -757,9 +757,9 @@ class RequestStress(tester.TempestaTest):
         client.threads = THREADS
         client.timeout = 0
 
-        client.start()
+        await client.start()
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
 
         self.assertGreater(client.statuses[200], 0, "Client has not received 200 responses.")
 
@@ -770,9 +770,9 @@ class RequestStress(tester.TempestaTest):
         client = self.get_client("h2load")
         client.options[0] += f' -H ":method:{method}"'
 
-        client.start()
+        await client.start()
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
 
         self.assertEqual(client.returncode, 0)
         self.assertNotIn(" 0 2xx, ", client.response_msg)

--- a/tests/tf/test_tf.py
+++ b/tests/tf/test_tf.py
@@ -155,8 +155,8 @@ class TestTFt(tester.TempestaTest):
                 name="hash_for_client_block_by_rate",
                 tempesta_tf_config="""
 					tft {
-						hash 66cb9fd8d4250000 1 0;
-						hash 66cb8f00d4250002 1 0;
+						hash 66cb9fd8ef170000 1 0;
+						hash 66cb8f00ef170002 1 0;
 					}
 				""",
                 expected_block=True,
@@ -253,10 +253,10 @@ class TestTFtStress(tester.TempestaTest):
     async def test(self, name, client_id: str):
         await self.start_all_services()
         client = self.get_client(client_id)
-        client.start()
+        await client.start()
         self.change_cfg()
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
 
         if client_id == "wrk":
             self.assertGreater(client.statuses[200], 0)

--- a/tests/tf/test_tf_filters.py
+++ b/tests/tf/test_tf_filters.py
@@ -5,7 +5,7 @@ Tests for TF Hash Filtering and Configuration Parsing
 import asyncio
 import typing
 
-from framework.helpers import remote, tf_cfg
+from framework.helpers import remote, tf_cfg, util
 from framework.helpers.access_log import AccessLogLine
 from framework.helpers.error import ProcessBadExitStatusException
 from framework.test_suite import marks, tester
@@ -111,9 +111,9 @@ class BaseTFTestSuite(tester.TempestaTest):
 
     async def get_client_fingerprint(self, name: str) -> AccessLogLine:
         client = self.get_client(name)
-        client.start()
+        await client.start()
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
 
         self.assertEqual(client.stdout, self.response_ok)
 
@@ -271,7 +271,7 @@ class TestTFFiltersTestSuite(BaseTFTestSuite):
         await self.start_all_services(client=False)
 
         client_names = list(map(lambda __client: __client["id"], self.clients))
-        clients = list(map(self.get_client, client_names))
+        clients = util.ForEach(*self.get_clients())
         fingerprints = []
         for name in client_names:
             fingerprint = await self.get_client_fingerprint(name)
@@ -283,9 +283,9 @@ class TestTFFiltersTestSuite(BaseTFTestSuite):
 
         self.set_config_tf_hash(self.get_hash(fingerprints[0]))
 
-        list(map(lambda __client: __client.start(), clients))
-        await asyncio.gather(*[self.wait_while_busy(client) for client in clients])
-        list(map(lambda __client: __client.stop(), clients))
+        await clients.start()
+        await clients.wait_for_finish()
+        await clients.stop()
 
         self.assertEqual(
             self.count_equal(client_names, "limited", self.response_ok),
@@ -328,21 +328,21 @@ class TestTFHashDoesNotMatchedWithFiltered(BaseTFTestSuite):
         Verify the default tf filters
         does not affect the application
         """
-        self.start_all_servers()
+        await self.start_all_servers()
         await self.start_tempesta()
-        self.deproxy_manager.start()
+        await self.deproxy_manager.start()
 
         limited_1 = self.get_client("limited-1")
         limited_2 = self.get_client("limited-2")
 
-        limited_1.start()
-        limited_2.start()
+        await limited_1.start()
+        await limited_2.start()
 
         await self.wait_while_busy(limited_1)
         await self.wait_while_busy(limited_2)
 
-        limited_1.stop()
-        limited_2.stop()
+        await limited_1.stop()
+        await limited_2.stop()
 
         self.assertEqual(limited_1.stdout, self.response_ok)
         self.assertEqual(limited_2.stdout, self.response_ok)
@@ -424,16 +424,16 @@ class TestRestartAppWithUpdatedHash(BaseTFTestSuite):
         Verify successful application restart with
         tf configuration
         """
-        self.start_all_servers()
+        await self.start_all_servers()
         await self.start_tempesta()
-        self.get_tempesta().restart()
+        await self.get_tempesta().restart()
 
     async def test_reload_ok(self):
         """
         Verify successful application reload with
         tf configuration
         """
-        self.start_all_servers()
+        await self.start_all_servers()
         await self.start_tempesta()
         self.get_tempesta().reload()
 
@@ -482,9 +482,9 @@ class TestClearHashes(BaseTFTestSuite):
         self.set_config_tf_hash(self.get_hash(fingerprint))
 
         blocked_client = self.get_client("blocked")
-        blocked_client.start()
+        await blocked_client.start()
         await self.wait_while_busy(blocked_client)
-        blocked_client.stop()
+        await blocked_client.stop()
         self.assertIn(
             "Connection reset by peer",
             blocked_client.stderr.decode(),
@@ -493,9 +493,9 @@ class TestClearHashes(BaseTFTestSuite):
 
         self.update_config_with_tf_hash_limit()
         client = self.get_client("curl")
-        client.start()
+        await client.start()
         await self.wait_while_busy(client)
-        client.stop()
+        await client.stop()
         self.assertEqual(
             client.stdout,
             self.response_ok,

--- a/tests/tls/handshake.py
+++ b/tests/tls/handshake.py
@@ -166,6 +166,7 @@ class ModifiedTLSClientAutomaton(TLSClientAutomaton):
 
     @ATMT.condition(TLSClientAutomaton.RECEIVED_SERVERDATA, prio=1)
     def should_handle_ServerData(self):
+        self.master_secret = self.cur_session.master_secret
         if not self.buffer_in:
             raise self.WAIT_CLIENTDATA()
         p = self.buffer_in[0]
@@ -278,11 +279,6 @@ class ModifiedTLSClientAutomaton(TLSClientAutomaton):
             s = b"".join(p.raw_stateful() for p in self.buffer_out)
             self.socket.send(s)
         self.buffer_out = []
-
-    @ATMT.state()
-    def HANDLED_SERVERDATA(self):
-        self.master_secret = self.cur_session.master_secret
-        raise self.WAIT_CLIENTDATA()
 
     @ATMT.state()
     def HANDLED_SERVERFINISHED(self):

--- a/tests/tls/test_tls_cert.py
+++ b/tests/tls/test_tls_cert.py
@@ -101,19 +101,13 @@ class X509(tester.TempestaTest):
         """
         Tempesta normally loads a certificate, but fails on TLS handshake.
         """
-        deproxy_srv = self.get_server("deproxy")
-        deproxy_srv.start()
-
         # We have to copy the certificate and key on our own.
         cert_path, key_path = self.cgen.get_file_paths()
         remote.tempesta.copy_file(cert_path, self.cgen.serialize_cert().decode())
         remote.tempesta.copy_file(key_path, self.cgen.serialize_priv_key().decode())
-        await self.start_tempesta()
 
         # Collect warnings before start w/ a bad certificate.
-        self.start_all_clients()
-        self.deproxy_manager.start()
-        await deproxy_srv.wait_for_connections(timeout=X509.TIMEOUT, msg="Cannot start Tempesta")
+        await self.start_all_services()
         client = self.get_client("deproxy")
         client.make_request("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
         res = await client.wait_for_response(timeout=X509.TIMEOUT)
@@ -435,11 +429,8 @@ class TlsCertSelect(tester.TempestaTest):
         self.gen_cert("tempesta_ec")
         self.gen_cert("tempesta_rsa", "rsa")
         self.gen_cert("tempesta_global", "rsa")
-        deproxy_srv = self.get_server("0")
-        deproxy_srv.start()
-        await self.start_tempesta()
-        self.deproxy_manager.start()
-        await deproxy_srv.wait_for_connections(timeout=1, msg="Cannot start Tempesta")
+
+        await self.start_all_services(client=False)
         # TlsHandshake proposes EC only cipher suite and it must successfully
         # request Tempesta.
         res = self.get_tls_handshake().do_12()
@@ -865,10 +856,10 @@ http {
         self.set_first_config()
         await self.start_all_services(client=False)
         wrk = self.get_client("wrk")
-        wrk.start()
+        await wrk.start()
         self.config_changer(10)
         await self.wait_while_busy(wrk)
-        wrk.stop()
+        await wrk.stop()
         self.assertNotEqual(
             0,
             wrk.requests,

--- a/tests/tls/test_tls_handshake.py
+++ b/tests/tls/test_tls_handshake.py
@@ -5,7 +5,7 @@ handshake messages.
 
 from framework.helpers import analyzer, dmesg, remote
 from framework.helpers.cert_generator_x509 import CertGenerator
-from framework.test_suite import marks, tester
+from framework.test_suite import tester
 
 from .fuzzer import tls_record_fuzzer
 from .handshake import *
@@ -535,11 +535,7 @@ class TlsCertReconfig(tester.TempestaTest):
         remote.tempesta.copy_file(key_path, cgen.serialize_priv_key().decode())
 
     async def test(self):
-        deproxy_srv = self.get_server("0")
-        deproxy_srv.start()
-        await self.start_tempesta()
-        self.deproxy_manager.start()
-        await deproxy_srv.wait_for_connections(timeout=1, msg="Cannot start Tempesta")
+        await self.start_all_services()
 
         vhs = TlsHandshake()
         res = vhs.do_12()

--- a/tests/tls/test_tls_limits.py
+++ b/tests/tls/test_tls_limits.py
@@ -76,7 +76,7 @@ class TLSMatchHostSni(tester.TempestaTest):
         klog = dmesg.DmesgFinder(disable_ratelimit=True)
 
         deproxy_cl = self.get_client("usual-client")
-        deproxy_cl.start()
+        await deproxy_cl.start()
 
         # case 1.1 (sni match)
         deproxy_cl.make_request("GET / HTTP/1.1\r\nHost: tempesta-tech.com\r\n\r\n")

--- a/tests/tls/test_tls_stress.py
+++ b/tests/tls/test_tls_stress.py
@@ -96,16 +96,16 @@ class StressTls(tester.TempestaTest):
 
     @dmesg.limited_rate_on_tempesta_node
     async def test(self):
-        self.start_all_servers()
+        await self.start_all_servers()
         await self.start_tempesta()
 
         wrk = self.get_client("0")
         wrk.set_script("foo", content="")
         # Wrk can't handle very big amound of TLS connections.
         wrk.connections = min(int(CONCURRENT_CONNECTIONS), 100)
-        wrk.start()
+        await wrk.start()
         await self.wait_while_busy(wrk)
-        wrk.stop()
+        await wrk.stop()
 
         self.assertTrue(200 in wrk.statuses)
         self.assertGreater(wrk.statuses[200], 0)
@@ -200,11 +200,11 @@ class TlsHandshakeDheRsaTest(tester.TempestaTest):
     async def test(self, name, alg):
         tls_perf = self.get_client(alg)
 
-        self.start_all_servers()
+        await self.start_all_servers()
         await self.start_tempesta()
-        tls_perf.start()
+        await tls_perf.start()
         await self.wait_while_busy(tls_perf)
-        tls_perf.stop()
+        await tls_perf.stop()
 
         self.assertFalse(tls_perf.stderr)
 
@@ -233,7 +233,7 @@ class TlsHandshakeDheRsaTest(tester.TempestaTest):
         updated.
         """
         tls_perf = self.get_client(alg)
-        self.start_all_servers()
+        await self.start_all_servers()
         await self.start_tempesta()
 
         t = threading.Thread(target=self.__reload_tempesta)
@@ -243,8 +243,8 @@ class TlsHandshakeDheRsaTest(tester.TempestaTest):
         '5' runs usually enough to this purpose.
         """
         for i in range(0, 5):
-            tls_perf.start()
+            await tls_perf.start()
             await self.wait_while_busy(tls_perf)
-            tls_perf.stop()
+            await tls_perf.stop()
         self.stop_flag = True
         t.join()

--- a/tests/tls/test_tls_tickets.py
+++ b/tests/tls/test_tls_tickets.py
@@ -458,9 +458,7 @@ class StandardTlsClient(tester.TempestaTest):
     async def test(self):
         tls_perf = self.get_client("tls-perf")
 
-        self.start_all_servers()
-        await self.start_tempesta()
-        tls_perf.start()
+        await self.start_all_services()
         await self.wait_while_busy(tls_perf)
-        tls_perf.stop()
+        await tls_perf.stop()
         self.assertFalse(tls_perf.stderr)

--- a/tests/ws/test_ws_ping.py
+++ b/tests/ws/test_ws_ping.py
@@ -232,7 +232,7 @@ class BaseWsPing(tester.TempestaTest):
 
     # Client
 
-    async def ws_ping_test(self, port: int, is_ssl: bool) -> None:
+    async def ws_ping_test(self, port: int, is_ssl: bool, timeout: float = 10.0) -> None:
         proto = "wss" if is_ssl else "ws"
         ssl_context = None
         if is_ssl:
@@ -241,7 +241,7 @@ class BaseWsPing(tester.TempestaTest):
             ssl_context.verify_mode = ssl.CERT_NONE
 
         async with websockets.connect(
-            f"{proto}://{TEMPESTA_IP}:{port}", ssl=ssl_context
+            f"{proto}://{TEMPESTA_IP}:{port}", ssl=ssl_context, open_timeout=timeout
         ) as websocket:
             await websocket.send(b"request")
             response_body = await websocket.recv()
@@ -249,7 +249,7 @@ class BaseWsPing(tester.TempestaTest):
 
     async def ws_ping_stress(self, port: int, is_ssl: bool) -> bool:
         try:
-            await self.ws_ping_test(port, is_ssl)
+            await self.ws_ping_test(port, is_ssl, timeout=1)
             return http.HTTPStatus.OK
         except websockets.InvalidStatusCode as e:
             self.assertEqual(
@@ -258,6 +258,8 @@ class BaseWsPing(tester.TempestaTest):
                 "Tempesta FW returns an unexpected status code when creating a connection.",
             )
             return http.HTTPStatus.GATEWAY_TIMEOUT
+        except TimeoutError:
+            return http.HTTPStatus.SERVICE_UNAVAILABLE
 
     # Backend
 
@@ -361,7 +363,7 @@ class TestWssPingProxy(BaseWsPing):
         remote.server.copy_file(cert_generator.f_key, cert_generator.serialize_priv_key().decode())
 
     async def test(self):
-        self.start_all_servers()
+        await self.start_all_servers()
         await self._test(tempesta_port=82, is_ssl=True)
 
 
@@ -423,14 +425,18 @@ class TestWssStress(BaseWsPing):
             )
         await self.start_tempesta()
         await self.wait_for_connections(conns_n=servers_n * 32)  # conns_n == 32
-        results = {http.HTTPStatus.OK: 0, http.HTTPStatus.GATEWAY_TIMEOUT: 0}
-        for i in range(4000):
+        results = {
+            http.HTTPStatus.OK: 0,
+            http.HTTPStatus.GATEWAY_TIMEOUT: 0,
+            http.HTTPStatus.SERVICE_UNAVAILABLE: 0,
+        }
+        for i in range(1000):
             results[await self.ws_ping_stress(82, True)] += 1
             if i in self.fibo(4000):
-                self.get_tempesta().restart()
+                await self.get_tempesta().restart()
         self.assertGreater(
             results[http.HTTPStatus.OK],
-            results[http.HTTPStatus.GATEWAY_TIMEOUT],
+            results[http.HTTPStatus.GATEWAY_TIMEOUT] + results[http.HTTPStatus.SERVICE_UNAVAILABLE],
             "Tempesta FW returns 504 responses more than 200.",
         )
 
@@ -564,7 +570,7 @@ class TestRestartOnUpgrade(BaseWsPing):
         for i in range(1500):
             results[await self.ws_ping_stress(81, False)] += 1
             if i in self.fibo(1500):
-                self.get_tempesta().restart()
+                await self.get_tempesta().restart()
         self.assertGreater(
             results[http.HTTPStatus.OK],
             results[http.HTTPStatus.GATEWAY_TIMEOUT],


### PR DESCRIPTION
This PR updates the framework's service lifecycle interfaces (`start` / `stop`) to support asynchronous execution. 

This is an architectural preparation for future updates.
